### PR TITLE
rm release-plz pr

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -15,7 +15,6 @@ on:
       - main
 
 jobs:
-
   # Release unpublished packages.
   release-plz-release:
     name: Release-plz release
@@ -30,27 +29,6 @@ jobs:
         uses: aranya-project/release-plz-action@main
         with:
           command: release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.ARANYA_BOT_CRATESIO_CARGO_LOGIN_KEY }}
-
-  # Create a PR with the new versions and changelog, preparing the next release.
-  release-plz-pr:
-    name: Release-plz PR
-    runs-on: ubuntu-latest
-    concurrency:
-      group: release-plz-${{ github.ref }}
-      cancel-in-progress: false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/setup
-      - name: Run release-plz
-        uses: aranya-project/release-plz-action@main
-        with:
-          command: release-pr
         env:
           GITHUB_TOKEN: ${{ github.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.ARANYA_BOT_CRATESIO_CARGO_LOGIN_KEY }}


### PR DESCRIPTION
The `release-plz` PR is unable to update crate versions correctly when there are complex dependency trees with newer versions. We'll need to update crate versions in a PR manually for now until we can add the needed functionality to the tooling.