### PR TITLE
Remove limit on session command

### DIFF
--- a/crates/aranya-runtime/src/client/session.rs
+++ b/crates/aranya-runtime/src/client/session.rs
@@ -21,7 +21,6 @@ use crate::{
     Address, Checkpoint, ClientError, ClientState, Command, CommandId, CommandRecall, Engine, Fact,
     FactPerspective, GraphId, Keys, NullSink, Perspective, Policy, PolicyId, Prior, Priority,
     Query, QueryMut, Revertable, Segment, Sink, Storage, StorageError, StorageProvider,
-    MAX_COMMAND_LENGTH,
 };
 
 type Bytes = Box<[u8]>;
@@ -407,9 +406,8 @@ where
     fn add_command(&mut self, command: &impl Command) -> Result<usize, StorageError> {
         let command = SessionCommand::from_cmd(self.session.storage_id, command)?;
         self.session.head = command.address()?;
-        let mut buf = [0u8; MAX_COMMAND_LENGTH];
-        let bytes = postcard::to_slice(&command, &mut buf).assume("can serialize")?;
-        self.message_sink.consume(bytes);
+        let bytes = postcard::to_allocvec(&command).assume("serialize session command")?;
+        self.message_sink.consume(&bytes);
 
         Ok(0)
     }


### PR DESCRIPTION
This is more consistent since we don't currently limit the command size anywhere else. We may want to handle session commands differently anyways. Limiting will later be handled by #84.