### PR TITLE
Close #73: Change enum representation to be orderable

### DIFF
--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -210,7 +210,7 @@ impl<'a> CompileState<'a> {
         // Add values to enum, checking for duplicates
         let mut values = Vec::<String>::new();
         for value_name in enum_def.values.iter() {
-            if values.contains(&value_name) {
+            if values.contains(value_name) {
                 return Err(self.err(CompileErrorType::AlreadyDefined(format!(
                     "{}::{}",
                     enum_name, value_name

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -221,7 +221,8 @@ impl<'a> CompileState<'a> {
                     // TODO ensure value is unique. Currently, it always will be, but if enum
                     // variants start allowing specific values, e.g. `enum Color { Red = 100, Green = 200 }`,
                     // then we'll need to ensure those are unique.
-                    e.insert(i64::try_from(i).expect("should set enum value to index"));
+                    let n = i64::try_from(i).assume("should set enum value to index")?;
+                    e.insert(n);
                 }
             }
         }
@@ -1751,7 +1752,7 @@ impl<'a> CompileState<'a> {
 
         // attributes
         let mut attr_values = BTreeMap::new();
-        for (name, value_expr) in command.attributes.iter() {
+        for (name, value_expr) in &command.attributes {
             match attr_values.entry(name.clone()) {
                 Entry::Vacant(e) => {
                     let value = self.expression_value(value_expr).ok_or_else(|| {
@@ -1937,8 +1938,8 @@ impl<'a> CompileState<'a> {
                 name: identfier.clone(),
                 fields: {
                     let mut value_fields = BTreeMap::new();
-                    for field in fields {
-                        value_fields.insert(field.0.clone(), self.expression_value(&field.1)?);
+                    for (value, expr) in fields {
+                        value_fields.insert(value.clone(), self.expression_value(expr)?);
                     }
                     value_fields
                 },

--- a/crates/aranya-policy-compiler/src/compile/target.rs
+++ b/crates/aranya-policy-compiler/src/compile/target.rs
@@ -22,6 +22,8 @@ pub struct CompileTarget {
     pub fact_defs: BTreeMap<String, FactDefinition>,
     /// Struct schemas
     pub struct_defs: BTreeMap<String, Vec<ast::FieldDefinition>>,
+    /// Enum definitions
+    pub enum_defs: BTreeMap<String, Vec<String>>,
     /// Command attributes
     pub command_attributes: BTreeMap<String, BTreeMap<String, Value>>,
     /// Mapping between program instructions and original code
@@ -40,6 +42,7 @@ impl CompileTarget {
             command_defs: BTreeMap::new(),
             fact_defs: BTreeMap::new(),
             struct_defs: BTreeMap::new(),
+            enum_defs: BTreeMap::new(),
             command_attributes: BTreeMap::new(),
             codemap: Some(codemap),
             globals: BTreeMap::new(),
@@ -56,6 +59,7 @@ impl CompileTarget {
                 command_defs: self.command_defs,
                 fact_defs: self.fact_defs,
                 struct_defs: self.struct_defs,
+                enum_defs: self.enum_defs,
                 command_attributes: self.command_attributes,
                 codemap: self.codemap,
                 globals: self.globals,

--- a/crates/aranya-policy-compiler/src/compile/target.rs
+++ b/crates/aranya-policy-compiler/src/compile/target.rs
@@ -23,7 +23,7 @@ pub struct CompileTarget {
     /// Struct schemas
     pub struct_defs: BTreeMap<String, Vec<ast::FieldDefinition>>,
     /// Enum definitions
-    pub enum_defs: BTreeMap<String, Vec<String>>,
+    pub enum_defs: BTreeMap<String, BTreeMap<String, i64>>,
     /// Command attributes
     pub command_attributes: BTreeMap<String, BTreeMap<String, Value>>,
     /// Mapping between program instructions and original code

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -375,7 +375,7 @@ fn test_command_attributes() {
             );
             assert_eq!(
                 attrs.get("priority").expect("should find 3nd value"),
-                &Value::Enum("Priority".to_string(), "High".to_string())
+                &Value::Enum("Priority".to_string(), 1)
             );
         }
     }

--- a/crates/aranya-policy-ifgen-macro/src/value.rs
+++ b/crates/aranya-policy-ifgen-macro/src/value.rs
@@ -139,6 +139,7 @@ fn handle_enum(enumeration: ItemEnum) -> syn::Result<TokenStream> {
 
         impl ::core::convert::From<#ident> for ::aranya_policy_ifgen::Value {
             fn from(e: #ident) -> Self {
+                // TODO if variant discriminants can be set to arbitrary values, we'll need to
                 ::aranya_policy_ifgen::Value::Enum(#enum_ident.into(), e as i64)
             }
         }

--- a/crates/aranya-policy-ifgen-macro/src/value.rs
+++ b/crates/aranya-policy-ifgen-macro/src/value.rs
@@ -126,7 +126,7 @@ fn handle_enum(enumeration: ItemEnum) -> syn::Result<TokenStream> {
                     ));
                 }
 
-                #( const #var_const_names: usize = #ident::#var_idents as usize; )*
+                #( const #var_const_names: i64 = #ident::#var_idents as i64; )*
 
                 match val {
                     #(
@@ -139,7 +139,7 @@ fn handle_enum(enumeration: ItemEnum) -> syn::Result<TokenStream> {
 
         impl ::core::convert::From<#ident> for ::aranya_policy_ifgen::Value {
             fn from(e: #ident) -> Self {
-                ::aranya_policy_ifgen::Value::Enum(#enum_ident.into(), e as usize)
+                ::aranya_policy_ifgen::Value::Enum(#enum_ident.into(), e as i64)
             }
         }
     })

--- a/crates/aranya-policy-ifgen-macro/src/value.rs
+++ b/crates/aranya-policy-ifgen-macro/src/value.rs
@@ -123,7 +123,7 @@ fn handle_enum(enumeration: ItemEnum) -> syn::Result<TokenStream> {
                     ));
                 }
 
-                match val.as_str() {
+                match val {
                     #(
                         #var_vals => ::core::result::Result::Ok(Self::#var_idents),
                     )*

--- a/crates/aranya-policy-module/src/data.rs
+++ b/crates/aranya-policy-module/src/data.rs
@@ -110,7 +110,7 @@ pub enum Value {
     /// A unique identifier.
     Id(Id),
     /// Enumeration value
-    Enum(String, String),
+    Enum(String, usize),
     /// Empty optional value
     None,
 }

--- a/crates/aranya-policy-module/src/data.rs
+++ b/crates/aranya-policy-module/src/data.rs
@@ -110,7 +110,7 @@ pub enum Value {
     /// A unique identifier.
     Id(Id),
     /// Enumeration value
-    Enum(String, usize),
+    Enum(String, i64),
     /// Empty optional value
     None,
 }

--- a/crates/aranya-policy-module/src/module.rs
+++ b/crates/aranya-policy-module/src/module.rs
@@ -81,7 +81,7 @@ pub struct ModuleV0 {
     /// Struct definitions
     pub struct_defs: BTreeMap<String, Vec<ast::FieldDefinition>>,
     /// Enum definitions
-    pub enum_defs: BTreeMap<String, Vec<String>>,
+    pub enum_defs: BTreeMap<String, BTreeMap<String, i64>>,
     /// Command attributes
     pub command_attributes: BTreeMap<String, BTreeMap<String, Value>>,
     /// Code map

--- a/crates/aranya-policy-module/src/module.rs
+++ b/crates/aranya-policy-module/src/module.rs
@@ -80,6 +80,8 @@ pub struct ModuleV0 {
     pub fact_defs: BTreeMap<String, FactDefinition>,
     /// Struct definitions
     pub struct_defs: BTreeMap<String, Vec<ast::FieldDefinition>>,
+    /// Enum definitions
+    pub enum_defs: BTreeMap<String, Vec<String>>,
     /// Command attributes
     pub command_attributes: BTreeMap<String, BTreeMap<String, Value>>,
     /// Code map

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -231,12 +231,9 @@ impl Machine {
             .enum_defs
             .get(name)
             .ok_or_else(|| MachineErrorType::NotDefined(alloc::format!("enum {name}")))?;
-        let int_value =
-            variants
-                .get(variant)
-                .ok_or_else(|| MachineErrorType::NotDefined(alloc::format!(
-                    "no value `{variant}` in enum `{name}`"
-                )))?;
+        let int_value = variants.get(variant).ok_or_else(|| {
+            MachineErrorType::NotDefined(alloc::format!("no value `{variant}` in enum `{name}`"))
+        })?;
 
         Ok(Value::Enum(name.to_owned(), *int_value))
     }

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -220,6 +220,27 @@ impl Machine {
         }
     }
 
+    /// Parses an enum reference (e.g. "Color::Red") into a [Value::Enum].
+    pub fn parse_enum(&self, value: &str) -> Result<Value, MachineError> {
+        let mut parts = value.splitn(2, "::");
+        let name = parts.next().ok_or(MachineErrorType::invalid_type(
+            "<Enum>::<Value>",
+            value,
+            "invalid enum reference",
+        ))?;
+        let value = parts.next().ok_or_else(|| {
+            MachineErrorType::invalid_type("<Enum>::<Value>", value, "missing enum value")
+        })?;
+        let values = self
+            .enum_defs
+            .get(name)
+            .ok_or_else(|| MachineErrorType::NotDefined(alloc::format!("enum {name}")))?;
+        let value_index = values.iter().position(|v| v == value).ok_or_else(|| {
+            MachineErrorType::NotDefined(alloc::format!("no value {value} in enum {name}"))
+        })?;
+        Ok(Value::Enum(name.to_owned(), value_index))
+    }
+
     /// Create a RunState associated with this Machine.
     pub fn create_run_state<'a, M>(
         &'a self,

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -222,11 +222,13 @@ impl Machine {
 
     /// Parses an enum reference (e.g. `Color::Red`) into a [`Value::Enum`].
     pub fn parse_enum(&self, value: &str) -> Result<Value, MachineError> {
-        let invalid_enum_ref =
-            || MachineErrorType::invalid_type("<Enum>::<Value>", value, "invalid enum reference");
-        let mut parts = value.splitn(2, "::");
-        let name = parts.next().ok_or_else(invalid_enum_ref)?;
-        let variant = parts.next().ok_or_else(invalid_enum_ref)?;
+        let Some((name, variant)) = value.split_once("::") else {
+            return Err(MachineError::new(MachineErrorType::invalid_type(
+                "<Enum>::<Variant>",
+                value,
+                "invalid enum reference",
+            )));
+        };
         let variants = self
             .enum_defs
             .get(name)

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -137,6 +137,8 @@ pub struct Machine {
     pub fact_defs: BTreeMap<String, ast::FactDefinition>,
     /// Struct schemas
     pub struct_defs: BTreeMap<String, Vec<ast::FieldDefinition>>,
+    /// Enum definitions
+    pub enum_defs: BTreeMap<String, Vec<String>>,
     /// Command attributes
     pub command_attributes: BTreeMap<String, BTreeMap<String, Value>>,
     /// Mapping between program instructions and original code
@@ -158,6 +160,7 @@ impl Machine {
             command_defs: BTreeMap::new(),
             fact_defs: BTreeMap::new(),
             struct_defs: BTreeMap::new(),
+            enum_defs: BTreeMap::new(),
             command_attributes: BTreeMap::new(),
             codemap: None,
             globals: BTreeMap::new(),
@@ -173,6 +176,7 @@ impl Machine {
             command_defs: BTreeMap::new(),
             fact_defs: BTreeMap::new(),
             struct_defs: BTreeMap::new(),
+            enum_defs: BTreeMap::new(),
             command_attributes: BTreeMap::new(),
             codemap: Some(codemap),
             globals: BTreeMap::new(),
@@ -189,6 +193,7 @@ impl Machine {
                 command_defs: m.command_defs,
                 fact_defs: m.fact_defs,
                 struct_defs: m.struct_defs,
+                enum_defs: m.enum_defs,
                 command_attributes: m.command_attributes,
                 codemap: m.codemap,
                 globals: m.globals,
@@ -197,6 +202,7 @@ impl Machine {
     }
 
     /// Converts the `Machine` into a `Module`.
+    /// NOTE this is not used
     pub fn into_module(self) -> Module {
         Module {
             data: ModuleData::V0(ModuleV0 {
@@ -206,6 +212,7 @@ impl Machine {
                 command_defs: self.command_defs,
                 fact_defs: self.fact_defs,
                 struct_defs: self.struct_defs,
+                enum_defs: self.enum_defs,
                 command_attributes: self.command_attributes,
                 codemap: self.codemap,
                 globals: self.globals,

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -222,22 +222,22 @@ impl Machine {
 
     /// Parses an enum reference (e.g. "Color::Red") into a [Value::Enum].
     pub fn parse_enum(&self, value: &str) -> Result<Value, MachineError> {
+        let invalid_enum_ref =
+            || MachineErrorType::invalid_type("<Enum>::<Value>", value, "invalid enum reference");
         let mut parts = value.splitn(2, "::");
-        let name = parts.next().ok_or(MachineErrorType::invalid_type(
-            "<Enum>::<Value>",
-            value,
-            "invalid enum reference",
-        ))?;
-        let value = parts.next().ok_or_else(|| {
-            MachineErrorType::invalid_type("<Enum>::<Value>", value, "missing enum value")
-        })?;
+        let name = parts.next().ok_or(invalid_enum_ref())?;
+        let value = parts.next().ok_or(invalid_enum_ref())?;
         let values = self
             .enum_defs
             .get(name)
-            .ok_or_else(|| MachineErrorType::NotDefined(alloc::format!("enum {name}")))?;
-        let value_index = values.iter().position(|v| v == value).ok_or_else(|| {
-            MachineErrorType::NotDefined(alloc::format!("no value {value} in enum {name}"))
-        })?;
+            .ok_or(MachineErrorType::NotDefined(alloc::format!("enum {name}")))?;
+        let value_index =
+            values
+                .iter()
+                .position(|v| v == value)
+                .ok_or(MachineErrorType::NotDefined(alloc::format!(
+                    "no value `{value}` in enum `{name}`"
+                )))?;
         Ok(Value::Enum(name.to_owned(), value_index))
     }
 

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -220,21 +220,21 @@ impl Machine {
         }
     }
 
-    /// Parses an enum reference (e.g. "Color::Red") into a [Value::Enum].
+    /// Parses an enum reference (e.g. `Color::Red`) into a [`Value::Enum`].
     pub fn parse_enum(&self, value: &str) -> Result<Value, MachineError> {
         let invalid_enum_ref =
             || MachineErrorType::invalid_type("<Enum>::<Value>", value, "invalid enum reference");
         let mut parts = value.splitn(2, "::");
-        let name = parts.next().ok_or(invalid_enum_ref())?;
-        let variant = parts.next().ok_or(invalid_enum_ref())?;
+        let name = parts.next().ok_or_else(invalid_enum_ref)?;
+        let variant = parts.next().ok_or_else(invalid_enum_ref)?;
         let variants = self
             .enum_defs
             .get(name)
-            .ok_or(MachineErrorType::NotDefined(alloc::format!("enum {name}")))?;
+            .ok_or_else(|| MachineErrorType::NotDefined(alloc::format!("enum {name}")))?;
         let int_value =
             variants
                 .get(variant)
-                .ok_or(MachineErrorType::NotDefined(alloc::format!(
+                .ok_or_else(|| MachineErrorType::NotDefined(alloc::format!(
                     "no value `{variant}` in enum `{name}`"
                 )))?;
 

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -138,7 +138,7 @@ pub struct Machine {
     /// Struct schemas
     pub struct_defs: BTreeMap<String, Vec<ast::FieldDefinition>>,
     /// Enum definitions
-    pub enum_defs: BTreeMap<String, Vec<String>>,
+    pub enum_defs: BTreeMap<String, BTreeMap<String, i64>>,
     /// Command attributes
     pub command_attributes: BTreeMap<String, BTreeMap<String, Value>>,
     /// Mapping between program instructions and original code
@@ -226,19 +226,19 @@ impl Machine {
             || MachineErrorType::invalid_type("<Enum>::<Value>", value, "invalid enum reference");
         let mut parts = value.splitn(2, "::");
         let name = parts.next().ok_or(invalid_enum_ref())?;
-        let value = parts.next().ok_or(invalid_enum_ref())?;
-        let values = self
+        let variant = parts.next().ok_or(invalid_enum_ref())?;
+        let variants = self
             .enum_defs
             .get(name)
             .ok_or(MachineErrorType::NotDefined(alloc::format!("enum {name}")))?;
-        let value_index =
-            values
-                .iter()
-                .position(|v| v == value)
+        let int_value =
+            variants
+                .get(variant)
                 .ok_or(MachineErrorType::NotDefined(alloc::format!(
-                    "no value `{value}` in enum `{name}`"
+                    "no value `{variant}` in enum `{name}`"
                 )))?;
-        Ok(Value::Enum(name.to_owned(), value_index))
+
+        Ok(Value::Enum(name.to_owned(), *int_value))
     }
 
     /// Create a RunState associated with this Machine.

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -1973,9 +1973,18 @@ fn test_enum_parse() -> anyhow::Result<()> {
     let module = Compiler::new(&policy).compile()?;
     let machine = Machine::from_module(module)?;
 
-    machine.parse_enum("Drink").expect_err("msg");
-    machine.parse_enum("Drink::").expect_err("msg");
-    machine.parse_enum("Coffee").expect_err("msg");
+    assert_eq!(
+        machine.parse_enum("Drink").unwrap_err().err_type,
+        MachineErrorType::invalid_type("<Enum>::<Value>", "Drink", "invalid enum reference")
+    );
+    assert_eq!(
+        machine.parse_enum("Drink::").unwrap_err().err_type,
+        MachineErrorType::NotDefined("no value `` in enum `Drink`".to_owned())
+    );
+    assert_eq!(
+        machine.parse_enum("Coffee").unwrap_err().err_type,
+        MachineErrorType::invalid_type("<Enum>::<Value>", "Coffee", "invalid enum reference")
+    );
     assert_eq!(
         machine.parse_enum("Drink::Water")?,
         Value::Enum("Drink".to_owned(), 0)
@@ -1985,10 +1994,8 @@ fn test_enum_parse() -> anyhow::Result<()> {
         Value::Enum("Drink".to_owned(), 1)
     );
     assert_eq!(
-        machine.parse_enum("Drink::Tea"),
-        Err(MachineError::new(MachineErrorType::NotDefined(
-            "no value Tea in enum Drink".to_owned()
-        )))
+        machine.parse_enum("Drink::Tea").unwrap_err().err_type,
+        MachineErrorType::NotDefined("no value `Tea` in enum `Drink`".to_owned())
     );
 
     Ok(())

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -1969,7 +1969,7 @@ where
 
 #[test]
 fn test_enum_parse() -> anyhow::Result<()> {
-    let policy = parse_policy_str("enum Drink { Water, Coffee }", Version::V1)?;
+    let policy = parse_policy_str("enum Drink { Water, Coffee }", Version::V2)?;
     let module = Compiler::new(&policy).compile()?;
     let machine = Machine::from_module(module)?;
 

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -1975,7 +1975,7 @@ fn test_enum_parse() -> anyhow::Result<()> {
 
     assert_eq!(
         machine.parse_enum("Drink").unwrap_err().err_type,
-        MachineErrorType::invalid_type("<Enum>::<Value>", "Drink", "invalid enum reference")
+        MachineErrorType::invalid_type("<Enum>::<Variant>", "Drink", "invalid enum reference")
     );
     assert_eq!(
         machine.parse_enum("Drink::").unwrap_err().err_type,
@@ -1983,7 +1983,7 @@ fn test_enum_parse() -> anyhow::Result<()> {
     );
     assert_eq!(
         machine.parse_enum("Coffee").unwrap_err().err_type,
-        MachineErrorType::invalid_type("<Enum>::<Value>", "Coffee", "invalid enum reference")
+        MachineErrorType::invalid_type("<Enum>::<Variant>", "Coffee", "invalid enum reference")
     );
     assert_eq!(
         machine.parse_enum("Drink::Water")?,


### PR DESCRIPTION
Enum values are now stored as `Vec<usize>`s in the VM. 