### PR TITLE
Close #103: `if`, `match` statements now limit scope to their blocks.

### DIFF
--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1982,7 +1982,7 @@ impl<'a> CompileState<'a> {
                     // Drop expression value (It's still around because of the Dup)
                     self.append_instruction(Instruction::Pop);
 
-                    self.compile_statements(&arm.statements, Scope::Same)?;
+                    self.compile_statements(&arm.statements, Scope::Layered)?;
 
                     // break out of match
                     self.append_instruction(Instruction::Jump(Target::Unresolved(

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1137,14 +1137,14 @@ impl<'a> CompileState<'a> {
                         self.append_instruction(Instruction::Branch(Target::Unresolved(
                             next_label.clone(),
                         )));
-                        self.compile_statements(branch, Scope::Same)?;
+                        self.compile_statements(branch, Scope::Layered)?;
                         self.append_instruction(Instruction::Jump(Target::Unresolved(
                             end_label.clone(),
                         )));
                         self.define_label(next_label, self.wp)?;
                     }
                     if let Some(fallback) = &s.fallback {
-                        self.compile_statements(fallback, Scope::Same)?;
+                        self.compile_statements(fallback, Scope::Layered)?;
                     }
                     self.define_label(end_label, self.wp)?;
                 }

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -1587,6 +1587,17 @@ fn test_if_match_block_scope() {
             }"#,
             CompileErrorType::NotDefined("Unknown identifier `y`".to_string()),
         ),
+        (
+            r#"
+            function foo(b bool) int {
+                match b {
+                    true => { let x = 0 }
+                    _ => { let y = 1 }
+                }
+                return y
+            }"#,
+            CompileErrorType::NotDefined("Unknown identifier `y`".to_string()),
+        ),
     ];
     for (text, res) in cases {
         let policy = parse_policy_str(text, Version::V1).expect("should parse");

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -1600,7 +1600,7 @@ fn test_if_match_block_scope() {
         ),
     ];
     for (text, res) in cases {
-        let policy = parse_policy_str(text, Version::V1).expect("should parse");
+        let policy = parse_policy_str(text, Version::V2).expect("should parse");
         let r = Compiler::new(&policy).compile().unwrap_err().err_type;
         assert_eq!(r, res)
     }


### PR DESCRIPTION
Close #103: Variables defined in `if` and `match` blocks are now scoped to the blocks.