### PR TITLE
Close #110: Add match expressions.

### DIFF
--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -389,13 +389,13 @@ pub struct MatchExpression {
     pub arms: Vec<AstNode<MatchExpressionArm>>,
 }
 
-/// A container for one of two possible values
+/// A container for a statement or expression
 #[derive(Debug, Clone, PartialEq)]
-pub enum Either<A, B> {
-    /// option A
-    First(A),
-    /// option B
-    Second(B),
+pub enum LanguageContext<A, B> {
+    /// statement
+    Statement(A),
+    /// expression
+    Expression(B),
 }
 
 /// Match arm expression

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -386,7 +386,7 @@ pub struct MatchExpression {
     /// Value to match against
     pub expression: Expression,
     /// Match arms
-    pub arms: Vec<AstNode<MatchArmExpression>>,
+    pub arms: Vec<AstNode<MatchExpressionArm>>,
 }
 
 /// A container for one of two possible values
@@ -400,7 +400,7 @@ pub enum Either<A, B> {
 
 /// Match arm expression
 #[derive(Debug, Clone, PartialEq)]
-pub struct MatchArmExpression {
+pub struct MatchExpressionArm {
     /// value to match against the match expression
     pub pattern: MatchPattern,
     /// Expression

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -384,7 +384,7 @@ pub struct MatchStatement {
 #[derive(Debug, Clone, PartialEq)]
 pub struct MatchExpression {
     /// Value to match against
-    pub expression: Expression,
+    pub scrutinee: Expression,
     /// Match arms
     pub arms: Vec<AstNode<MatchExpressionArm>>,
 }

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -317,6 +317,8 @@ pub enum Expression {
     Is(Box<Expression>, bool),
     /// A block expression
     Block(Vec<AstNode<Statement>>, Box<Expression>),
+    /// Match expression
+    MatchExpression(Box<Expression>, Vec<AstNode<MatchArmExpression>>),
 }
 
 /// Encapsulates both [FunctionDefinition] and [FinishFunctionDefinition] for the purpose
@@ -376,6 +378,24 @@ pub struct MatchStatement {
     pub expression: Expression,
     /// All of the potential match arms
     pub arms: Vec<MatchArm>,
+}
+
+/// Match statement expression
+#[derive(Debug, Clone, PartialEq)]
+pub struct MatchExpression {
+    /// Value to match against
+    pub expression: Expression,
+    /// Match arms
+    pub arms: Vec<MatchArmExpression>,
+}
+
+/// Match arm expression
+#[derive(Debug, Clone, PartialEq)]
+pub struct MatchArmExpression {
+    /// value to match against the match expression
+    pub pattern: MatchPattern,
+    /// Expression
+    pub expression: Expression,
 }
 
 /// Test a series of conditions and execute the statements for the first true condition.

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -318,7 +318,7 @@ pub enum Expression {
     /// A block expression
     Block(Vec<AstNode<Statement>>, Box<Expression>),
     /// Match expression
-    MatchExpression(Box<Expression>, Vec<AstNode<MatchArmExpression>>),
+    Match(Box<MatchExpression>),
 }
 
 /// Encapsulates both [FunctionDefinition] and [FinishFunctionDefinition] for the purpose
@@ -386,7 +386,16 @@ pub struct MatchExpression {
     /// Value to match against
     pub expression: Expression,
     /// Match arms
-    pub arms: Vec<MatchArmExpression>,
+    pub arms: Vec<AstNode<MatchArmExpression>>,
+}
+
+/// A container for one of two possible values
+#[derive(Debug, Clone, PartialEq)]
+pub enum Either<A, B> {
+    /// option A
+    First(A),
+    /// option B
+    Second(B),
 }
 
 /// Match arm expression

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1011,8 +1011,10 @@ impl<'a> CompileState<'a> {
                 subexpression_type
             }
             Expression::Match(e) => {
-                let expr_type = self.compile_match_statement_or_expression(Either::Second(e), 0)?;
-                expr_type.unwrap_or(Typeish::Indeterminate)
+                let expr_type = self
+                    .compile_match_statement_or_expression(Either::Second(e), 0)?
+                    .assume("match expression must return a type")?;
+                expr_type
             }
         };
 
@@ -1875,6 +1877,8 @@ impl<'a> CompileState<'a> {
         Ok(())
     }
 
+    /// Compile a match statement or expression
+    /// Returns the type of the `match` is an expression, or `None` if it's a statement.
     fn compile_match_statement_or_expression(
         &mut self,
         s: Either<&MatchStatement, &MatchExpression>,

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1010,12 +1010,9 @@ impl<'a> CompileState<'a> {
 
                 subexpression_type
             }
-            Expression::Match(e) => {
-                let expr_type = self
-                    .compile_match_statement_or_expression(Either::Second(e), 0)?
-                    .assume("match expression must return a type")?;
-                expr_type
-            }
+            Expression::Match(e) => self
+                .compile_match_statement_or_expression(Either::Second(e), 0)?
+                .assume("match expression must return a type")?,
         };
 
         Ok(expression_type)

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -8,7 +8,10 @@ use std::{
     ops::Range,
 };
 
-use aranya_policy_ast::{self as ast, AstNode, FactCountType, FunctionCall, VType};
+use aranya_policy_ast::{
+    self as ast, AstNode, Either, FactCountType, FunctionCall, MatchExpression, MatchStatement,
+    VType,
+};
 use aranya_policy_module::{
     ffi::ModuleSchema, CodeMap, ExitReason, Instruction, Label, LabelType, Meta, Module, Struct,
     Target, Value,
@@ -1007,35 +1010,9 @@ impl<'a> CompileState<'a> {
 
                 subexpression_type
             }
-            Expression::MatchExpression(_, arms) => {
-                // Ensure all arms have the same expression type
-                let mut expr_type: Option<Typeish> = None;
-                for arm in arms {
-                    let etype = self.compile_expression(&arm.expression)?;
-                    match expr_type {
-                        None => expr_type = Some(etype),
-                        Some(ref t) => {
-                            if !t.is_equal(&etype) {
-                                return Err(self.err(CompileErrorType::InvalidType(format!(
-                                    "match arm expression type mismatch; expected {}, got {}",
-                                    t, etype
-                                ))));
-                            }
-                        }
-                    }
-                }
-
-                // There should be at least one match arm. No-arm matches are not even syntactically-correct, but we check anyway.
-                match expr_type {
-                    Some(t) => t,
-                    None => {
-                        return Err(
-                            self.err(CompileErrorType::Missing("no match arms".to_string()))
-                        );
-                    }
-                }
-
-                // TODO implement actual branching logic
+            Expression::Match(e) => {
+                let expr_type = self.compile_match_statement_or_expression(Either::Second(e), 0)?;
+                expr_type.unwrap_or(Typeish::Indeterminate)
             }
         };
 
@@ -1138,101 +1115,10 @@ impl<'a> CompileState<'a> {
                     | StatementContext::CommandPolicy(_)
                     | StatementContext::CommandRecall(_),
                 ) => {
-                    // Ensure there are no duplicate arm values. Note that this is not completely reliable, because arm values are expressions, evaluated at runtime.
-                    // Note: we don't check for zero arms, because that's syntactically invalid.
-                    let all_values = s
-                        .arms
-                        .iter()
-                        .flat_map(|arm| match &arm.pattern {
-                            MatchPattern::Values(values) => values.as_slice(),
-                            MatchPattern::Default => &[],
-                        })
-                        .collect::<Vec<&Expression>>();
-                    if find_duplicate(&all_values, |v| v).is_some() {
-                        return Err(self.err_loc(
-                            CompileErrorType::AlreadyDefined(String::from(
-                                "duplicate match arm value",
-                            )),
-                            statement.locator,
-                        ));
-                    }
-
-                    let expr_t = self.compile_expression(&s.expression)?;
-
-                    let end_label = self.anonymous_label();
-
-                    // 1. Generate branching instructions, and arm-start labels
-                    let mut arm_labels: Vec<Label> = vec![];
-
-                    for (i, arm) in s.arms.iter().enumerate() {
-                        let arm_label = self.anonymous_label();
-                        arm_labels.push(arm_label.clone());
-
-                        match &arm.pattern {
-                            MatchPattern::Values(values) => {
-                                for value in values.iter() {
-                                    self.append_instruction(Instruction::Dup(0));
-                                    if !value.is_literal() {
-                                        return Err(self.err(CompileErrorType::InvalidType(
-                                            String::from("match arm is not a literal expression"),
-                                        )));
-                                    }
-                                    let arm_t = self.compile_expression(value)?;
-                                    if !arm_t.is_maybe_equal(&expr_t) {
-                                        let arm_n =
-                                            i.checked_add(1).assume("match arm count overflow")?;
-                                        return Err(self.err(CompileErrorType::InvalidType(
-                                            format!(
-                                            "match expression is `{}` but arm expression {} is `{}`",
-                                            expr_t, arm_n, arm_t
-                                        ),
-                                        )));
-                                    }
-
-                                    // if value == target, jump to start-of-arm
-                                    self.append_instruction(Instruction::Eq);
-                                    self.append_instruction(Instruction::Branch(
-                                        Target::Unresolved(arm_label.clone()),
-                                    ));
-                                }
-                            }
-                            MatchPattern::Default => {
-                                self.append_instruction(Instruction::Jump(Target::Unresolved(
-                                    arm_label.clone(),
-                                )));
-
-                                // Ensure this is the last case, and also that it's not the only case.
-                                if arm != s.arms.last().expect("last arm") {
-                                    return Err(self.err(CompileErrorType::Unknown(String::from(
-                                        "Default match case must be last.",
-                                    ))));
-                                }
-                            }
-                        }
-                    }
-
-                    // if no match, and no default case, panic
-                    if !s.arms.iter().any(|a| a.pattern == MatchPattern::Default) {
-                        self.append_instruction(Instruction::Exit(ExitReason::Panic));
-                    }
-
-                    // 2. Define arm labels, and compile instructions
-                    for (i, arm) in s.arms.iter().enumerate() {
-                        let arm_start = arm_labels[i].to_owned();
-                        self.define_label(arm_start, self.wp)?;
-
-                        // Drop expression value (It's still around because of the Dup)
-                        self.append_instruction(Instruction::Pop);
-
-                        self.compile_statements(&arm.statements, Scope::Same)?;
-
-                        // break out of match
-                        self.append_instruction(Instruction::Jump(Target::Unresolved(
-                            end_label.clone(),
-                        )));
-                    }
-
-                    self.define_label(end_label, self.wp)?;
+                    self.compile_match_statement_or_expression(
+                        Either::First(s),
+                        statement.locator,
+                    )?;
                 }
                 (
                     ast::Statement::If(s),
@@ -1987,6 +1873,147 @@ impl<'a> CompileState<'a> {
             }
         }
         Ok(())
+    }
+
+    fn compile_match_statement_or_expression(
+        &mut self,
+        s: Either<&MatchStatement, &MatchExpression>,
+        locator: usize,
+    ) -> Result<Option<Typeish>, CompileError> {
+        let patterns: Vec<MatchPattern> = match s {
+            Either::First(s) => s.arms.iter().map(|a| a.pattern.clone()).collect(),
+            Either::Second(e) => e.arms.iter().map(|a| a.pattern.clone()).collect(),
+        };
+
+        // Ensure there are no duplicate arm values.
+        // NOTE This is not completely reliable, because arm values are expressions, evaluated at runtime.
+        //      We also don't check for zero arms, because that's syntactically invalid.
+        let all_values = patterns
+            .iter()
+            .flat_map(|pattern| match &pattern {
+                MatchPattern::Values(values) => values.as_slice(),
+                MatchPattern::Default => &[],
+            })
+            .collect::<Vec<&Expression>>();
+        if find_duplicate(&all_values, |v| v).is_some() {
+            return Err(self.err_loc(
+                CompileErrorType::AlreadyDefined(String::from("duplicate match arm value")),
+                locator,
+            ));
+        }
+
+        let expr = match s {
+            Either::First(s) => &s.expression,
+            Either::Second(e) => &e.expression,
+        };
+        let expr_t = self.compile_expression(expr)?;
+
+        let end_label = self.anonymous_label();
+
+        // 1. Generate branching instructions, and arm-start labels
+        let mut arm_labels: Vec<Label> = vec![];
+
+        for pattern in &patterns {
+            let arm_label = self.anonymous_label();
+            arm_labels.push(arm_label.clone());
+
+            match pattern {
+                MatchPattern::Values(values) => {
+                    for (i, value) in values.iter().enumerate() {
+                        self.append_instruction(Instruction::Dup(0));
+                        if !value.is_literal() {
+                            return Err(self.err(CompileErrorType::InvalidType(String::from(
+                                "match arm is not a literal expression",
+                            ))));
+                        }
+                        let arm_t = self.compile_expression(value)?;
+                        if !arm_t.is_maybe_equal(&expr_t) {
+                            let arm_n = i.checked_add(1).assume("match arm count overflow")?;
+                            return Err(self.err(CompileErrorType::InvalidType(format!(
+                                "match expression is `{}` but arm expression {} is `{}`",
+                                expr_t, arm_n, arm_t
+                            ))));
+                        }
+
+                        // if value == target, jump to start-of-arm
+                        self.append_instruction(Instruction::Eq);
+                        self.append_instruction(Instruction::Branch(Target::Unresolved(
+                            arm_label.clone(),
+                        )));
+                    }
+                }
+                MatchPattern::Default => {
+                    self.append_instruction(Instruction::Jump(Target::Unresolved(
+                        arm_label.clone(),
+                    )));
+
+                    // Ensure this is the last case, and also that it's not the only case.
+                    if pattern != patterns.last().expect("last arm") {
+                        return Err(self.err(CompileErrorType::Unknown(String::from(
+                            "Default match case must be last.",
+                        ))));
+                    }
+                }
+            }
+        }
+
+        // if no match, and no default case, panic
+        if !patterns.iter().any(|p| *p == MatchPattern::Default) {
+            self.append_instruction(Instruction::Exit(ExitReason::Panic));
+        }
+
+        // Match expression/statement type. For statements, it's None; for expressions, it's Some(Typeish)
+        let mut expr_type: Option<Typeish> = None;
+
+        // 2. Define arm labels, and compile instructions
+        match s {
+            Either::First(s) => {
+                for (i, arm) in s.arms.iter().enumerate() {
+                    let arm_start = arm_labels[i].to_owned();
+                    self.define_label(arm_start, self.wp)?;
+
+                    // Drop expression value (It's still around because of the Dup)
+                    self.append_instruction(Instruction::Pop);
+
+                    self.compile_statements(&arm.statements, Scope::Same)?;
+
+                    // break out of match
+                    self.append_instruction(Instruction::Jump(Target::Unresolved(
+                        end_label.clone(),
+                    )));
+                }
+            }
+            Either::Second(e) => {
+                for (i, arm) in e.arms.iter().enumerate() {
+                    let arm_start = arm_labels[i].to_owned();
+                    self.define_label(arm_start, self.wp)?;
+
+                    // Drop expression value (It's still around because of the Dup)
+                    self.append_instruction(Instruction::Pop);
+
+                    let etype = self.compile_expression(&arm.expression)?;
+                    match expr_type {
+                        None => expr_type = Some(etype),
+                        Some(ref t) => {
+                            if !t.is_equal(&etype) {
+                                return Err(self.err(CompileErrorType::InvalidType(format!(
+                                    "match arm expression type mismatch; expected {}, got {}",
+                                    t, etype
+                                ))));
+                            }
+                        }
+                    }
+
+                    // break out of match
+                    self.append_instruction(Instruction::Jump(Target::Unresolved(
+                        end_label.clone(),
+                    )));
+                }
+            }
+        }
+
+        self.define_label(end_label, self.wp)?;
+        Ok(expr_type)
     }
 
     /// Compile a policy into instructions inside the given Machine.

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1887,8 +1887,7 @@ impl<'a> CompileState<'a> {
         };
 
         // Ensure there are no duplicate arm values.
-        // NOTE This is not completely reliable, because arm values are expressions, evaluated at runtime.
-        //      We also don't check for zero arms, because that's syntactically invalid.
+        // NOTE We don't check for zero arms, because that's enforced by the parser.
         let all_values = patterns
             .iter()
             .flat_map(|pattern| match &pattern {
@@ -2003,7 +2002,7 @@ impl<'a> CompileState<'a> {
                     match expr_type {
                         None => expr_type = Some(etype),
                         Some(ref t) => {
-                            if !t.is_equal(&etype) {
+                            if !t.is_maybe_equal(&etype) {
                                 return Err(self.err(CompileErrorType::InvalidType(format!(
                                     "match arm expression type mismatch; expected {}, got {}",
                                     t, etype

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1896,9 +1896,16 @@ impl<'a> CompileState<'a> {
                 MatchPattern::Default => &[],
             })
             .collect::<Vec<&Expression>>();
-        if find_duplicate(&all_values, |v| v).is_some() {
+        if find_duplicate(&all_values, |p| p).is_some() {
             return Err(self.err_loc(
                 CompileErrorType::AlreadyDefined(String::from("duplicate match arm value")),
+                locator,
+            ));
+        }
+        // find duplicate default arms
+        if find_duplicate(&patterns, |p| p).is_some() {
+            return Err(self.err_loc(
+                CompileErrorType::AlreadyDefined(String::from("duplicate match arm default value")),
                 locator,
             ));
         }

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1911,7 +1911,7 @@ impl<'a> CompileState<'a> {
 
         let expr = match s {
             LanguageContext::Statement(s) => &s.expression,
-            LanguageContext::Expression(e) => &e.expression,
+            LanguageContext::Expression(e) => &e.scrutinee,
         };
         let expr_t = self.compile_expression(expr)?;
 

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -1246,8 +1246,8 @@ fn test_match_expression() {
             // expression type doesn't match expected type
             r#"function f(n int) bool {
                 return match n {
-                    0 => { :1 }
-                    _ => { :0 }
+                    0 => 1
+                    _ => 0
                 }
             }"#,
             CompileErrorType::InvalidType("Return value of `f()` must be bool".to_string()),

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -1226,6 +1226,55 @@ fn test_match_arm_should_be_limited_to_literals() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_match_expression() {
+    let invalid_cases = vec![
+        (
+            // arms expressions have different types
+            r#"action foo(a int) {
+                let x = match a {
+                    1 => { :"one" }
+                    _ => { :false }
+                }
+            }
+            "#,
+            CompileErrorType::InvalidType(
+                "match arm expression type mismatch; expected string, got bool".to_string(),
+            ),
+        ),
+        (
+            // expression type doesn't match expected type
+            r#"function f(n int) bool {
+                return match n {
+                    0 => { :1 }
+                    _ => { :0 }
+                }
+            }"#,
+            CompileErrorType::InvalidType("Return value of `f()` must be bool".to_string()),
+        ),
+    ];
+    for (src, result) in invalid_cases {
+        let policy = parse_policy_str(src, Version::V2).expect("should parse");
+        assert_eq!(
+            Compiler::new(&policy).compile().unwrap_err().err_type,
+            result
+        );
+    }
+
+    let valid_cases = vec![
+        r#"function f(n int) int {
+            return match n {
+                0 => { :1 }
+                _ => { :0 }
+            }
+        }"#,
+    ];
+    for src in valid_cases {
+        let policy = parse_policy_str(src, Version::V2).expect("should parse");
+        Compiler::new(&policy).compile().expect("should compile");
+    }
+}
+
 // Note: this test is not exhaustive
 #[test]
 fn test_bad_statements() -> anyhow::Result<()> {

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -1270,10 +1270,12 @@ fn test_match_expression() {
     }
 
     let valid_cases = vec![
+        // match expression type is indeterminate
         r#"function f(n int) int {
             return match n {
-                0 => { :1 }
-                _ => { :0 }
+                0 => None
+                1 => "1"
+                _ => 0
             }
         }"#,
     ];

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 
-use aranya_policy_ast::{self as ast, AstNode, MapStatement, Version};
+use aranya_policy_ast::{self as ast, AstNode, MapStatement, MatchExpression, Version};
 use ast::{EnumDefinition, EnumReference, Expression, FactField, MatchPattern};
 use buggy::BugExt;
 use pest::{
@@ -664,16 +664,20 @@ impl<'a> ChunkParser<'a> {
             // Remaining tokens are policy statements
             let expression = self.parse_block_expression(pc.consume()?)?;
 
+            let locator = self.add_range(&arm)?;
             arms.push(AstNode::new(
                 ast::MatchArmExpression {
                     pattern,
                     expression,
                 },
-                0,
+                locator,
             ));
         }
 
-        Ok(Expression::MatchExpression(Box::new(expression), arms))
+        Ok(Expression::Match(Box::new(MatchExpression {
+            expression,
+            arms,
+        })))
     }
 
     fn parse_counting_fn(

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -630,24 +630,7 @@ impl<'a> ChunkParser<'a> {
                 Rule::match_arm_expression => {
                     let values = token
                         .into_inner()
-                        .map(|token| {
-                            let expr = self.parse_expression(token.to_owned())?;
-                            // Ensure expression values are all literals
-                            if !matches!(
-                                expr,
-                                Expression::Int(_)
-                                    | Expression::String(_)
-                                    | Expression::Bool(_)
-                                    | Expression::EnumReference(_)
-                            ) {
-                                return Err(ParseError::new(
-                                    ParseErrorKind::InvalidType,
-                                    String::from("match arm value must be a literal"),
-                                    Some(token.as_span()),
-                                ));
-                            }
-                            Ok(expr)
-                        })
+                        .map(|token| self.parse_expression(token.to_owned()))
                         .collect::<Result<Vec<Expression>, ParseError>>()?;
 
                     MatchPattern::Values(values)
@@ -1577,7 +1560,3 @@ pub fn get_pratt_parser() -> PrattParser<Rule> {
 
 #[cfg(test)]
 mod tests;
-
-// fn parse_either<A, B>(pair: Pair<_, Rule>) -> Result<Either<A, B>> {
-
-// }

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -621,7 +621,7 @@ impl<'a> ChunkParser<'a> {
         // All remaining tokens are match arms
         let mut arms = vec![];
         for arm in pc.into_inner() {
-            assert_eq!(arm.as_rule(), Rule::match_arm_expr);
+            assert_eq!(arm.as_rule(), Rule::match_expression_arm);
             let pc = descend(arm.to_owned());
             let token = pc.consume()?;
 
@@ -666,7 +666,7 @@ impl<'a> ChunkParser<'a> {
 
             let locator = self.add_range(&arm)?;
             arms.push(AstNode::new(
-                ast::MatchArmExpression {
+                ast::MatchExpressionArm {
                     pattern,
                     expression,
                 },

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -662,7 +662,7 @@ impl<'a> ChunkParser<'a> {
             };
 
             // Remaining tokens are policy statements
-            let expression = self.parse_block_expression(pc.consume()?)?;
+            let expression = self.parse_expression(pc.consume()?)?;
 
             let locator = self.add_range(&arm)?;
             arms.push(AstNode::new(

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -616,7 +616,7 @@ impl<'a> ChunkParser<'a> {
 
     fn parse_match_expression(&mut self, expr: Pair<'_, Rule>) -> Result<Expression, ParseError> {
         let pc = descend(expr);
-        let expression = pc.consume_expression(self)?;
+        let scrutinee = pc.consume_expression(self)?;
 
         // All remaining tokens are match arms
         let mut arms = vec![];
@@ -658,7 +658,7 @@ impl<'a> ChunkParser<'a> {
         }
 
         Ok(Expression::Match(Box::new(MatchExpression {
-            expression,
+            scrutinee,
             arms,
         })))
     }

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -462,7 +462,8 @@ impl<'a> ChunkParser<'a> {
                 Rule::at_least => self.parse_counting_fn(primary, ast::FactCountType::AtLeast),
                 Rule::at_most => self.parse_counting_fn(primary, ast::FactCountType::AtMost),
                 Rule::exactly => self.parse_counting_fn(primary, ast::FactCountType::Exactly),
-                Rule::if_e => {
+                Rule::match_expression => self.parse_match_expression(primary),
+                Rule::if_expr => {
                     let mut pairs = primary.clone().into_inner();
                     let token = pairs.next().ok_or(ParseError::new(
                         ParseErrorKind::InvalidFunctionCall,
@@ -516,13 +517,7 @@ impl<'a> ChunkParser<'a> {
                     ))
                 }
                 Rule::identifier => Ok(Expression::Identifier(primary.as_str().to_owned())),
-                Rule::block_expression => {
-                    let pc = descend(primary.clone());
-                    let statements = pc.consume()?.into_inner();
-                    let statement_list = self.parse_statement_list(statements)?;
-                    let expr = pc.consume_expression(self)?;
-                    Ok(Expression::Block(statement_list, Box::new(expr)))
-                }
+                Rule::block_expression => self.parse_block_expression(primary),
                 Rule::expression => self.parse_expression(primary),
                 _ => Err(ParseError::new(
                     ParseErrorKind::Expression,
@@ -609,6 +604,76 @@ impl<'a> ChunkParser<'a> {
                 )),
             })
             .parse(pairs)
+    }
+
+    fn parse_block_expression(&mut self, expr: Pair<'_, Rule>) -> Result<Expression, ParseError> {
+        let pc = descend(expr.clone());
+        let statements = pc.consume()?.into_inner();
+        let statement_list = self.parse_statement_list(statements)?;
+        let expr = pc.consume_expression(self)?;
+        Ok(Expression::Block(statement_list, Box::new(expr)))
+    }
+
+    fn parse_match_expression(&mut self, expr: Pair<'_, Rule>) -> Result<Expression, ParseError> {
+        let pc = descend(expr);
+        let expression = pc.consume_expression(self)?;
+
+        // All remaining tokens are match arms
+        let mut arms = vec![];
+        for arm in pc.into_inner() {
+            assert_eq!(arm.as_rule(), Rule::match_arm_expr);
+            let pc = descend(arm.to_owned());
+            let token = pc.consume()?;
+
+            let pattern = match token.as_rule() {
+                Rule::match_default => MatchPattern::Default,
+                Rule::match_arm_expression => {
+                    let values = token
+                        .into_inner()
+                        .map(|token| {
+                            let expr = self.parse_expression(token.to_owned())?;
+                            // Ensure expression values are all literals
+                            if !matches!(
+                                expr,
+                                Expression::Int(_)
+                                    | Expression::String(_)
+                                    | Expression::Bool(_)
+                                    | Expression::EnumReference(_)
+                            ) {
+                                return Err(ParseError::new(
+                                    ParseErrorKind::InvalidType,
+                                    String::from("match arm value must be a literal"),
+                                    Some(token.as_span()),
+                                ));
+                            }
+                            Ok(expr)
+                        })
+                        .collect::<Result<Vec<Expression>, ParseError>>()?;
+
+                    MatchPattern::Values(values)
+                }
+                _ => {
+                    return Err(ParseError::new(
+                        ParseErrorKind::Unknown,
+                        String::from("invalid token in match arm"),
+                        Some(token.as_span()),
+                    ))
+                }
+            };
+
+            // Remaining tokens are policy statements
+            let expression = self.parse_block_expression(pc.consume()?)?;
+
+            arms.push(AstNode::new(
+                ast::MatchArmExpression {
+                    pattern,
+                    expression,
+                },
+                0,
+            ));
+        }
+
+        Ok(Expression::MatchExpression(Box::new(expression), arms))
     }
 
     fn parse_counting_fn(
@@ -1508,3 +1573,7 @@ pub fn get_pratt_parser() -> PrattParser<Rule> {
 
 #[cfg(test)]
 mod tests;
+
+// fn parse_either<A, B>(pair: Pair<_, Rule>) -> Result<Either<A, B>> {
+
+// }

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -154,7 +154,7 @@ at_most = { "at_most" ~ int_literal ~ fact_literal }
 exactly = { "exactly" ~ int_literal ~ fact_literal }
 // Similar to the `match` statement, but resolves to a value. e.g. `let x = match { ... }`
 match_expression = { "match" ~ expression ~ "{" ~ match_arm_expr* ~ "}" }
-match_arm_expr = { (match_arm_expression | match_default) ~ "=>" ~ block_expression }
+match_arm_expr = { (match_arm_expression | match_default) ~ "=>" ~ expression }
 // An if/else expression is a logical statement that returns one
 // expression or the other depending on the boolean evaluation of the
 // first expression.

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -152,16 +152,30 @@ at_least = { "at_least" ~ int_literal ~ fact_literal}
 at_most = { "at_most" ~ int_literal ~ fact_literal }
 // count facts, returning true if the number of facts found equals the expected number
 exactly = { "exactly" ~ int_literal ~ fact_literal }
+// Similar to the `match` statement, but resolves to a value. e.g. `let x = match { ... }`
+match_expression = { "match" ~ expression ~ "{" ~ match_arm_expr* ~ "}" }
+match_arm_expr = { (match_arm_expression | match_default) ~ "=>" ~ block_expression }
 // An if/else expression is a logical statement that returns one
 // expression or the other depending on the boolean evaluation of the
 // first expression.
-if_e = { "if" ~ expression ~ "{" ~ expression ~ "}" ~ "else" ~ "{" ~ expression ~ "}" }
+if_expr = { "if" ~ expression ~ "{" ~ expression ~ "}" ~ "else" ~ "{" ~ expression ~ "}" }
 // serialize() and deserialize() transform command structs to/from bytes
 serialize = { "serialize(" ~ expression ~ ")" }
 deserialize = { "deserialize(" ~ expression ~ ")" }
 // Internal functions are just expressions that have their rules that
 // don't fit into the pratt parser.
-internal_function = _{ query | exists | count_up_to | at_least | at_most | exactly | if_e | serialize | deserialize }
+internal_function = _{
+    query |
+    exists |
+    count_up_to |
+    at_least |
+    at_most |
+    exactly |
+    match_expression |
+    if_expr |
+    serialize |
+    deserialize
+}
 // A block expression is a series of statements followed by an expression
 // the statement list is separated for easier parsing
 block_statement_list = { statements* }

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -153,8 +153,8 @@ at_most = { "at_most" ~ int_literal ~ fact_literal }
 // count facts, returning true if the number of facts found equals the expected number
 exactly = { "exactly" ~ int_literal ~ fact_literal }
 // Similar to the `match` statement, but resolves to a value. e.g. `let x = match { ... }`
-match_expression = { "match" ~ expression ~ "{" ~ match_arm_expr* ~ "}" }
-match_arm_expr = { (match_arm_expression | match_default) ~ "=>" ~ expression }
+match_expression = { "match" ~ expression ~ "{" ~ match_expression_arm* ~ "}" }
+match_expression_arm = { (match_arm_expression | match_default) ~ "=>" ~ expression }
 // An if/else expression is a logical statement that returns one
 // expression or the other depending on the boolean evaluation of the
 // first expression.

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -171,7 +171,6 @@ internal_function = _{
     at_least |
     at_most |
     exactly |
-    match_expression |
     if_expr |
     serialize |
     deserialize
@@ -188,6 +187,7 @@ atom = _{
     bool_literal |
     optional_literal |
     named_struct_literal |
+    match_expression |
     internal_function |
     function_call |
     foreign_function_call |

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -1763,9 +1763,7 @@ fn parse_match_expression() {
                     let x = true
                     : x
                 }
-                _ => {
-                    : false
-                }
+                _ => false
             }
         }
     "#;
@@ -1798,10 +1796,7 @@ fn parse_match_expression() {
                         AstNode::new(
                             ast::MatchArmExpression {
                                 pattern: MatchPattern::Default,
-                                expression: Expression::Block(
-                                    vec![],
-                                    Box::new(Expression::Bool(false))
-                                )
+                                expression: Expression::Bool(false)
                             },
                             173
                         )

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -1776,9 +1776,9 @@ fn parse_match_expression() {
         vec![AstNode {
             inner: ast::Statement::Let(ast::LetStatement {
                 identifier: "x".to_string(),
-                expression: Expression::MatchExpression(
-                    Box::new(Expression::Identifier("n".to_string())),
-                    vec![
+                expression: Expression::Match(Box::new(ast::MatchExpression {
+                    expression: Expression::Identifier("n".to_string()),
+                    arms: vec![
                         AstNode::new(
                             ast::MatchArmExpression {
                                 pattern: MatchPattern::Values(vec![Expression::Int(0)]),
@@ -1793,7 +1793,7 @@ fn parse_match_expression() {
                                     Box::new(Expression::Identifier("x".to_string()))
                                 )
                             },
-                            0
+                            75
                         ),
                         AstNode::new(
                             ast::MatchArmExpression {
@@ -1803,10 +1803,10 @@ fn parse_match_expression() {
                                     Box::new(Expression::Bool(false))
                                 )
                             },
-                            0
+                            173
                         )
                     ]
-                )
+                }))
             }),
             locator: 41
         }]

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -1809,11 +1809,11 @@ fn parse_match_expression() {
 }
 
 #[test]
-fn match_expression() {
+fn test_match_expression() {
     let invalid = vec![
         (
             // block without subexpression (`:value`)
-            r#"action foo(string status) {
+            r#"action foo(status string) {
                 let x = match a {
                     "ready" => {
                         1
@@ -1821,16 +1821,6 @@ fn match_expression() {
                     _ => {
                         0
                     }
-                }
-            }"#,
-            ParseErrorKind::Syntax,
-        ),
-        (
-            // literal expressions are not allowed
-            r#"action foo(string status) {
-                let x = match a {
-                    "ready" => 1
-                    _ => 0
                 }
             }"#,
             ParseErrorKind::Syntax,
@@ -1850,6 +1840,7 @@ fn match_expression() {
             ParseErrorKind::Syntax,
         ),
         (
+            // empty match
             r#"function f(n int) bool {
                 return match n {}
             }"#,

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -1775,7 +1775,7 @@ fn parse_match_expression() {
             inner: ast::Statement::Let(ast::LetStatement {
                 identifier: "x".to_string(),
                 expression: Expression::Match(Box::new(ast::MatchExpression {
-                    expression: Expression::Identifier("n".to_string()),
+                    scrutinee: Expression::Identifier("n".to_string()),
                     arms: vec![
                         AstNode::new(
                             ast::MatchExpressionArm {

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -1778,7 +1778,7 @@ fn parse_match_expression() {
                     expression: Expression::Identifier("n".to_string()),
                     arms: vec![
                         AstNode::new(
-                            ast::MatchArmExpression {
+                            ast::MatchExpressionArm {
                                 pattern: MatchPattern::Values(vec![Expression::Int(0)]),
                                 expression: Expression::Block(
                                     vec![AstNode::new(
@@ -1794,7 +1794,7 @@ fn parse_match_expression() {
                             75
                         ),
                         AstNode::new(
-                            ast::MatchArmExpression {
+                            ast::MatchExpressionArm {
                                 pattern: MatchPattern::Default,
                                 expression: Expression::Bool(false)
                             },

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -1768,7 +1768,7 @@ fn parse_match_expression() {
         }
     "#;
 
-    let policy = parse_policy_str(&src, Version::V2).expect("should parse");
+    let policy = parse_policy_str(src, Version::V2).expect("should parse");
     assert_eq!(
         policy.actions[0].statements,
         vec![AstNode {
@@ -1814,27 +1814,25 @@ fn match_expression() {
         (
             // block without subexpression (`:value`)
             r#"action foo(string status) {
-            let x = match a {
-                "ready" => {
-                    1
+                let x = match a {
+                    "ready" => {
+                        1
+                    }
+                    _ => {
+                        0
+                    }
                 }
-                _ => {
-                    0
-                }
-            }
-        }
-        "#,
+            }"#,
             ParseErrorKind::Syntax,
         ),
         (
             // literal expressions are not allowed
             r#"action foo(string status) {
-            let x = match a {
-                "ready" => 1
-                _ => 0
-            }
-        }
-        "#,
+                let x = match a {
+                    "ready" => 1
+                    _ => 0
+                }
+            }"#,
             ParseErrorKind::Syntax,
         ),
         (
@@ -1848,22 +1846,19 @@ fn match_expression() {
                         : false
                     }
                 }
-            }
-            "#,
+            }"#,
             ParseErrorKind::Syntax,
         ),
         (
             r#"function f(n int) bool {
                 return match n {}
-            }
-            "#,
+            }"#,
             ParseErrorKind::Syntax,
         ),
     ];
 
-    // mismatched arm types (can parser detect this?)
     for (src, expected) in invalid {
-        let err_kind = parse_policy_str(&src, Version::V2).unwrap_err().kind;
+        let err_kind = parse_policy_str(src, Version::V2).unwrap_err().kind;
         assert_eq!(err_kind, expected);
     }
 }

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -202,7 +202,6 @@ impl Machine {
     }
 
     /// Converts the `Machine` into a `Module`.
-    /// NOTE this is not used
     pub fn into_module(self) -> Module {
         Module {
             data: ModuleData::V0(ModuleV0 {

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -1204,8 +1204,10 @@ fn test_match_return() -> anyhow::Result<()> {
 #[test]
 fn test_match_expression() -> anyhow::Result<()> {
     let text = r#"
-        effect F {
-            x int
+        command F {
+            fields { x int }
+            seal { return None }
+            open { return None }
         }
         action foo(x int) {
             let y = match x {


### PR DESCRIPTION
Allows `match` to be use as an expression. E.g.:
```
let x = match n {
    1 => {
      :"one"
    }
    _ => "other"
  }
```