### PR TITLE
Security updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
  "postcard",
  "serde",
  "siphasher",
- "spin 0.9.8",
+ "spin",
  "thiserror 2.0.7",
  "tracing",
 ]
@@ -514,7 +514,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
- "spin 0.9.8",
+ "spin",
  "tempfile",
  "test-log",
  "thiserror 2.0.7",
@@ -553,7 +553,7 @@ checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
 dependencies = [
  "aws-lc-sys",
  "paste",
- "untrusted 0.7.1",
+ "untrusted",
  "zeroize",
 ]
 
@@ -619,7 +619,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -1553,7 +1553,7 @@ dependencies = [
  "hash32 0.2.1",
  "rustc_version",
  "serde",
- "spin 0.9.8",
+ "spin",
  "stable_deref_trait",
 ]
 
@@ -1731,7 +1731,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -2345,12 +2345,13 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.11.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
+ "aws-lc-rs",
  "pem",
- "ring 0.16.20",
+ "rustls-pki-types",
  "time",
  "yasna",
 ]
@@ -2430,36 +2431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.15",
- "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2494,46 +2465,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
-dependencies = [
- "aws-lc-rs",
- "log",
- "once_cell",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "aws-lc-rs",
- "ring 0.17.8",
- "rustls-pki-types",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustversion"
@@ -2587,7 +2522,7 @@ dependencies = [
  "s2n-quic-core",
  "s2n-quic-crypto",
  "s2n-quic-platform",
- "s2n-quic-tls-default",
+ "s2n-quic-tls",
  "s2n-quic-transport",
  "tokio",
  "zerocopy",
@@ -2645,20 +2580,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "s2n-quic-rustls"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b58c89e5d3b62b20d1eee0712101e7689b5c8751b0935d9c80abc197156cb7b"
-dependencies = [
- "bytes",
- "rustls",
- "rustls-pemfile",
- "s2n-codec",
- "s2n-quic-core",
- "s2n-quic-crypto",
-]
-
-[[package]]
 name = "s2n-quic-tls"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,16 +2592,6 @@ dependencies = [
  "s2n-quic-core",
  "s2n-quic-crypto",
  "s2n-tls",
-]
-
-[[package]]
-name = "s2n-quic-tls-default"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a111eeff2e7bf9d98ac6fb803465739333ce0c41daa506bde3e453de4a84d25"
-dependencies = [
- "s2n-quic-rustls",
- "s2n-quic-tls",
 ]
 
 [[package]]
@@ -2736,9 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.2.6"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b13f8ea6177672c49d12ed964cca44836f59621981b04a3e26b87e675181de"
+checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
 dependencies = [
  "sdd",
 ]
@@ -2751,9 +2662,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
-version = "3.0.5"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9"
+checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
 
 [[package]]
 name = "sec1"
@@ -2994,7 +2905,7 @@ dependencies = [
  "sha2",
  "sha3-utils",
  "spideroak-crypto-derive",
- "spin 0.9.8",
+ "spin",
  "subtle",
  "typenum",
  "wycheproof",
@@ -3012,12 +2923,6 @@ dependencies = [
  "quote",
  "syn 2.0.90",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -3445,12 +3350,6 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,12 +46,10 @@ log = { version = "0.4", default-features = false }
 postcard = { version = "1", default-features = false }
 proptest = { version = "1.6", default-features = false, features = ["no_std", "alloc"] }
 proptest-derive = { version = "0.5" }
-quinn = { version = "0.10.1" }
-s2n-quic = { version = "1.51.0" }
+s2n-quic = { version = "1.51.0", default-features = false, features = ["provider-address-token-default", "provider-tls-s2n"] }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 rustix = { version = "0.38", default-features = false }
-rustls = { version = "0.21.0", default-features = false }
 serde = { version = "1.0.210", default-features = false }
 spin = { version = "0.9.8", default-features = false }
 test-log = { version = "0.2", default-features = false, features = ["trace"] }

--- a/crates/aranya-quic-syncer/Cargo.toml
+++ b/crates/aranya-quic-syncer/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { workspace = true }
 aranya-crypto = { path = "../aranya-crypto", features = ["std"] }
 
 criterion = { version = "0.5", features = ["async_tokio"] }
-rcgen = "0.11.3"
+rcgen = { version = "0.13", default-features = false, features = ["pem", "aws_lc_rs"] }
 test-log = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { workspace = true, default-features = true }

--- a/crates/aranya-quic-syncer/benches/quic_syncer.rs
+++ b/crates/aranya-quic-syncer/benches/quic_syncer.rs
@@ -107,10 +107,10 @@ fn sync_bench(c: &mut Criterion) {
             // setup
             let request_sink = Arc::new(TMutex::new(CountSink::new()));
             let request_client = Arc::new(TMutex::new(create_client()));
-            let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])
+            let ck = rcgen::generate_simple_self_signed(vec!["localhost".into()])
                 .expect("error generating cert");
-            let key = cert.serialize_private_key_pem();
-            let cert = cert.serialize_pem().expect("error serilizing cert");
+            let key = ck.key_pair.serialize_pem();
+            let cert = ck.cert.pem();
             let server1 = get_server(cert.clone(), key.clone()).expect("error getting server");
             let (tx1, _) = mpsc::unbounded_channel();
             let syncer1 = Arc::new(TMutex::new(

--- a/crates/aranya-quic-syncer/examples/quic_syncer.rs
+++ b/crates/aranya-quic-syncer/examples/quic_syncer.rs
@@ -94,10 +94,10 @@ async fn run(options: Opt) -> Result<()> {
     {
         Ok(x) => x,
         Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
-            let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])
+            let ck = rcgen::generate_simple_self_signed(vec!["localhost".into()])
                 .expect("error generating cert");
-            let key = cert.serialize_private_key_pem();
-            let cert = cert.serialize_pem().expect("error serializing cert");
+            let key = ck.key_pair.serialize_pem();
+            let cert = ck.cert.pem();
             fs::create_dir_all(path).context("failed to create certificate directory")?;
             fs::write(&cert_path, &cert).context("failed to write certificate")?;
             fs::write(&key_path, &key).context("failed to write private key")?;

--- a/crates/aranya-quic-syncer/tests/test.rs
+++ b/crates/aranya-quic-syncer/tests/test.rs
@@ -17,9 +17,9 @@ use tokio::sync::{mpsc, Mutex as TMutex};
 async fn test_sync() -> Result<()> {
     let client1 = make_client();
     let sink1 = Arc::new(TMutex::new(TestSink::new()));
-    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
-    let key = cert.serialize_private_key_pem();
-    let cert = cert.serialize_pem()?;
+    let ck = rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
+    let key = ck.key_pair.serialize_pem();
+    let cert = ck.cert.pem();
     let (tx, rx) = mpsc::unbounded_channel();
     let server_addr1 = get_server(cert.clone(), key.clone())?;
     let syncer1 = Arc::new(TMutex::new(Syncer::new(
@@ -82,9 +82,9 @@ async fn test_sync() -> Result<()> {
 async fn test_sync_subscribe() -> Result<()> {
     let client1 = make_client();
     let sink1 = Arc::new(TMutex::new(TestSink::new()));
-    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
-    let key = cert.serialize_private_key_pem();
-    let cert = cert.serialize_pem()?;
+    let ck = rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
+    let key = ck.key_pair.serialize_pem();
+    let cert = ck.cert.pem();
     let (tx1, rx1) = mpsc::unbounded_channel();
     let server_addr1 = get_server(cert.clone(), key.clone())?;
     let syncer1 = Arc::new(TMutex::new(Syncer::new(

--- a/deny.toml
+++ b/deny.toml
@@ -76,6 +76,7 @@ yanked = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but shouldn't need any, and we don't use it directly" },
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
@@ -237,7 +238,6 @@ skip = [
     "getrandom@0.1.16",
     "hash32@0.2.1",
     "heapless@0.7.17",
-    "itertools@0.10.5",
     "itertools@0.11.0",
     "rand@0.7.3",
     "rand_chacha@0.2.2",
@@ -247,7 +247,6 @@ skip = [
     "syn@1.0.109",
     "thiserror-impl@1.0.69",
     "thiserror@1.0.69",
-    "untrusted@0.7.1",
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,7 +1,20 @@
 
 # cargo-vet audits file
 
-[audits]
+[[audits.rcgen]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-run"
+delta = "0.11.3 -> 0.13.2"
+
+[[audits.scc]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-run"
+delta = "2.2.6 -> 2.3.3"
+
+[[audits.sdd]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-run"
+delta = "3.0.5 -> 3.0.7"
 
 [[trusted.aranya-afc-util]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -466,10 +466,6 @@ version = "1.70.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]
-version = "0.10.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.itertools]]
 version = "0.11.0"
 criteria = "safe-to-deploy"
 
@@ -697,33 +693,13 @@ criteria = "safe-to-deploy"
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.ring]]
-version = "0.16.20"
-criteria = "safe-to-run"
-
-[[exemptions.ring]]
-version = "0.17.8"
-criteria = "safe-to-deploy"
-
 [[exemptions.rustix]]
 version = "0.38.42"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustls]]
-version = "0.23.21"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustls-pemfile]]
-version = "2.2.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.rustls-pki-types]]
 version = "1.10.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustls-webpki]]
-version = "0.102.8"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.rusty-fork]]
 version = "0.3.0"
@@ -753,15 +729,7 @@ criteria = "safe-to-deploy"
 version = "0.52.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.s2n-quic-rustls]]
-version = "0.52.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.s2n-quic-tls]]
-version = "0.52.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.s2n-quic-tls-default]]
 version = "0.52.0"
 criteria = "safe-to-deploy"
 
@@ -840,10 +808,6 @@ criteria = "safe-to-deploy"
 [[exemptions.socket2]]
 version = "0.5.8"
 criteria = "safe-to-deploy"
-
-[[exemptions.spin]]
-version = "0.5.2"
-criteria = "safe-to-run"
 
 [[exemptions.spin]]
 version = "0.9.8"
@@ -955,10 +919,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.unsafe-libyaml]]
 version = "0.2.11"
-criteria = "safe-to-deploy"
-
-[[exemptions.untrusted]]
-version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.utf8parse]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -500,6 +500,12 @@ https://source.chromium.org/chromium/chromium/src/+/28841c33c77833cc30b286f9ae24
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.itertools]]
+who = "ChromeOS"
+criteria = "safe-to-run"
+version = "0.10.5"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.google.audits.itoa]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
@@ -1459,12 +1465,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Simon Friedberger <simon@mozilla.com>"
 criteria = "safe-to-deploy"
 version = "0.4.3"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.itertools]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.10.3 -> 0.10.5"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-conv]]


### PR DESCRIPTION
- Update `rcgen` and use aws crypto for it and `s2n-quic` instead of `ring`
  - `ring`'s https://rustsec.org/advisories/RUSTSEC-2025-0009 required updating `rcgen`, which now has a flag for choosing aws crypto, so I switched off `ring` entirely.
- Update `scc` and `sdd` off yanked versions.
- Allow https://rustsec.org/advisories/RUSTSEC-2024-0436.html
  - it doesn't seem problematic and has no easy migration at the moment.