### PR TITLE
aranya-core: user -> device crate release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-crypto"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aranya-crypto",
  "buggy",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-crypto-ffi"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "aranya-crypto",
  "aranya-crypto-ffi",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-device-ffi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-envelope-ffi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-fast-channels"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aranya-crypto",
  "aranya-fast-channels",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-idam-ffi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aranya-crypto",
  "aranya-idam-ffi",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-perspective-ffi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-compiler"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aranya-policy-ifgen-build",
  "aranya-policy-ifgen-macro",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-module"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-ast",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-vm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-runtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aranya-crypto",
  "aranya-libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "aranya-afc-util"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aranya-afc-util",
  "aranya-crypto",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-crypto-ffi"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aranya-crypto",
  "aranya-crypto-ffi",

--- a/crates/aranya-afc-util/CHANGELOG.md
+++ b/crates/aranya-afc-util/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-afc-util-v0.4.0...aranya-afc-util-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-afc-util-v0.3.0...aranya-afc-util-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-afc-util/Cargo.toml
+++ b/crates/aranya-afc-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-afc-util"
 description = "Utilities for using Aranya Fast Channels"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-afc-util/Cargo.toml
+++ b/crates/aranya-afc-util/Cargo.toml
@@ -43,9 +43,9 @@ testing = [
 ]
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-fast-channels = { version = "0.4.0", path = "../aranya-fast-channels", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.4.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-fast-channels = { version = "0.5.0", path = "../aranya-fast-channels", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 buggy = { version = "0.1.0", default-features = false }
 indexmap = { version = "2.1", default-features = false, optional = true }
 postcard = { workspace = true, default-features = false, features = ["heapless"] }

--- a/crates/aranya-crypto-ffi/CHANGELOG.md
+++ b/crates/aranya-crypto-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-ffi-v0.4.0...aranya-crypto-ffi-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-ffi-v0.3.0...aranya-crypto-ffi-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-crypto-ffi/Cargo.toml
+++ b/crates/aranya-crypto-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-crypto-ffi"
 description = "The crypto FFI for Aranya Policy"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -41,8 +41,8 @@ testing = [
 ]
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.4.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 postcard = { workspace = true, default-features = false, features = ["heapless"] }
 serde = { workspace = true, default-features = false, features = ["derive"], optional = true }

--- a/crates/aranya-crypto-ffi/Cargo.toml
+++ b/crates/aranya-crypto-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-crypto-ffi"
 description = "The crypto FFI for Aranya Policy"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-crypto/CHANGELOG.md
+++ b/crates/aranya-crypto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-v0.3.0...aranya-crypto-v0.4.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.3.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-v0.2.1...aranya-crypto-v0.3.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-crypto/Cargo.toml
+++ b/crates/aranya-crypto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-crypto"
 description = "The Aranya Cryptography Engine"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-device-ffi/CHANGELOG.md
+++ b/crates/aranya-device-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-device-ffi-v0.4.0...aranya-device-ffi-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-device-ffi-v0.3.0...aranya-device-ffi-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-device-ffi/Cargo.toml
+++ b/crates/aranya-device-ffi/Cargo.toml
@@ -24,8 +24,8 @@ std = ["alloc"]
 testing = []
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", default-features = false }
-aranya-policy-vm = { version = "0.4.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false }
+aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 aranya-crypto = { path = "../aranya-crypto", features = ["getrandom"] }

--- a/crates/aranya-device-ffi/Cargo.toml
+++ b/crates/aranya-device-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-device-ffi"
 description = "The device FFI for Aranya Policy"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-envelope-ffi/CHANGELOG.md
+++ b/crates/aranya-envelope-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-envelope-ffi-v0.4.0...aranya-envelope-ffi-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-envelope-ffi-v0.3.0...aranya-envelope-ffi-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-envelope-ffi/Cargo.toml
+++ b/crates/aranya-envelope-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-envelope-ffi"
 description = "The envelope FFI for Aranya Policy"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -28,8 +28,8 @@ std = [
 ]
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.4.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/aranya-envelope-ffi/Cargo.toml
+++ b/crates/aranya-envelope-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-envelope-ffi"
 description = "The envelope FFI for Aranya Policy"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-fast-channels/CHANGELOG.md
+++ b/crates/aranya-fast-channels/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-fast-channels-v0.4.0...aranya-fast-channels-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-fast-channels-v0.3.0...aranya-fast-channels-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-fast-channels/Cargo.toml
+++ b/crates/aranya-fast-channels/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-fast-channels"
 description = "High throughput, low latency encryption protected by Aranya Policy"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -79,7 +79,7 @@ core_intrinsics = []
 try_find = []
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", default-features = false, features = ["getrandom"] }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["getrandom"] }
 buggy = { version = "0.1.0", default-features = false }
 
 byteorder = { version = "1", default-features = false }

--- a/crates/aranya-fast-channels/Cargo.toml
+++ b/crates/aranya-fast-channels/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-fast-channels"
 description = "High throughput, low latency encryption protected by Aranya Policy"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-idam-ffi/CHANGELOG.md
+++ b/crates/aranya-idam-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-idam-ffi-v0.4.0...aranya-idam-ffi-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-idam-ffi-v0.3.0...aranya-idam-ffi-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-idam-ffi/Cargo.toml
+++ b/crates/aranya-idam-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-idam-ffi"
 description = "The IDAM FFI for Aranya Policy"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-idam-ffi/Cargo.toml
+++ b/crates/aranya-idam-ffi/Cargo.toml
@@ -33,8 +33,8 @@ std = [
 testing = []
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.4.0", path = "../aranya-policy-vm", features = ["derive"] }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", features = ["derive"] }
 postcard = { workspace = true, default-features = false, features = ["heapless"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/aranya-model/Cargo.toml
+++ b/crates/aranya-model/Cargo.toml
@@ -8,11 +8,11 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "fs-keystore"] }
-aranya-policy-compiler = { version = "0.4.0", path = "../aranya-policy-compiler" }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "fs-keystore"] }
+aranya-policy-compiler = { version = "0.5.0", path = "../aranya-policy-compiler" }
 aranya-policy-lang = { version = "0.2.0", path = "../aranya-policy-lang" }
-aranya-policy-vm = { version = "0.4.0", path = "../aranya-policy-vm" }
-aranya-runtime = { version = "0.4.0", path = "../aranya-runtime", features = ["testing"] }
+aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm" }
+aranya-runtime = { version = "0.5.0", path = "../aranya-runtime", features = ["testing"] }
 
 anyhow = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aranya-perspective-ffi/CHANGELOG.md
+++ b/crates/aranya-perspective-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-perspective-ffi-v0.4.0...aranya-perspective-ffi-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-perspective-ffi-v0.3.0...aranya-perspective-ffi-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-perspective-ffi/Cargo.toml
+++ b/crates/aranya-perspective-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-perspective-ffi"
 description = "The perspective FFI for Aranya Policy"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -26,8 +26,8 @@ std = []
 testing = []
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", default-features = false }
-aranya-policy-vm = { version = "0.4.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false }
+aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 aranya-crypto = { path = "../aranya-crypto", features = ["getrandom"] }

--- a/crates/aranya-perspective-ffi/Cargo.toml
+++ b/crates/aranya-perspective-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-perspective-ffi"
 description = "The perspective FFI for Aranya Policy"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-policy-compiler/CHANGELOG.md
+++ b/crates/aranya-policy-compiler/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-compiler-v0.4.0...aranya-policy-compiler-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-compiler-v0.3.0...aranya-policy-compiler-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-policy-compiler/Cargo.toml
+++ b/crates/aranya-policy-compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-compiler"
 description = "The Aranya Policy Compiler"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -17,7 +17,7 @@ default = []
 [dependencies]
 aranya-policy-ast = { version = "0.2.0", path = "../aranya-policy-ast" }
 aranya-policy-lang = { version = "0.2.0", path = "../aranya-policy-lang" }
-aranya-policy-module = { version = "0.4.0", path = "../aranya-policy-module", features = ["std"] }
+aranya-policy-module = { version = "0.5.0", path = "../aranya-policy-module", features = ["std"] }
 buggy = { version = "0.1.0", features = ["std"] }
 
 ciborium = { version = "0.2" }

--- a/crates/aranya-policy-compiler/Cargo.toml
+++ b/crates/aranya-policy-compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-compiler"
 description = "The Aranya Policy Compiler"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-policy-ifgen/CHANGELOG.md
+++ b/crates/aranya-policy-ifgen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.4.0...aranya-policy-ifgen-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.3.1...aranya-policy-ifgen-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-policy-ifgen/Cargo.toml
+++ b/crates/aranya-policy-ifgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ifgen"
 description = "Tools for generating Rust interfaces to Aranya Policies"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -19,8 +19,8 @@ serde = [
 
 [dependencies]
 aranya-policy-ifgen-macro = { version = "0.3.0", path = "../aranya-policy-ifgen-macro" }
-aranya-policy-vm = { version = "0.4.0", path = "../aranya-policy-vm" }
-aranya-runtime = { version = "0.4.0", path = "../aranya-runtime" }
+aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm" }
+aranya-runtime = { version = "0.5.0", path = "../aranya-runtime" }
 
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/crates/aranya-policy-ifgen/Cargo.toml
+++ b/crates/aranya-policy-ifgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ifgen"
 description = "Tools for generating Rust interfaces to Aranya Policies"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-policy-module/CHANGELOG.md
+++ b/crates/aranya-policy-module/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-module-v0.4.0...aranya-policy-module-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-module-v0.3.0...aranya-policy-module-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-policy-module/Cargo.toml
+++ b/crates/aranya-policy-module/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", default-features = false }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false }
 aranya-policy-ast = { version = "0.2.0", path = "../aranya-policy-ast" }
 
 proptest = { workspace = true, default-features = false, features = ["std"], optional = true }

--- a/crates/aranya-policy-module/Cargo.toml
+++ b/crates/aranya-policy-module/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-module"
 description = "The Aranya Policy module format"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-policy-vm-explorer/Cargo.toml
+++ b/crates/aranya-policy-vm-explorer/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 default = []
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto" }
-aranya-policy-compiler = { version = "0.4.0", path = "../aranya-policy-compiler" }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto" }
+aranya-policy-compiler = { version = "0.5.0", path = "../aranya-policy-compiler" }
 aranya-policy-lang = { version = "0.2.0", path = "../aranya-policy-lang" }
-aranya-policy-vm = { version = "0.4.0", path = "../aranya-policy-vm", features = ["std"] }
+aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", features = ["std"] }
 
 anyhow = { workspace = true }
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/aranya-policy-vm/CHANGELOG.md
+++ b/crates/aranya-policy-vm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.4.0...aranya-policy-vm-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.3.1...aranya-policy-vm-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-policy-vm/Cargo.toml
+++ b/crates/aranya-policy-vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-vm"
 description = "The Aranya Policy Virtual Machine"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-policy-vm/Cargo.toml
+++ b/crates/aranya-policy-vm/Cargo.toml
@@ -30,10 +30,10 @@ std = [
 bench = ["dep:table_formatter", "std"]
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", default-features = false }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false }
 aranya-policy-ast = { version = "0.2.0", path = "../aranya-policy-ast" }
 aranya-policy-derive = { version = "0.3.0", path = "../aranya-policy-derive" }
-aranya-policy-module = { version = "0.4.0", path = "../aranya-policy-module" }
+aranya-policy-module = { version = "0.5.0", path = "../aranya-policy-module" }
 buggy = { version = "0.1.0", features = ["alloc"] }
 
 heapless = { workspace = true }

--- a/crates/aranya-quic-syncer/Cargo.toml
+++ b/crates/aranya-quic-syncer/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", features = ["std"] }
-aranya-runtime = { version = "0.4.0", path = "../aranya-runtime", features = ["std"] }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", features = ["std"] }
+aranya-runtime = { version = "0.5.0", path = "../aranya-runtime", features = ["std"] }
 buggy = { version = "0.1.0", features = ["std"] }
 
 heapless = { workspace = true, features = ["serde"] }

--- a/crates/aranya-runtime/CHANGELOG.md
+++ b/crates/aranya-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-runtime-v0.4.0...aranya-runtime-v0.5.0) - 2025-03-19
+
+### Other
+
+- rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-runtime-v0.3.0...aranya-runtime-v0.4.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-runtime/Cargo.toml
+++ b/crates/aranya-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-runtime"
 description = "The Aranya core runtime"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-runtime/Cargo.toml
+++ b/crates/aranya-runtime/Cargo.toml
@@ -14,9 +14,9 @@ workspace = true
 [dependencies]
 buggy = { version = "0.1.0", features = ["alloc"] }
 # `aranya-crypto` enables `getrandom` by default.
-aranya-crypto = { version = "0.3.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "rand_compat"] }
+aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "rand_compat"] }
 aranya-libc = { version = "0.1.1", path = "../aranya-libc", default-features = false, optional = true }
-aranya-policy-vm = { version = "0.4.0", path = "../aranya-policy-vm" }
+aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm" }
 
 heapless = { workspace = true, features = ["serde"] }
 postcard = { workspace = true, features = ["alloc"] }
@@ -27,7 +27,7 @@ tracing = { workspace = true }
 vec1 = { version = "1.10.1", default-features = false, features = ["serde"] }
 
 # Used by `testing`.
-aranya-policy-module = { version = "0.4.0", path = "../aranya-policy-module", optional = true }
+aranya-policy-module = { version = "0.5.0", path = "../aranya-policy-module", optional = true }
 serde_json = { version = "1.0.117", default-features = false, features = ["alloc"], optional = true }
 
 # graphviz


### PR DESCRIPTION
This unblocks user -> device rename for the aranya repo.

```
aranya-afc-util@0.5.0
aranya-crypto-ffi@0.5.0
aranya-crypto@0.4.0
aranya-device-ffi@0.5.0
aranya-envelope-ffi@0.5.0
aranya-fast-channels@0.5.0
aranya-idam-ffi@0.5.0
aranya-perspective-ffi@0.5.0
aranya-policy-compiler@0.5.0
aranya-policy-ifgen@0.5.0
aranya-policy-module@0.5.0
aranya-policy-vm@0.5.0
aranya-runtime@0.5.0
```