### PR TITLE
aranya-policy-lang: allow block expressions in `if` expressions.

### DIFF
--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -27,7 +27,7 @@ fn test_compile() -> anyhow::Result<()> {
         }
         action foo(b int) {
             let i = 4
-            let x = if b == 0 { 4+i } else { 3 }
+            let x = if b == 0 { :4+i } else { :3 }
             let y = Foo{
                 a: x,
                 b: 4
@@ -1637,7 +1637,7 @@ fn test_type_errors() -> anyhow::Result<()> {
         Case {
             t: r#"
                 function f() int {
-                    return if 0 { 3 } else { 4 }
+                    return if 0 { :3 } else { :4 }
                 }
             "#,
             e: "if condition must be a boolean expression",
@@ -2160,5 +2160,26 @@ fn test_validate_return() {
         let policy = parse_policy_str(p, Version::V2).expect("should parse");
         let m = Compiler::new(&policy).compile().expect("should compile");
         assert!(validate(&m));
+    }
+}
+
+#[test]
+fn if_expression_block() {
+    let cases = [(
+        r#"function f(n int) int {
+            let n = if n > 1 {
+                let x = n + 1
+                :x
+            } else 0
+            return n
+        }"#,
+        None,
+    )];
+
+    for (text, expected) in cases {
+        println!(">");
+        let policy = parse_policy_str(text, Version::V2).expect("should parse");
+        let res = Compiler::new(&policy).compile().err();
+        assert_eq!(res, expected);
     }
 }

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -2166,12 +2166,11 @@ fn test_validate_return() {
 #[test]
 fn if_expression_block() {
     let cases = [(
-        r#"function f(n int) int {
-            let n = if n > 1 {
+        r#"action f(n int) {
+            let x = if n > 1 {
                 let x = n + 1
                 :x
-            } else 0
-            return n
+            } else { :0 }
         }"#,
         None,
     )];

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -703,7 +703,7 @@ impl<'a> ChunkParser<'a> {
                 Some(expr.as_span()),
             )
         })?;
-        let then_expr = self.parse_expression(token)?;
+        let then_expr = self.parse_block_expression(token)?;
 
         let token = pairs.next().ok_or_else(|| {
             ParseError::new(
@@ -712,7 +712,7 @@ impl<'a> ChunkParser<'a> {
                 Some(expr.as_span()),
             )
         })?;
-        let else_expr = self.parse_expression(token)?;
+        let else_expr = self.parse_block_expression(token)?;
 
         Ok(Expression::InternalFunction(ast::InternalFunction::If(
             Box::new(condition),

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -60,8 +60,7 @@ impl<'a> PairContext<'a> {
     /// Consumes the next Pair out of this context and returns it.
     /// Errors if the next pair doesn't exist.
     fn consume(&self) -> Result<Pair<'_, Rule>, ParseError> {
-        let errmsg = self.location_error();
-        self.next().ok_or(errmsg)
+        self.next().ok_or_else(|| self.location_error())
     }
 
     /// Consumes the next Pair out of this context and returns it if
@@ -192,11 +191,13 @@ impl<'a> ChunkParser<'a> {
             }
             Rule::optional_t => {
                 let mut pairs = token.clone().into_inner();
-                let token = pairs.next().ok_or(ParseError::new(
-                    ParseErrorKind::Unknown,
-                    String::from("no type following optional"),
-                    Some(token.as_span()),
-                ))?;
+                let token = pairs.next().ok_or_else(|| {
+                    ParseError::new(
+                        ParseErrorKind::Unknown,
+                        String::from("no type following optional"),
+                        Some(token.as_span()),
+                    )
+                })?;
                 let vtype = Self::parse_type(token)?;
                 Ok(ast::VType::Optional(Box::new(vtype)))
             }
@@ -379,11 +380,13 @@ impl<'a> ChunkParser<'a> {
                 }
                 Rule::bool_literal => {
                     let mut pairs = primary.clone().into_inner();
-                    let token = pairs.next().ok_or(ParseError::new(
-                        ParseErrorKind::Unknown,
-                        String::from("bad bool expression"),
-                        Some(primary.as_span()),
-                    ))?;
+                    let token = pairs.next().ok_or_else(|| {
+                        ParseError::new(
+                            ParseErrorKind::Unknown,
+                            String::from("bad bool expression"),
+                            Some(primary.as_span()),
+                        )
+                    })?;
                     match token.as_rule() {
                         Rule::btrue => Ok(Expression::Bool(true)),
                         Rule::bfalse => Ok(Expression::Bool(false)),
@@ -396,19 +399,23 @@ impl<'a> ChunkParser<'a> {
                 }
                 Rule::optional_literal => {
                     let mut pairs = primary.clone().into_inner();
-                    let token = pairs.next().ok_or(ParseError::new(
-                        ParseErrorKind::Unknown,
-                        String::from("no token in optional literal"),
-                        Some(primary.as_span()),
-                    ))?;
+                    let token = pairs.next().ok_or_else(|| {
+                        ParseError::new(
+                            ParseErrorKind::Unknown,
+                            String::from("no token in optional literal"),
+                            Some(primary.as_span()),
+                        )
+                    })?;
                     Ok(Expression::Optional(match token.as_rule() {
                         Rule::none => None,
                         Rule::some => {
-                            let token = pairs.next().ok_or(ParseError::new(
-                                ParseErrorKind::Unknown,
-                                String::from("bad Some expression"),
-                                Some(primary.as_span()),
-                            ))?;
+                            let token = pairs.next().ok_or_else(|| {
+                                ParseError::new(
+                                    ParseErrorKind::Unknown,
+                                    String::from("bad Some expression"),
+                                    Some(primary.as_span()),
+                                )
+                            })?;
                             let e = self.parse_expression(token)?;
                             Some(Box::new(e))
                         }
@@ -436,11 +443,13 @@ impl<'a> ChunkParser<'a> {
                 )?)),
                 Rule::query => {
                     let mut pairs = primary.clone().into_inner();
-                    let token = pairs.next().ok_or(ParseError::new(
-                        ParseErrorKind::InvalidFunctionCall,
-                        String::from("query requires fact literal"),
-                        Some(primary.as_span()),
-                    ))?;
+                    let token = pairs.next().ok_or_else(|| {
+                        ParseError::new(
+                            ParseErrorKind::InvalidFunctionCall,
+                            String::from("query requires fact literal"),
+                            Some(primary.as_span()),
+                        )
+                    })?;
                     let fact_literal = self.parse_fact_literal(token)?;
                     Ok(Expression::InternalFunction(ast::InternalFunction::Query(
                         fact_literal,
@@ -448,11 +457,13 @@ impl<'a> ChunkParser<'a> {
                 }
                 Rule::exists => {
                     let mut pairs = primary.clone().into_inner();
-                    let token = pairs.next().ok_or(ParseError::new(
-                        ParseErrorKind::InvalidFunctionCall,
-                        String::from("exists requires fact literal"),
-                        Some(primary.as_span()),
-                    ))?;
+                    let token = pairs.next().ok_or_else(|| {
+                        ParseError::new(
+                            ParseErrorKind::InvalidFunctionCall,
+                            String::from("exists requires fact literal"),
+                            Some(primary.as_span()),
+                        )
+                    })?;
                     let fact_literal = self.parse_fact_literal(token)?;
                     Ok(Expression::InternalFunction(ast::InternalFunction::Exists(
                         fact_literal,
@@ -466,11 +477,13 @@ impl<'a> ChunkParser<'a> {
                 Rule::if_expr => self.parse_if_expression(primary),
                 Rule::serialize => {
                     let mut pairs = primary.clone().into_inner();
-                    let token = pairs.next().ok_or(ParseError::new(
-                        ParseErrorKind::InvalidFunctionCall,
-                        String::from("empty serialize function"),
-                        Some(primary.as_span()),
-                    ))?;
+                    let token = pairs.next().ok_or_else(|| {
+                        ParseError::new(
+                            ParseErrorKind::InvalidFunctionCall,
+                            String::from("empty serialize function"),
+                            Some(primary.as_span()),
+                        )
+                    })?;
                     let inner = self.parse_expression(token)?;
                     Ok(Expression::InternalFunction(
                         ast::InternalFunction::Serialize(Box::new(inner)),
@@ -478,11 +491,13 @@ impl<'a> ChunkParser<'a> {
                 }
                 Rule::deserialize => {
                     let mut pairs = primary.clone().into_inner();
-                    let token = pairs.next().ok_or(ParseError::new(
-                        ParseErrorKind::InvalidFunctionCall,
-                        String::from("empty deserialize function"),
-                        Some(primary.as_span()),
-                    ))?;
+                    let token = pairs.next().ok_or_else(|| {
+                        ParseError::new(
+                            ParseErrorKind::InvalidFunctionCall,
+                            String::from("empty deserialize function"),
+                            Some(primary.as_span()),
+                        )
+                    })?;
                     let inner = self.parse_expression(token)?;
                     Ok(Expression::InternalFunction(
                         ast::InternalFunction::Deserialize(Box::new(inner)),
@@ -551,11 +566,13 @@ impl<'a> ChunkParser<'a> {
                 Rule::is => {
                     let op_span = op.as_span();
                     let mut pairs = op.into_inner();
-                    let token = pairs.next().ok_or(ParseError::new(
-                        ParseErrorKind::InvalidFunctionCall,
-                        String::from("if requires expression"),
-                        Some(op_span),
-                    ))?;
+                    let token = pairs.next().ok_or_else(|| {
+                        ParseError::new(
+                            ParseErrorKind::InvalidFunctionCall,
+                            String::from("if requires expression"),
+                            Some(op_span),
+                        )
+                    })?;
                     let some = match token.as_rule() {
                         Rule::some => true,
                         Rule::none => false,
@@ -641,11 +658,13 @@ impl<'a> ChunkParser<'a> {
         cmp_type: ast::FactCountType,
     ) -> Result<Expression, ParseError> {
         let mut pairs = statement.clone().into_inner();
-        let token = pairs.next().ok_or(ParseError::new(
-            ParseErrorKind::Expression,
-            format!("{} requires count limit (int)", cmp_type),
-            Some(statement.as_span()),
-        ))?;
+        let token = pairs.next().ok_or_else(|| {
+            ParseError::new(
+                ParseErrorKind::Expression,
+                format!("{} requires count limit (int)", cmp_type),
+                Some(statement.as_span()),
+            )
+        })?;
         let limit = token.as_str().parse::<i64>().map_err(|e| {
             ParseError::new(
                 ParseErrorKind::InvalidNumber,
@@ -653,11 +672,13 @@ impl<'a> ChunkParser<'a> {
                 Some(statement.as_span()),
             )
         })?;
-        let token = pairs.next().ok_or(ParseError::new(
-            ParseErrorKind::Expression,
-            format!("{} requires fact literal", cmp_type),
-            Some(statement.as_span()),
-        ))?;
+        let token = pairs.next().ok_or_else(|| {
+            ParseError::new(
+                ParseErrorKind::Expression,
+                format!("{} requires fact literal", cmp_type),
+                Some(statement.as_span()),
+            )
+        })?;
         let fact = self.parse_fact_literal(token)?;
         Ok(Expression::InternalFunction(
             ast::InternalFunction::FactCount(cmp_type, limit, fact),
@@ -666,25 +687,31 @@ impl<'a> ChunkParser<'a> {
 
     fn parse_if_expression(&mut self, expr: Pair<'_, Rule>) -> Result<Expression, ParseError> {
         let mut pairs = expr.clone().into_inner();
-        let token = pairs.next().ok_or(ParseError::new(
-            ParseErrorKind::InvalidFunctionCall,
-            String::from("if requires expression"),
-            Some(expr.as_span()),
-        ))?;
+        let token = pairs.next().ok_or_else(|| {
+            ParseError::new(
+                ParseErrorKind::InvalidFunctionCall,
+                String::from("if requires expression"),
+                Some(expr.as_span()),
+            )
+        })?;
         let condition = self.parse_expression(token)?;
 
-        let token = pairs.next().ok_or(ParseError::new(
-            ParseErrorKind::InvalidFunctionCall,
-            String::from("if requires then case"),
-            Some(expr.as_span()),
-        ))?;
+        let token = pairs.next().ok_or_else(|| {
+            ParseError::new(
+                ParseErrorKind::InvalidFunctionCall,
+                String::from("if requires then case"),
+                Some(expr.as_span()),
+            )
+        })?;
         let then_expr = self.parse_expression(token)?;
 
-        let token = pairs.next().ok_or(ParseError::new(
-            ParseErrorKind::InvalidFunctionCall,
-            String::from("if requires else case"),
-            Some(expr.as_span()),
-        ))?;
+        let token = pairs.next().ok_or_else(|| {
+            ParseError::new(
+                ParseErrorKind::InvalidFunctionCall,
+                String::from("if requires else case"),
+                Some(expr.as_span()),
+            )
+        })?;
         let else_expr = self.parse_expression(token)?;
 
         Ok(Expression::InternalFunction(ast::InternalFunction::If(
@@ -1477,11 +1504,13 @@ pub fn parse_policy_chunk(
 /// Parse a function or finish function declaration for the FFI
 pub fn parse_ffi_decl(data: &str) -> Result<ast::FunctionDecl, ParseError> {
     let mut def = PolicyParser::parse(Rule::ffi_def, data)?;
-    let decl = def.next().ok_or(ParseError::new(
-        ParseErrorKind::Unknown,
-        String::from("Not a function declaration"),
-        None,
-    ))?;
+    let decl = def.next().ok_or_else(|| {
+        ParseError::new(
+            ParseErrorKind::Unknown,
+            String::from("Not a function declaration"),
+            None,
+        )
+    })?;
 
     let rule = decl.as_rule();
 

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -158,7 +158,7 @@ match_expression_arm = { (match_arm_expression | match_default) ~ "=>" ~ express
 // An if/else expression is a logical statement that returns one
 // expression or the other depending on the boolean evaluation of the
 // first expression.
-if_expr = { "if" ~ expression ~ expression ~ "else" ~ expression }
+if_expr = { "if" ~ expression ~ block_expression ~ "else" ~ block_expression }
 // serialize() and deserialize() transform command structs to/from bytes
 serialize = { "serialize(" ~ expression ~ ")" }
 deserialize = { "deserialize(" ~ expression ~ ")" }

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -158,7 +158,7 @@ match_expression_arm = { (match_arm_expression | match_default) ~ "=>" ~ express
 // An if/else expression is a logical statement that returns one
 // expression or the other depending on the boolean evaluation of the
 // first expression.
-if_expr = { "if" ~ expression ~ "{" ~ expression ~ "}" ~ "else" ~ "{" ~ expression ~ "}" }
+if_expr = { "if" ~ expression ~ expression ~ "else" ~ expression }
 // serialize() and deserialize() transform command structs to/from bytes
 serialize = { "serialize(" ~ expression ~ ")" }
 deserialize = { "deserialize(" ~ expression ~ ")" }

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -1642,8 +1642,7 @@ fn test_if_statement() -> anyhow::Result<()> {
 fn if_expression() {
     let text = r#"
         action test() {
-            // let a = if true { 1 } not allowed
-            let b = if true { 1 } else { 0 }
+            let b = if true { :1 } else { :0 }
         }
     "#;
     parse_policy_str(text, Version::V2).expect("should parse");

--- a/crates/aranya-policy-lang/src/lang/tictactoe-policy.md
+++ b/crates/aranya-policy-lang/src/lang/tictactoe-policy.md
@@ -140,8 +140,8 @@ command Move {
 }
 
 function game_over(gameID id, x int, y int, p string) bool {
-    let f10 = if x == 1 && y == 0 { :Some(p) } else { :query Field[gameID: gameID, x: 1, y: 0]=>{p: ?} }
     let f00 = if x == 0 && y == 0 { :Some(p) } else { :query Field[gameID: gameID, x: 0, y: 0]=>{p: ?} }
+    let f10 = if x == 1 && y == 0 { :Some(p) } else { :query Field[gameID: gameID, x: 1, y: 0]=>{p: ?} }
     let f20 = if x == 2 && y == 0 { :Some(p) } else { :query Field[gameID: gameID, x: 2, y: 0]=>{p: ?} }
     let f01 = if x == 0 && y == 1 { :Some(p) } else { :query Field[gameID: gameID, x: 0, y: 1]=>{p: ?} }
     let f11 = if x == 1 && y == 1 { :Some(p) } else { :query Field[gameID: gameID, x: 1, y: 1]=>{p: ?} }

--- a/crates/aranya-policy-lang/src/lang/tictactoe-policy.md
+++ b/crates/aranya-policy-lang/src/lang/tictactoe-policy.md
@@ -109,7 +109,7 @@ command Move {
         let p = unwrap query NextPlayer[gameID: gameID]=>{p: ?}
         // the if expression works like a ternary expression, where both
         // branches must be specified.
-        let nextp = if p == "X" { "O" } else { "X" }
+        let nextp = if p == "X" { :"O" } else { :"X" }
 
         // Checks are separated here, but they can be interleaved with let
         // statements.
@@ -140,15 +140,15 @@ command Move {
 }
 
 function game_over(gameID id, x int, y int, p string) bool {
-    let f00 = if x == 0 && y == 0 { Some(p) } else { query Field[gameID: gameID, x: 0, y: 0]=>{p: ?} }
-    let f10 = if x == 1 && y == 0 { Some(p) } else { query Field[gameID: gameID, x: 1, y: 0]=>{p: ?} }
-    let f20 = if x == 2 && y == 0 { Some(p) } else { query Field[gameID: gameID, x: 2, y: 0]=>{p: ?} }
-    let f01 = if x == 0 && y == 1 { Some(p) } else { query Field[gameID: gameID, x: 0, y: 1]=>{p: ?} }
-    let f11 = if x == 1 && y == 1 { Some(p) } else { query Field[gameID: gameID, x: 1, y: 1]=>{p: ?} }
-    let f21 = if x == 2 && y == 1 { Some(p) } else { query Field[gameID: gameID, x: 2, y: 1]=>{p: ?} }
-    let f02 = if x == 0 && y == 2 { Some(p) } else { query Field[gameID: gameID, x: 0, y: 2]=>{p: ?} }
-    let f12 = if x == 1 && y == 2 { Some(p) } else { query Field[gameID: gameID, x: 1, y: 2]=>{p: ?} }
-    let f22 = if x == 2 && y == 2 { Some(p) } else { query Field[gameID: gameID, x: 2, y: 2]=>{p: ?} }
+    let f10 = if x == 1 && y == 0 { :Some(p) } else { :query Field[gameID: gameID, x: 1, y: 0]=>{p: ?} }
+    let f00 = if x == 0 && y == 0 { :Some(p) } else { :query Field[gameID: gameID, x: 0, y: 0]=>{p: ?} }
+    let f20 = if x == 2 && y == 0 { :Some(p) } else { :query Field[gameID: gameID, x: 2, y: 0]=>{p: ?} }
+    let f01 = if x == 0 && y == 1 { :Some(p) } else { :query Field[gameID: gameID, x: 0, y: 1]=>{p: ?} }
+    let f11 = if x == 1 && y == 1 { :Some(p) } else { :query Field[gameID: gameID, x: 1, y: 1]=>{p: ?} }
+    let f21 = if x == 2 && y == 1 { :Some(p) } else { :query Field[gameID: gameID, x: 2, y: 1]=>{p: ?} }
+    let f02 = if x == 0 && y == 2 { :Some(p) } else { :query Field[gameID: gameID, x: 0, y: 2]=>{p: ?} }
+    let f12 = if x == 1 && y == 2 { :Some(p) } else { :query Field[gameID: gameID, x: 1, y: 2]=>{p: ?} }
+    let f22 = if x == 2 && y == 2 { :Some(p) } else { :query Field[gameID: gameID, x: 2, y: 2]=>{p: ?} }
     return (f00 is Some && f00 == f10 && f10 == f20) ||
            (f01 is Some && f01 == f11 && f11 == f21) ||
            (f01 is Some && f02 == f12 && f12 == f22) ||
@@ -170,7 +170,7 @@ command Move2 {
         let player = envelope::author_id(envelope)
         let players = unwrap query PlayerProfile[gameID: gameID]=>{x: ?, o: ?}
         let p = unwrap query NextPlayer[gameID: gameID]=>{p: ?}
-        let nextp = if p == "X" { "O" } else { "X" }
+        let nextp = if p == "X" { :"O" } else { :"X" }
 
         check !exists GameOver[gameID: gameID]=>{}
         check bounds(X)

--- a/crates/aranya-policy-vm/tests/bits/policies.rs
+++ b/crates/aranya-policy-vm/tests/bits/policies.rs
@@ -21,7 +21,7 @@ command Foo {
 }
 
 action foo(b int) {
-    let x = if b == 0 { 4 } else { 3 }
+    let x = if b == 0 { :4 } else { :3 }
     let y = Foo{
         a: x,
         b: 4


### PR DESCRIPTION
Closes #163. `if` expression arms are now block expressions, e.g.
```
let x = if y > 0 {
    let x = y + 1
    : x
} else { :0 }
```
