### PR TITLE
Enforce `wrap_comments` on policy crates

### DIFF
--- a/crates/aranya-policy-ast/rustfmt.toml
+++ b/crates/aranya-policy-ast/rustfmt.toml
@@ -1,0 +1,7 @@
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+format_generated_files = false
+wrap_comments = true
+comment_width = 100
+format_code_in_doc_comments = true

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -5,8 +5,7 @@ use core::{fmt, ops::Deref, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-/// An invalid version string was provided to
-/// [`Version::from_str`].
+/// An invalid version string was provided to [`Version::from_str`].
 #[derive(Copy, Clone, Debug, thiserror::Error)]
 #[error("invalid version string")]
 pub struct InvalidVersion;
@@ -14,8 +13,7 @@ pub struct InvalidVersion;
 /// Policy language version
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum Version {
-    /// Version 1, the initial version of the "new" policy
-    /// language.
+    /// Version 1, the initial version of the "new" policy language.
     #[deprecated]
     V1,
     /// Version 2, the second version of the policy language
@@ -23,8 +21,7 @@ pub enum Version {
     V2,
 }
 
-// This supports the command-line tools, allowing automatic
-// conversion between string arguments and the enum.
+// This is for command-line tools, allowing automatic conversion between string args and the enum.
 impl FromStr for Version {
     type Err = InvalidVersion;
 
@@ -112,8 +109,7 @@ impl fmt::Display for VType {
 
 /// An identifier and its type
 ///
-/// Field definitions are used in Command fields, fact
-/// key/value fields, and action/function arguments.
+/// Field definitions are used in Command fields, fact key/value fields, and action/function args.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct FieldDefinition {
     /// the field's name
@@ -135,8 +131,7 @@ pub struct EffectFieldDefinition {
     pub dynamic: bool,
 }
 
-/// Convert from EffectFieldDefinition to FieldDefinition, losing the
-/// dynamic information.
+/// Convert from EffectFieldDefinition to FieldDefinition, losing the dynamic information.
 impl From<&EffectFieldDefinition> for FieldDefinition {
     fn from(value: &EffectFieldDefinition) -> Self {
         FieldDefinition {
@@ -319,8 +314,8 @@ pub enum Expression {
     Block(Vec<AstNode<Statement>>, Box<Expression>),
 }
 
-/// Encapsulates both [FunctionDefinition] and [FinishFunctionDefinition] for the purpose
-/// of parsing FFI function declarations.
+/// Encapsulates both [FunctionDefinition] and [FinishFunctionDefinition] for the purpose of parsing
+/// FFI function declarations.
 #[derive(Debug, PartialEq)]
 pub struct FunctionDecl {
     /// The identifier of the function
@@ -360,8 +355,7 @@ pub enum MatchPattern {
 #[derive(Debug, Clone, PartialEq)]
 pub struct MatchArm {
     /// The values to check against. Matches any value if the option is None.
-    // TODO(chip): Restrict this to only literal values so we can do
-    // exhaustive range checks.
+    // TODO(chip): Restrict this to only literal values so we can do exhaustive range checks.
     pub pattern: MatchPattern,
     /// The statements to execute if the value matches
     pub statements: Vec<AstNode<Statement>>,
@@ -431,6 +425,7 @@ pub struct ReturnStatement {
 }
 
 /// Statements in the policy language.
+/// 
 /// Not all statements are valid in all contexts.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
@@ -542,9 +537,8 @@ pub struct FunctionDefinition {
     pub statements: Vec<AstNode<Statement>>,
 }
 
-/// A finish function definition. This is slightly different than a
-/// regular function since it cannot return values and can only
-/// execute finish block statements.
+/// A finish function definition. This is slightly different than a regular function since it cannot
+/// return values and can only execute finish block statements.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FinishFunctionDefinition {
     /// The name of the function

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -425,7 +425,7 @@ pub struct ReturnStatement {
 }
 
 /// Statements in the policy language.
-/// 
+///
 /// Not all statements are valid in all contexts.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {

--- a/crates/aranya-policy-compiler/rustfmt.toml
+++ b/crates/aranya-policy-compiler/rustfmt.toml
@@ -1,0 +1,7 @@
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+format_generated_files = false
+wrap_comments = true
+comment_width = 100
+format_code_in_doc_comments = true

--- a/crates/aranya-policy-compiler/src/bin/policy-compiler/main.rs
+++ b/crates/aranya-policy-compiler/src/bin/policy-compiler/main.rs
@@ -10,8 +10,7 @@ use clap::Parser;
 struct Args {
     /// The file containing policy code.
     file: PathBuf,
-    /// The output file. If omitted, the output file is the input, but with the extension
-    /// '.pmod'.
+    /// The output file. If omitted, the output file is the input, but with the extension '.pmod'.
     #[arg(short, long)]
     out: Option<PathBuf>,
     /// Be verbose

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -220,9 +220,9 @@ impl<'a> CompileState<'a> {
                     ))));
                 }
                 Entry::Vacant(e) => {
-                    // TODO ensure value is unique. Currently, it always will be, but if enum
-                    // variants start allowing specific values, e.g. `enum Color { Red = 100, Green
-                    // = 200 }`, then we'll need to ensure those are unique.
+                    // TODO(aleko): ensure value is unique. Right now it always is, but if we start
+                    // allowing enum variants to have specific values then we'll need to ensure
+                    // those are unique; e.g. `enum Color { Red = 100, Green = 200 }`.
                     let n = i64::try_from(i).assume("should set enum value to index")?;
                     e.insert(n);
                 }

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -671,8 +671,8 @@ impl<'a> CompileState<'a> {
                     }
                     self.append_instruction(Instruction::Deserialize);
 
-                    // TODO(chip): Use information about which command we're in to determine this
-                    // concretely
+                    // TODO(chip): Use information about which command
+                    // we're in to determine this concretely
                     Typeish::Indeterminate
                 }
             },

--- a/crates/aranya-policy-compiler/src/compile/error.rs
+++ b/crates/aranya-policy-compiler/src/compile/error.rs
@@ -68,9 +68,8 @@ pub enum CompileErrorType {
     Unknown(String),
 }
 
-// TODO(chip): this is identical to MachineErrorSource and could
-// probably be merged with it. I'm keeping it separate for now as I
-// expect the compiler will be moved out of the VM crate.
+// TODO(chip): this is identical to MachineErrorSource and could probably be merged with it. I'm
+// keeping it separate for now as I expect the compiler will be moved out of the VM crate.
 /// The source location and text of an error
 #[derive(Debug, PartialEq)]
 struct ErrorSource {
@@ -80,8 +79,7 @@ struct ErrorSource {
     text: String,
 }
 
-/// An error produced by the compiler. May contain the textual source of
-/// an error.
+/// An error produced by the compiler. May contain the textual source of an error.
 #[derive(Debug, PartialEq)]
 pub struct CompileError {
     /// The type of the error
@@ -131,9 +129,8 @@ impl fmt::Display for CompileError {
     }
 }
 
-// Implementing Display and deriving Debug implements
-// error::Error with default behavior by declaring this empty
-// implementation.
+// Implementing Display and deriving Debug implements error::Error with default behavior by
+// declaring this empty implementation.
 impl core::error::Error for CompileError {}
 
 impl From<CompileErrorType> for CompileError {

--- a/crates/aranya-policy-compiler/src/compile/target.rs
+++ b/crates/aranya-policy-compiler/src/compile/target.rs
@@ -4,8 +4,7 @@ use aranya_policy_ast as ast;
 use aranya_policy_module::{CodeMap, Instruction, Label, Module, ModuleData, ModuleV0, Value};
 use ast::FactDefinition;
 
-/// This is a stripped down version of the VM `Machine` type, which exists to be a target
-/// for compilation
+/// This is a stripped-down version of the VM `Machine` type, which exists as a compilation target
 #[derive(Debug)]
 #[cfg_attr(test, derive(Clone, Eq, PartialEq))]
 pub struct CompileTarget {

--- a/crates/aranya-policy-compiler/src/compile/types.rs
+++ b/crates/aranya-policy-compiler/src/compile/types.rs
@@ -35,8 +35,8 @@ impl From<TypeError> for CompileErrorType {
     }
 }
 
-/// Holds a stack of identifier-type mappings. Lookups traverse down the stack. The "current
-/// scope" is the one on the top of the stack.
+/// Holds a stack of identifier-type mappings. Lookups traverse down the stack. The "current scope"
+/// is the one on the top of the stack.
 #[derive(Debug, Clone)]
 pub struct IdentifierTypeStack {
     globals: HashMap<String, Typeish>,
@@ -100,8 +100,8 @@ impl IdentifierTypeStack {
         }
     }
 
-    /// Retrieve a type for an identifier. Searches lower stack items if a mapping is not
-    /// found in the current scope.
+    /// Retrieve a type for an identifier. Searches lower stack items if a mapping is not found in
+    /// the current scope.
     pub fn get(&self, name: &str) -> Result<Typeish, CompileErrorType> {
         if let Some(locals) = self.locals.last() {
             for scope in locals.iter().rev() {
@@ -121,8 +121,8 @@ impl IdentifierTypeStack {
         self.locals.push(vec![HashMap::new()]);
     }
 
-    /// Pop the current scope off of the type stack. It is a fatal error to pop an empty
-    /// stack, as this indicates a mistake in the compiler.
+    /// Pop the current scope off of the type stack. It is a fatal error to pop an empty stack, as
+    /// this indicates a mistake in the compiler.
     pub fn exit_function(&mut self) {
         self.locals.pop().expect("no function scope");
     }
@@ -145,17 +145,15 @@ impl IdentifierTypeStack {
     }
 }
 
-/// This is a calculated type, which may be indeterminate if we don't have all the
-/// information we need to calculate it.
+/// This is a calculated type, which may be indeterminate if we don't have all the information we
+/// need to calculate it.
 ///
-/// [`PartialEq`] and [`Eq`] are intentionally not derived, as naive equality doesn't make
-/// sense here. Use [`is_equal()`](Typeish::is_equal),
-/// [`is_indeterminate()`](Typeish::is_indeterminate), and
-/// [`is_maybe()`](Typeish::is_indeterminate).
+/// [`PartialEq`] and [`Eq`] are intentionally not derived, as naive equality doesn't make sense
+/// here. Use [`is_equal()`](Typeish::is_equal), [`is_indeterminate()`](Typeish::is_indeterminate),
+/// and [`is_maybe()`](Typeish::is_indeterminate).
 //
-// TODO(chip): This _should_
-// eventually go away as every expression should be well-defined by the language. But we're
-// not there yet.
+// TODO(chip): This _should_ eventually go away as every expression should be well-defined by the
+// language. But we're not there yet.
 #[must_use]
 #[derive(Debug, Clone)]
 pub enum Typeish {
@@ -194,8 +192,7 @@ impl Typeish {
         }
     }
 
-    /// Two Typeish's are maybe equal if either one is indeterminate or they are the same
-    /// definite type
+    /// Two Typeish's are maybe equal if either is indeterminate or they're the same definite type
     pub fn is_maybe_equal(&self, ot: &Typeish) -> bool {
         match (self, ot) {
             (Self::Type(x), Self::Type(y)) => x == y,
@@ -208,7 +205,7 @@ impl Typeish {
         matches!(self, Self::Indeterminate)
     }
 
-    /// Is this an instance of this type or an Indeterminate value? Indeterminate types
+    /// Checks if the type is an instance of self or an Indeterminate value. Indeterminate types
     /// always match.
     pub fn is_maybe(&self, ot: &VType) -> bool {
         match self {
@@ -262,8 +259,7 @@ impl CompileState<'_> {
         }
     }
 
-    /// Construct the type of a query based on its fact argument, or error if the fact is
-    /// not defined.
+    /// Construct the type of a query based on its fact argument or error if the fact isn't defined.
     pub(super) fn query_fact_type(&self, f: &ast::FactLiteral) -> Result<Typeish, TypeError> {
         if self.m.fact_defs.contains_key(&f.identifier) {
             Ok(Typeish::Type(VType::Struct(f.identifier.clone())))
@@ -275,9 +271,8 @@ impl CompileState<'_> {
         }
     }
 
-    /// If two types are defined, and are the same, the result is that type. If they are
-    /// different, it is a type error. If either type is indeterminate, the type is
-    /// indeterminate.
+    /// If two types are defined, and are the same, the result is that type. If they are different,
+    /// it is a type error. If either type is indeterminate, the type is indeterminate.
     pub(super) fn unify_pair(
         &self,
         left_type: Typeish,
@@ -294,8 +289,8 @@ impl CompileState<'_> {
         }
     }
 
-    /// Like [`unify_pair`], except additionally the pair is checked against `target_type`
-    /// and an error is produced if they don't match.
+    /// Like [`unify_pair`], except additionally the pair is checked against `target_type` and an
+    /// error is produced if they don't match.
     pub(super) fn unify_pair_as(
         &self,
         left_type: Typeish,

--- a/crates/aranya-policy-compiler/src/tracer.rs
+++ b/crates/aranya-policy-compiler/src/tracer.rs
@@ -12,16 +12,15 @@ pub struct TraceFailure {
     /// The sequence of instructions that produced this failure. The last instruction is not
     /// necessarily the instruction responsible for the failure.
     pub instruction_path: Vec<usize>,
-    /// This is the instruction responsible for the failure. This is usually the last
-    /// instruction in `instruction_path`, but not always.
+    /// This is the instruction responsible for the failure. This is usually the last instruction in
+    /// `instruction_path`, but not always.
     pub responsible_instruction: usize,
     /// The message associated with the failure.
     pub message: String,
 }
 
 /// Builds a [`TraceAnalyzer`] by adding a series of [`Analyzer`] implementations with
-/// [`add_analyzer`](TraceAnalyzerBuilder::add_analyzer) and calling
-/// [`build`](TraceAnalyzerBuilder::build).
+/// [`add_analyzer`](Self::add_analyzer) and calling [`build`](Self::build).
 ///
 /// ```ignore
 /// let module = ...; // a `Module`
@@ -66,8 +65,8 @@ impl<'a> TraceAnalyzerBuilder<'a> {
     }
 }
 
-/// Traces compiled code paths to prove properties with [`Analyzer`]s. See
-/// [`TraceAnalyzerBuilder`] to construct a [`TraceAnalyzer`].
+/// Traces compiled code paths to prove properties with [`Analyzer`]s. See [`TraceAnalyzerBuilder`]
+/// to construct a [`TraceAnalyzer`].
 #[derive(Clone)]
 pub struct TraceAnalyzer<'a> {
     /// The compiled code we're analyzing
@@ -78,8 +77,8 @@ pub struct TraceAnalyzer<'a> {
     instruction_path: Vec<usize>,
     /// Addresses we've encountered for branch instructions
     branches: Vec<usize>,
-    /// Same length as the tracers list, and indexed the same way. If the entry is `false`,
-    /// the tracer is not run.
+    /// Same length as the tracers list, and indexed the same way. If the entry is `false`, the
+    /// tracer is not run.
     tracer_enable: Vec<bool>,
     /// An HList of tracer implementations
     analyzers: Vec<Box<dyn Analyzer>>,
@@ -96,12 +95,12 @@ impl TraceAnalyzer<'_> {
         TraceError::new(etype, self.instruction_path.clone())
     }
 
-    /// Begin a trace at a [`Label`]. Returns a list of [`TraceFailure`]s or a
-    /// [`TraceError`] if tracing failed.
+    /// Begin a trace at a [`Label`]. Returns a list of [`TraceFailure`]s or a [`TraceError`] if
+    /// tracing failed.
     ///
-    /// A [`TraceFailure`] is a failure in the code being analyzed. A [`TraceError`] is an
-    /// error in the tracing process itself. e.g., if a `Label` was given that didn't exist,
-    /// that would be a [`TraceError`].
+    /// A [`TraceFailure`] is a failure in the code being analyzed. A [`TraceError`] is an error in
+    /// the tracing process itself. e.g., if a `Label` was given that didn't exist, that would be a
+    /// [`TraceError`].
     pub fn trace(self, start: &Label) -> Result<Vec<TraceFailure>, TraceError> {
         match self.ct.labels.get(start) {
             Some(pc) => self.trace_pc(*pc),
@@ -124,8 +123,8 @@ impl TraceAnalyzer<'_> {
         // Flatten failures into a single list
         let mut failures: Vec<TraceFailure> = failures.into_iter().flatten().collect();
 
-        // Multiple paths may give us the same failures. Sort them by responsible
-        // instruction and consider them identical if they have the same message.
+        // Multiple paths may give us the same failures. Sort them by responsible instruction and
+        // consider them identical if they have the same message.
         failures.sort_by(|a, b| a.responsible_instruction.cmp(&b.responsible_instruction));
         failures.dedup_by(|a, b| {
             a.message == b.message && a.responsible_instruction == b.responsible_instruction
@@ -136,11 +135,10 @@ impl TraceAnalyzer<'_> {
 
     fn trace_inner(&mut self, entry: usize) -> Result<TraceIntermediate, TraceError> {
         let mut pc = entry;
-        // Failures are organized by which analyzer produced them, so we can hand them back
-        // for post-analysis.
-        let mut failures = vec![vec![]; self.analyzers.len()];
-        // Keep track of all the branches from paths that didn't fail, for use by
+        // Failures are organized by which analyzer produced them, so we can hand them back for
         // post-analysis.
+        let mut failures = vec![vec![]; self.analyzers.len()];
+        // Keep track of all the branches from paths that didn't fail, for use by post-analysis.
         let mut successful_branch_paths = vec![];
 
         while pc < self.ct.progmem.len() {

--- a/crates/aranya-policy-compiler/src/tracer.rs
+++ b/crates/aranya-policy-compiler/src/tracer.rs
@@ -12,8 +12,8 @@ pub struct TraceFailure {
     /// The sequence of instructions that produced this failure. The last instruction is not
     /// necessarily the instruction responsible for the failure.
     pub instruction_path: Vec<usize>,
-    /// This is the instruction responsible for the failure. This is usually the last instruction in
-    /// `instruction_path`, but not always.
+    /// This is the instruction responsible for the failure. This is usually the last instruction
+    /// in `instruction_path`, but not always.
     pub responsible_instruction: usize,
     /// The message associated with the failure.
     pub message: String,

--- a/crates/aranya-policy-compiler/src/tracer/analyzers.rs
+++ b/crates/aranya-policy-compiler/src/tracer/analyzers.rs
@@ -9,8 +9,7 @@ pub use value_analyzer::*;
 
 use super::{TraceError, TraceFailure};
 
-// Workaround for not being able to clone `Box<dyn T>`. See
-// https://stackoverflow.com/questions/30353462/how-to-clone-a-struct-storing-a-boxed-trait-object/30353928#30353928
+// Workaround for not being able to clone `Box<dyn T>`. See https://stackoverflow.com/a/30353928
 pub trait AnalyzerClone {
     fn clone_box(&self) -> Box<dyn Analyzer>;
 }
@@ -34,9 +33,8 @@ pub trait Analyzer: AnalyzerClone {
     /// Optionally initialize the analyzer using some information from the compile target.
     fn init(&mut self, _ct: &ModuleV0) {}
 
-    /// Analyzes the current instruction. This may modify its own internal state, modify the
-    /// `reqs` reference, and optionally return a string describing a failure at the current
-    /// PC.
+    /// Analyzes the current instruction. This may modify its own internal state, modify the `reqs`
+    /// reference, and optionally return a string describing a failure at the current PC.
     fn analyze_instruction(
         &mut self,
         pc: usize,

--- a/crates/aranya-policy-compiler/src/tracer/analyzers/finish_analyzer.rs
+++ b/crates/aranya-policy-compiler/src/tracer/analyzers/finish_analyzer.rs
@@ -36,10 +36,10 @@ impl Analyzer for FinishAnalyzer {
         Ok(AnalyzerStatus::Ok)
     }
 
-    /// This attempts to find the branch point where we veered onto the failure path. It
-    /// compares each failure's execution trace with the list of successful branches to find
-    /// the last common address. This last common ancestor should be the point at which the
-    /// decision was made to go down a path that did not have a finish block.
+    /// This attempts to find the branch point where we veered onto the failure path. It compares
+    /// each failure's execution trace with the list of successful branches to find the last common
+    /// address. This last common ancestor should be the point at which the decision was made to go
+    /// down a path that did not have a finish block.
     fn post_analyze(&mut self, failures: &mut [TraceFailure], successful_branches: &[Vec<usize>]) {
         for f in failures {
             let mut longest_common_path = 0;
@@ -62,8 +62,8 @@ impl Analyzer for FinishAnalyzer {
             if let Some(la) = last_addr {
                 f.responsible_instruction = la;
             }
-            // If we didn't find a longest common path, something weird must be going on,
-            // and we leave the TraceFailure as-is.
+            // If we didn't find a longest common path, something weird must be going on, and we
+            // leave the TraceFailure as-is.
         }
     }
 }

--- a/crates/aranya-policy-compiler/src/tracer/analyzers/function_analyzer.rs
+++ b/crates/aranya-policy-compiler/src/tracer/analyzers/function_analyzer.rs
@@ -26,7 +26,8 @@ impl Analyzer for FunctionAnalyzer {
             Instruction::Return => self.have_return = true,
             Instruction::Exit(_) => {
                 if !self.have_return {
-                    // Branches without returns are potential errors; it depends on whether there is a return following the branch.
+                    // Branches without returns are potential errors; it depends on whether there is
+                    // a return following the branch.
                     return Ok(AnalyzerStatus::Failed("no return".to_string()));
                 }
             }

--- a/crates/aranya-policy-compiler/src/tracer/analyzers/value_analyzer.rs
+++ b/crates/aranya-policy-compiler/src/tracer/analyzers/value_analyzer.rs
@@ -13,8 +13,8 @@ pub struct ValueAnalyzer {
 }
 
 impl ValueAnalyzer {
-    /// `predefined` is a list of words that are understood to have been defined before
-    /// execution starts. Usually used to add things like `this` or global values.
+    /// `predefined` is a list of words that are understood to have been defined before execution
+    /// starts. Usually used to add things like `this` or global values.
     pub fn new(
         globals: impl IntoIterator<Item = String>,
         predefined: impl IntoIterator<Item = String>,

--- a/crates/aranya-policy-compiler/src/tracer/error.rs
+++ b/crates/aranya-policy-compiler/src/tracer/error.rs
@@ -4,7 +4,7 @@ use aranya_policy_module::Label;
 
 pub enum TraceErrorType {
     BadLabel(Label),
-    Bug, // TODO(chip) use actual Bug
+    Bug, // TODO(chip): use actual Bug
 }
 
 impl fmt::Display for TraceErrorType {

--- a/crates/aranya-policy-derive/rustfmt.toml
+++ b/crates/aranya-policy-derive/rustfmt.toml
@@ -1,0 +1,7 @@
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+format_generated_files = false
+wrap_comments = true
+comment_width = 100
+format_code_in_doc_comments = true

--- a/crates/aranya-policy-derive/src/ffi.rs
+++ b/crates/aranya-policy-derive/src/ffi.rs
@@ -16,8 +16,7 @@ use syn::{
 
 use crate::attr::{get_lit_str, Attr, Symbol};
 
-// TODO(eric): allow `#[ffi_export("foo")]` as an alternative to
-// `#[ffi_export(name = "foo")]`?
+// TODO(eric): allow `#[ffi_export("foo")]` as an alternative to `#[ffi_export(name = "foo")]`?
 
 pub(crate) fn parse(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> {
     let FfiAttr { module, structs } = syn::parse2(attr)?;
@@ -66,8 +65,7 @@ pub(crate) fn parse(attr: TokenStream, item: TokenStream) -> syn::Result<TokenSt
         }
     });
 
-    // `struct Foo { ... }` definitions as parsed from
-    // `#[ffi(def = "...")]`.
+    // `struct Foo { ... }` definitions as parsed from `#[ffi(def = "...")]`.
     let structs = structs.iter().map(|d| {
         let name = format_ident!("{}", d.identifier);
         let name_str = d.identifier.to_string();
@@ -168,8 +166,7 @@ pub(crate) fn parse(attr: TokenStream, item: TokenStream) -> syn::Result<TokenSt
             }
         });
 
-        // The `Func` variant identifiers mapped from
-        // `usize`:
+        // The `Func` variant identifiers mapped from `usize`:
         //    Func_some_func => Some(Func_some_func),
         //    Func_another_func => Some(Func_another_func),
         //    ...
@@ -218,8 +215,7 @@ pub(crate) fn parse(attr: TokenStream, item: TokenStream) -> syn::Result<TokenSt
                         let #name = #vm::Stack::pop::<#rtype>(__stack)?
                     }
                 })
-                // Arguments are pushed to the stack in argument
-                // order, so pop them in reverse order.
+                // Arguments are pushed to the stack in argument order, so pop them in reverse order
                 .rev();
 
             let name = &f.name;
@@ -303,10 +299,8 @@ pub(crate) fn parse(attr: TokenStream, item: TokenStream) -> syn::Result<TokenSt
                             }
                         }
                     };
-                    // TODO(eric): instead of making this
-                    // gigantic function, create a smaller
-                    // function for each case and let the
-                    // compiler decide whether they should be
+                    // TODO(eric): instead of making this gigantic function, create a smaller
+                    // function for each case and let the compiler decide whether they should be
                     // inlined.
                     match __f {
                         #(#cases),*
@@ -339,9 +333,8 @@ pub(crate) fn parse(attr: TokenStream, item: TokenStream) -> syn::Result<TokenSt
             #[allow(clippy::clippy::wildcard_imports)]
             use #module::*;
 
-            // TODO(eric): somehow move this out of the const
-            // wrapper. The trick is rewriting function
-            // arguments/results that use generated structs.
+            // TODO(eric): somehow move this out of the const wrapper. The trick is rewriting
+            // function arguments/results that use generated structs.
             #item
 
             // TODO(eric): make `alloc` optional.
@@ -511,13 +504,11 @@ impl Func {
             .iter()
             .any(|arg| matches!(arg, FnArg::Receiver(_)));
 
-        // The second and third arguments are `&CommandContext`
-        // and `&mut E`, which are passed in by `call`, so skip
-        // them.
+        // The second and third arguments are `&CommandContext` and `&mut E`, which are passed in by
+        // `call`, so skip them.
         //
-        // TODO(eric): we should issue a diagnostic when the
-        // first non-self argument isn't `&CommandContext` and
-        // second argument isn't `&mut E`.
+        // TODO(eric): we should issue a diagnostic when the first non-self argument isn't
+        // `&CommandContext` and second argument isn't `&mut E`.
         let num_skip = if is_method { 3 } else { 2 };
         let num_args = match item.sig.inputs.len().checked_sub(num_skip) {
             Some(n) => n,
@@ -639,8 +630,7 @@ impl ToTokens for VTypeTokens<'_> {
     }
 }
 
-/// An implementation of [`ToTokens`] that maps [`VType`] to its
-/// corresponding Rust types.
+/// An implementation of [`ToTokens`] that maps [`VType`] to its corresponding Rust types.
 struct TypeTokens<'a> {
     vtype: &'a VType,
     alloc: &'a Path,

--- a/crates/aranya-policy-derive/src/lib.rs
+++ b/crates/aranya-policy-derive/src/lib.rs
@@ -1,7 +1,6 @@
 //! A set of proc macros for policy lang compiler stuff.
 //!
-//! Do not use this crate directly. Use the `policy-vm` crate
-//! instead.
+//! Do not use this crate directly. Use the `policy-vm` crate instead.
 
 #![allow(unstable_name_collisions)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/crates/aranya-policy-ifgen-build/rustfmt.toml
+++ b/crates/aranya-policy-ifgen-build/rustfmt.toml
@@ -1,0 +1,7 @@
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+format_generated_files = false
+wrap_comments = true
+comment_width = 100
+format_code_in_doc_comments = true

--- a/crates/aranya-policy-ifgen-macro/rustfmt.toml
+++ b/crates/aranya-policy-ifgen-macro/rustfmt.toml
@@ -1,0 +1,7 @@
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+format_generated_files = false
+wrap_comments = true
+comment_width = 100
+format_code_in_doc_comments = true

--- a/crates/aranya-policy-ifgen-macro/src/value.rs
+++ b/crates/aranya-policy-ifgen-macro/src/value.rs
@@ -139,7 +139,8 @@ fn handle_enum(enumeration: ItemEnum) -> syn::Result<TokenStream> {
 
         impl ::core::convert::From<#ident> for ::aranya_policy_ifgen::Value {
             fn from(e: #ident) -> Self {
-                // TODO if variant discriminants can be set to arbitrary values, we'll need to
+                // TODO(aleko): if variant discriminants can be arbitrary values, we'll need to set
+                // those as well.
                 ::aranya_policy_ifgen::Value::Enum(#enum_ident.into(), e as i64)
             }
         }

--- a/crates/aranya-policy-ifgen/rustfmt.toml
+++ b/crates/aranya-policy-ifgen/rustfmt.toml
@@ -1,0 +1,7 @@
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+format_generated_files = false
+wrap_comments = true
+comment_width = 100
+format_code_in_doc_comments = true

--- a/crates/aranya-policy-lang/rustfmt.toml
+++ b/crates/aranya-policy-lang/rustfmt.toml
@@ -1,0 +1,7 @@
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+format_generated_files = false
+wrap_comments = true
+comment_width = 100
+format_code_in_doc_comments = true

--- a/crates/aranya-policy-lang/src/bin/parser-explorer/main.rs
+++ b/crates/aranya-policy-lang/src/bin/parser-explorer/main.rs
@@ -15,8 +15,7 @@ use pest::Parser as PestParser;
 #[command(name = "parser explorer", version)]
 #[command(about = "Converts text into AST trees for exploration and debugging")]
 struct Args {
-    /// The policy version. If this is set the policy is treated as raw.
-    /// Valid values are v1.
+    /// The policy version. If this is set the policy is treated as raw. Valid values are v1.
     #[arg(short, long)]
     raw_policy_version: Option<Version>,
     /// What to parse

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -27,12 +27,11 @@ mod internal {
     pub struct PolicyParser;
 }
 
-// Each of the rules in policy.pest becomes an enumerable value here
+// Each of the rules in policy.pest becomes an enumerable value here.
 // The core parser for policy documents
 pub use internal::{PolicyParser, Rule};
 
-/// Captures the iterator over a Pair's contents, and the span
-/// information for error reporting.
+/// Captures the iterator over a Pair's contents, and the span information for error reporting.
 struct PairContext<'a> {
     pairs: RefCell<Pairs<'a, Rule>>,
     span: Span<'a>,
@@ -47,8 +46,7 @@ impl<'a> PairContext<'a> {
         )
     }
 
-    /// Returns the next token from the interior Pairs in case you want
-    /// to manipulate it directly.
+    /// Returns the next token from the interior Pairs in case you want to manipulate it directly.
     fn next(&self) -> Option<Pair<'_, Rule>> {
         self.pairs.borrow_mut().next()
     }
@@ -64,8 +62,8 @@ impl<'a> PairContext<'a> {
         self.next().ok_or(errmsg)
     }
 
-    /// Consumes the next Pair out of this context and returns it if
-    /// it matches the given type. Otherwise returns an error.
+    /// Consumes the next Pair out of this context and returns it if it matches the given type.
+    /// Otherwise returns an error.
     fn consume_of_type(&self, rule: Rule) -> Result<Pair<'_, Rule>, ParseError> {
         let token = self.consume()?;
         if token.as_rule() != rule {
@@ -78,16 +76,15 @@ impl<'a> PairContext<'a> {
         Ok(token)
     }
 
-    /// Consumes the next Pair and returns it as a VType. Same error
-    /// conditions as [consume]
+    /// Consumes the next Pair and returns it as a VType. Same error conditions as [consume]
     fn consume_type(&self) -> Result<ast::VType, ParseError> {
         let token = self.consume()?;
         let vtype = ChunkParser::parse_type(token)?;
         Ok(vtype)
     }
 
-    /// Consumes the next Pair out of this context and returns it as a
-    /// string. Same error conditions as [consume].
+    /// Consumes the next Pair out of this context and returns it as a string. Same error conditions
+    /// as [consume].
     fn consume_string(&self, rule: Rule) -> Result<String, ParseError> {
         let token = self.consume_of_type(rule)?;
         Ok(token.as_str().to_owned())
@@ -98,21 +95,19 @@ impl<'a> PairContext<'a> {
         p.parse_fact_literal(token)
     }
 
-    /// Consumes the next Pair out of this context and returns it as an
-    /// [ast::Expression].
+    /// Consumes the next Pair out of this context and returns it as an [ast::Expression].
     fn consume_expression(&self, p: &mut ChunkParser<'_>) -> Result<Expression, ParseError> {
         let token = self.consume_of_type(Rule::expression)?;
         p.parse_expression(token)
     }
 
-    /// Consumes the ParserContext and returns the inner Pairs.
-    /// Destroys the span context.
+    /// Consumes the ParserContext and returns the inner Pairs. Destroys the span context.
     fn into_inner(self) -> Pairs<'a, Rule> {
         self.pairs.into_inner()
     }
 
-    /// Consumes the next Pair out of this context and returns it as a
-    /// string that is the identifier if it doesn't collide with a keyword.
+    /// Consumes the next Pair out of this context and returns it as a string that is the identifier
+    /// if it doesn't collide with a keyword.
     fn consume_identifier(&self) -> Result<String, ParseError> {
         let token = self.consume_of_type(Rule::identifier)?;
         let identifier = token.as_str().to_owned();
@@ -129,9 +124,8 @@ impl<'a> PairContext<'a> {
     }
 }
 
-/// Helper function which consumes and returns an iterator over the
-/// children of a token. Makes the parsing process a little more
-/// self-documenting.
+/// Helper function which consumes and returns an iterator over the children of a token. Makes the
+/// parsing process a little more self-documenting.
 fn descend(p: Pair<'_, Rule>) -> PairContext<'_> {
     let span = p.as_span();
     PairContext {
@@ -171,8 +165,7 @@ impl<'a> ChunkParser<'a> {
         Ok(start)
     }
 
-    /// Parse a type token (one of the types under Rule::vtype) into a
-    /// VType.
+    /// Parse a type token (one of the types under Rule::vtype) into a VType.
     fn parse_type(token: Pair<'_, Rule>) -> Result<ast::VType, ParseError> {
         match token.as_rule() {
             Rule::string_t => Ok(ast::VType::String),
@@ -348,13 +341,12 @@ impl<'a> ChunkParser<'a> {
 
     /// Parses a Rule::expression into an Expression
     ///
-    /// This uses the PrattParser to parse the syntax tree. As a part of
-    /// that process, it will further parse some atoms like function calls
-    /// and queries.
+    /// This uses the PrattParser to parse the syntax tree. As a part of that process, it will
+    /// further parse some atoms like function calls and queries.
     ///
-    /// The resulting expression tree is degree 2 - all operations are
-    /// either unary or binary. That means a string of operators with
-    /// equivalent precedence will create a lopsided tree. For example:
+    /// The resulting expression tree is degree 2 - all operations are either unary or binary. That
+    /// means a string of operators with equivalent precedence will create a lopsided tree. For
+    /// example:
     ///
     /// `A + B + C` => `Add(Add(A, B), C)`
     pub fn parse_expression(&mut self, expr: Pair<'_, Rule>) -> Result<Expression, ParseError> {
@@ -640,11 +632,10 @@ impl<'a> ChunkParser<'a> {
         ))
     }
 
-    /// Parses a list of Rule::struct_literal_field items into (String,
-    /// Expression) pairs.
+    /// Parses a list of Rule::struct_literal_field items into (String, Expression) pairs.
     ///
-    /// This is used any place where something looks like a struct literal -
-    /// fact key/values, publish, and effects.
+    /// This is used any place where something looks like a struct literal - fact key/values,
+    /// publish, and effects.
     fn parse_kv_literal_fields(
         &mut self,
         fields: Pairs<'_, Rule>,
@@ -1262,7 +1253,8 @@ impl<'a> ChunkParser<'a> {
         ))
     }
 
-    /// Parse a `Rule::finish_function_definition` into an [FinishFunctionDefinition](ast::FinishFunctionDefinition).
+    /// Parse a `Rule::finish_function_definition` into an
+    /// [FinishFunctionDefinition](ast::FinishFunctionDefinition).
     fn parse_finish_function_definition(
         &mut self,
         item: Pair<'_, Rule>,
@@ -1308,10 +1300,8 @@ impl<'a> ChunkParser<'a> {
 
 /// Parse a policy document string into an [Policy](ast::Policy) object.
 ///
-/// The version parameter asserts that the code conforms to that
-/// version, as the bare code does not have any way to specify its
-/// own version. This does not account for any offset for enclosing
-/// text.
+/// The version parameter asserts that the code conforms to that version, as the bare code does not
+/// have any way to specify its own version. This doesn't account for any offset for enclosing text.
 pub fn parse_policy_str(data: &str, version: Version) -> Result<ast::Policy, ParseError> {
     let mut policy = ast::Policy::new(version, data);
 
@@ -1320,8 +1310,8 @@ pub fn parse_policy_str(data: &str, version: Version) -> Result<ast::Policy, Par
     Ok(policy)
 }
 
-/// Adjusts the positioning of a Pest [Error](pest::error::Error) to account for any offset
-/// in the source text.
+/// Adjusts the positioning of a Pest [Error](pest::error::Error) to account for any offset in the
+/// source text.
 fn mangle_pest_error(offset: usize, text: &str, mut e: pest::error::Error<Rule>) -> ParseError {
     let pos = match &mut e.location {
         InputLocation::Pos(p) => {
@@ -1357,8 +1347,8 @@ fn mangle_pest_error(offset: usize, text: &str, mut e: pest::error::Error<Rule>)
 
     match &mut e.line_col {
         LineColLocation::Pos(p) => *p = line_col,
-        // FIXME(chip): I'm not sure if any possible pest error uses the Span case here, so
-        // I am not adjusting the endpoint.
+        // FIXME(chip): I'm not sure if any possible pest error uses the Span case here, so I'm not
+        // adjusting the endpoint.
         LineColLocation::Span(p, _) => *p = line_col,
     }
 

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -344,9 +344,9 @@ impl<'a> ChunkParser<'a> {
     /// This uses the PrattParser to parse the syntax tree. As a part of that process, it will
     /// further parse some atoms like function calls and queries.
     ///
-    /// The resulting expression tree is degree 2 - all operations are either unary or binary. That
-    /// means a string of operators with equivalent precedence will create a lopsided tree. For
-    /// example:
+    /// The resulting expression tree is second degree - all operations are either unary or binary.
+    /// This then means a string of operators with equivalent precedence will create a lopsided
+    /// tree. For example:
     ///
     /// `A + B + C` => `Add(Add(A, B), C)`
     pub fn parse_expression(&mut self, expr: Pair<'_, Rule>) -> Result<Expression, ParseError> {

--- a/crates/aranya-policy-lang/src/lang/parse/error.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/error.rs
@@ -11,8 +11,7 @@ use crate::lang::parse::Rule;
 
 /// The kinds of errors a parse operation can produce
 ///
-/// If the case contains a String, it is a message describing the item
-/// affected or a general error message.
+/// If the case contains a String, it's a message describing the affected item or a generic error.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParseErrorKind {
     /// An invalid type specifier was found. The string describes the type.

--- a/crates/aranya-policy-lang/src/lang/parse/markdown.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/markdown.rs
@@ -42,8 +42,7 @@ pub struct PolicyChunk {
 fn extract_policy_from_markdown(node: &Node) -> Result<(Vec<PolicyChunk>, Version), ParseError> {
     if let Node::Root(r) = node {
         let mut child_iter = r.children.iter();
-        // The front matter should always be the first node below the
-        // root.
+        // The front matter should always be the first node below the root.
         let version = if let Some(Node::Yaml(y)) = child_iter.next() {
             parse_front_matter(y)?
         } else {
@@ -56,17 +55,15 @@ fn extract_policy_from_markdown(node: &Node) -> Result<(Vec<PolicyChunk>, Versio
 
         let mut chunks = vec![];
 
-        // We are only looking for top level code blocks. If someone
-        // sneaks one into a table or something we won't see it.
+        // We are only looking for top level code blocks. If someone sneaks one into a table or
+        // something we won't see it.
         for c in child_iter {
             if let Node::Code(c) = c {
                 if let Some(lang) = &c.lang {
                     if lang == "policy" {
                         let position = c.position.as_ref().expect("no code block position");
-                        // The starting position of the code block is
-                        // the triple-backtick, so add three for the
-                        // backticks, six for the language tag, and
-                        // one newline.
+                        // The starting position of the code block is the triple-backtick, so add
+                        // three for the backticks, six for the language tag, and one newline.
                         let offset = position
                             .start
                             .offset
@@ -90,8 +87,8 @@ fn extract_policy_from_markdown(node: &Node) -> Result<(Vec<PolicyChunk>, Versio
     }
 }
 
-/// Parses a Markdown policy document into an AST. This AST will likely be further processed
-/// by the [`Compiler`](../../policy_vm/struct.Compiler.html).
+/// Parses a Markdown policy document into an AST. This AST will likely be further processed by the
+/// [`Compiler`](../../policy_vm/struct.Compiler.html).
 pub fn parse_policy_document(data: &str) -> Result<ast::Policy, ParseError> {
     let (chunks, version) = extract_policy(data)?;
     let mut policy = ast::Policy::new(version, data);
@@ -101,8 +98,7 @@ pub fn parse_policy_document(data: &str) -> Result<ast::Policy, ParseError> {
     Ok(policy)
 }
 
-/// Extract the policy chunks from a Markdown policy document. Returns the chunks plus the
-/// policy version.
+/// Extract the chunks from a Markdown policy document. Returns the chunks plus the policy version.
 pub fn extract_policy(data: &str) -> Result<(Vec<PolicyChunk>, Version), ParseError> {
     let mut parseoptions = ParseOptions::gfm();
     parseoptions.constructs.frontmatter = true;

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -134,8 +134,8 @@ fn parse_atom_fn() -> Result<(), PestError<Rule>> {
     // bad calls
     let cases = vec!["call(,)", "call(a a)", "call(-)"];
     for c in cases {
-        // We use Rule::function_call here directly as otherwise
-        // these bad calls fall back to parsing as identifiers.
+        // We use Rule::function_call here directly as otherwise these bad calls fall back to
+        // parsing as identifiers.
         let result = PolicyParser::parse(Rule::function_call, c);
         assert!(result.is_err());
     }
@@ -1045,8 +1045,7 @@ fn parse_policy_test() -> Result<(), ParseError> {
     Ok(())
 }
 
-// NB: this test depends on the external file tictactoe.policy,
-// which must be kept up-to-date with this test.
+// NB: this test depends on the external file tictactoe.policy, and must be kept up-to-date!
 #[test]
 fn parse_tictactoe() {
     let text = {

--- a/crates/aranya-policy-module/rustfmt.toml
+++ b/crates/aranya-policy-module/rustfmt.toml
@@ -1,0 +1,7 @@
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+format_generated_files = false
+wrap_comments = true
+comment_width = 100
+format_code_in_doc_comments = true

--- a/crates/aranya-policy-module/src/codemap.rs
+++ b/crates/aranya-policy-module/src/codemap.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 #[error("range error")]
 pub struct RangeError;
 
-/// This is a simplified version of Pest's `Span`. We can't use Pest's version because we
-/// need to work in `no_std` environments.
+/// This is a simplified version of Pest's `Span`. We can't use Pest's version because we need to
+/// work in `no_std` environments.
 pub struct Span<'a> {
     text: &'a str,
     start: usize,
@@ -18,9 +18,8 @@ pub struct Span<'a> {
 }
 
 impl<'a> Span<'a> {
-    /// Create a span inside a text reference. `start` and `end` are expressed in bytes. If
-    /// the `start` or `end` do not occur on a UTF-8 character boundary, this will return
-    /// `None`.
+    /// Create a span inside a text reference. `start` and `end` are expressed in bytes. If the
+    /// `start` or `end` do not occur on a UTF-8 character boundary, this will return `None`.
     pub fn new(text: &'a str, start: usize, end: usize) -> Option<Span<'a>> {
         if text.get(start..end).is_some() {
             Some(Span { text, start, end })
@@ -39,8 +38,7 @@ impl<'a> Span<'a> {
         self.end
     }
 
-    /// Return the span as a &str. Assumes the start and end positions
-    /// are character-aligned.
+    /// Return the span as a &str. Assumes the start and end positions are character-aligned.
     pub fn as_str(&self) -> &str {
         &self.text[self.start..self.end]
     }
@@ -73,17 +71,16 @@ impl<'a> Span<'a> {
     }
 }
 
-/// The code map contains the original source and can map VM instructions to text ranges
-/// inside that source.
+/// The code map contains the original source and maps VM instructions to text ranges inside it.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CodeMap {
     /// The original policy source code
     text: String,
-    /// All of the text ranges, mapped by locator. The key is the start
-    /// of the range and the value is the end of the range.
+    /// All of the text ranges, mapped by locator. The key is the start of the range and the value
+    /// is the end of the range.
     ranges: Vec<(usize, usize)>,
-    /// A mapping between ranges of instructions and source code
-    /// locators. The instuction ranges should be non-overlapping.
+    /// A mapping between ranges of instructions and source code locators. The instuction ranges
+    /// should be non-overlapping.
     instruction_mapping: Vec<(usize, usize)>,
 }
 
@@ -97,9 +94,8 @@ impl CodeMap {
         }
     }
 
-    /// Add a new text range from its beginning and ending position
-    /// A range can only be added if the start position has not already
-    /// been added.
+    /// Add a new text range from its beginning and ending position. A range can only be added if
+    /// the start position has not already been added.
     pub fn add_text_range(&mut self, start: usize, end: usize) -> Result<(), RangeError> {
         match self.ranges.binary_search_by(|(s, _)| s.cmp(&start)) {
             Err(_) => {
@@ -110,9 +106,8 @@ impl CodeMap {
         }
     }
 
-    /// Insert a new mapping between instruction position and text
-    /// locator. You can only add a mapping for an instruction
-    /// position larger than the last instruction position inserted.
+    /// Insert a new mapping between instruction position and text locator. You can only add a
+    /// mapping for an instruction position larger than the last instruction position inserted.
     pub fn map_instruction_range(
         &mut self,
         instruction: usize,
@@ -147,8 +142,7 @@ impl CodeMap {
 
     /// Retrieve the locator for the given instruction pointer
     pub fn locator_from_instruction(&self, ip: usize) -> Result<usize, RangeError> {
-        // Unwrapping the error case of binary_search_by() will get us
-        // the closest entry prior to the target.
+        // Unwrapping binary_search_by()'s error will get us the closest entry prior to the target.
         let r = self
             .instruction_mapping
             .binary_search_by(|(i, _)| i.cmp(&ip));

--- a/crates/aranya-policy-module/src/data.rs
+++ b/crates/aranya-policy-module/src/data.rs
@@ -117,8 +117,8 @@ pub enum Value {
 
 /// Trait for converting from a [`Value`], similar to [`TryFrom<Value>`].
 ///
-/// This trait allows us to add a blanket impl for `Option`, which we cannot
-/// do for `TryFrom<Value>` because of overlap and foreign type restrictions.
+/// This trait allows us to add a blanket impl for `Option`, which we cannot do for `TryFrom<Value>`
+/// because of overlap and foreign type restrictions.
 pub trait TryFromValue: Sized {
     /// Tries to convert a [`Value`] into `Self`.
     fn try_from_value(value: Value) -> Result<Self, ValueConversionError>;
@@ -145,8 +145,7 @@ pub trait TryAsMut<T: ?Sized> {
     /// The error result.
     type Error;
 
-    /// Converts this type into a mutable reference of the
-    /// (usually inferred) input type.
+    /// Converts this type into a mutable reference of the (usually inferred) input type.
     fn try_as_mut(&mut self) -> Result<&mut T, Self::Error>;
 }
 
@@ -516,8 +515,8 @@ impl Display for Value {
     }
 }
 
-/// The subset of Values that can be hashed. Only these types of values
-/// can be used in the key portion of a Fact.
+/// The subset of Values that can be hashed. Only these types of values can be used in the key
+/// portion of a Fact.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub enum HashableValue {
@@ -532,8 +531,7 @@ pub enum HashableValue {
 }
 
 impl HashableValue {
-    /// Get the ast:::Vtype. Unlike the Value version, this cannot
-    /// fail.
+    /// Get the ast:::Vtype. Unlike the Value version, this cannot fail.
     pub fn vtype(&self) -> VType {
         match self {
             HashableValue::Int(_) => VType::Int,
@@ -580,8 +578,8 @@ impl Display for HashableValue {
     }
 }
 
-/// One labeled value in a fact key. A sequence of FactKeys mapped to
-/// a sequence of FactValues comprises a Fact.
+/// One labeled value in a fact key. A sequence of FactKeys mapped to a sequence of FactValues
+/// comprises a Fact.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
 pub struct FactKey {
@@ -638,9 +636,8 @@ pub type FactKeyList = Vec<FactKey>;
 /// A list of fact values.
 pub type FactValueList = Vec<FactValue>;
 
-/// A generic key/value pair. Used for Effects and Command fields.
-/// Technically identical to a FactValue but separate to distinguish
-/// usage.
+/// A generic key/value pair. Used for Effects and Command fields. Technically identical to a
+/// FactValue but separate to distinguish usage.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KVPair(String, Value);
 

--- a/crates/aranya-policy-module/src/ffi.rs
+++ b/crates/aranya-policy-module/src/ffi.rs
@@ -45,8 +45,7 @@ impl Type<'_> {
                     if lhs[i] != rhs[i] {
                         return false;
                     }
-                    // Cannot overflow or wrap since `i` is
-                    // `usize` and `<[_]>::len()` is at most
+                    // Cannot overflow or wrap since `i` is `usize` and `<[_]>::len()` is at most
                     // `isize::MAX`.
                     #[allow(clippy::arithmetic_side_effects)]
                     {
@@ -78,11 +77,9 @@ impl From<&Type<'_>> for VType {
 /// Describes the context in which the function can be called.
 #[derive(Clone, Debug)]
 pub enum Color<'a> {
-    /// Function is valid outside of finish blocks, and returns
-    /// a value.
+    /// Function is valid outside of finish blocks, and returns a value.
     Pure(Type<'a>),
-    /// Function is valid inside finish blocks, and does not
-    /// return a value.
+    /// Function is valid inside finish blocks, and does not return a value.
     Finish,
 }
 
@@ -125,27 +122,45 @@ pub struct Struct<'a> {
 /// };
 ///
 /// let got = arg!("string", String);
-/// let want = Arg { name: "string", vtype: Type::String };
+/// let want = Arg {
+///     name: "string",
+///     vtype: Type::String,
+/// };
 /// assert_eq!(got, want);
 ///
 /// let got = arg!("bytes", Bytes);
-/// let want = Arg { name: "bytes", vtype: Type::Bytes };
+/// let want = Arg {
+///     name: "bytes",
+///     vtype: Type::Bytes,
+/// };
 /// assert_eq!(got, want);
 ///
 /// let got = arg!("int", Int);
-/// let want = Arg { name: "int", vtype: Type::Int };
+/// let want = Arg {
+///     name: "int",
+///     vtype: Type::Int,
+/// };
 /// assert_eq!(got, want);
 ///
 /// let got = arg!("bool", Bool);
-/// let want = Arg { name: "bool", vtype: Type::Bool };
+/// let want = Arg {
+///     name: "bool",
+///     vtype: Type::Bool,
+/// };
 /// assert_eq!(got, want);
 ///
 /// let got = arg!("id", Id);
-/// let want = Arg { name: "id", vtype: Type::Id };
+/// let want = Arg {
+///     name: "id",
+///     vtype: Type::Id,
+/// };
 /// assert_eq!(got, want);
 ///
 /// let got = arg!("struct", Struct("foo"));
-/// let want = Arg { name: "struct", vtype: Type::Struct("foo") };
+/// let want = Arg {
+///     name: "struct",
+///     vtype: Type::Struct("foo"),
+/// };
 /// assert_eq!(got, want);
 ///
 /// let got = arg!("optional", Optional(&Type::Struct("bar")));

--- a/crates/aranya-policy-module/src/instructions.rs
+++ b/crates/aranya-policy-module/src/instructions.rs
@@ -107,8 +107,8 @@ pub enum Instruction {
     Last,
     /// Call regular function at target
     Call(Target),
-    /// Call external function (FFI), specified by module, procedure indices. The FFI modules should
-    /// be added to the MachineIO.
+    /// Call external function (FFI), specified by module, procedure indices. The FFI modules
+    /// should be added to the MachineIO.
     ExtCall(usize, usize),
     /// Return to the last address on the control flow stack
     Return,

--- a/crates/aranya-policy-module/src/instructions.rs
+++ b/crates/aranya-policy-module/src/instructions.rs
@@ -17,7 +17,8 @@ use crate::{data::Value, Label};
 pub enum ExitReason {
     /// Execution completed without errors.
     Normal,
-    /// Execution is paused to return a result, which is at the top of the stack. Call `RunState::run()` again to resume.
+    /// Execution is paused to return a result, which is at the top of the stack. Call
+    /// `RunState::run()` again to resume.
     Yield,
     /// Execution was aborted gracefully, due an error.
     Check,
@@ -106,7 +107,8 @@ pub enum Instruction {
     Last,
     /// Call regular function at target
     Call(Target),
-    /// Call external function (FFI), specified by module, procedure indices. The FFI modules should be added to the MachineIO.
+    /// Call external function (FFI), specified by module, procedure indices. The FFI modules should
+    /// be added to the MachineIO.
     ExtCall(usize, usize),
     /// Return to the last address on the control flow stack
     Return,

--- a/crates/aranya-policy-module/src/module.rs
+++ b/crates/aranya-policy-module/src/module.rs
@@ -38,8 +38,7 @@ impl Display for Version {
 #[error("unsupported module version")]
 pub struct UnsupportedVersion(());
 
-/// The serializable state of
-/// a [`Machine`](../policy_vm/struct.Machine.html).
+/// The serializable state of a [`Machine`](../policy_vm/struct.Machine.html).
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Module {
     /// The module data

--- a/crates/aranya-policy-vm-explorer/rustfmt.toml
+++ b/crates/aranya-policy-vm-explorer/rustfmt.toml
@@ -1,0 +1,7 @@
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+format_generated_files = false
+wrap_comments = true
+comment_width = 100
+format_code_in_doc_comments = true

--- a/crates/aranya-policy-vm-explorer/src/main.rs
+++ b/crates/aranya-policy-vm-explorer/src/main.rs
@@ -30,16 +30,14 @@ enum Mode {
 #[command(group(ArgGroup::new("mode").required(true).args(["exec", "debug", "compile"])))]
 #[command(group(ArgGroup::new("call").conflicts_with("compile").args(["action", "command"])))]
 struct Args {
-    /// The policy version. If this is set the policy is treated as raw.
-    /// Valid values are v1.
+    /// The policy version. If this is set the policy is treated as raw. Valid values are v1.
     #[arg(short, long)]
     raw_policy_version: Option<Version>,
     /// Execute the action or command and show the machine state.
     #[arg(short, long)]
     exec: bool,
-    /// Step through the execution of policy instructions one-by-one,
-    /// showing the state after each step. One instruction is executed
-    /// for each newline read from stdin.
+    /// Step through the execution of policy instructions one-by-one, showing the state after each
+    /// step. One instruction is executed for each newline read from stdin.
     #[arg(short, long)]
     debug: bool,
     /// Show only the compiled instructions and exit.
@@ -47,12 +45,10 @@ struct Args {
     compile: bool,
     /// The file to read from. If omitted, the document is read from stdin.
     file: String,
-    /// Call an action. Command-line arguments are positional arguments
-    /// to the function.
+    /// Call an action. Command-line arguments are positional arguments to the function.
     #[arg(short, long)]
     action: Option<String>,
-    /// Call a command policy block. Command-line arguments are
-    /// key:value pairs that form the `self` struct.
+    /// Call a command block. Command-line args are key:value pairs that form the `self` struct.
     #[arg(short = 'm', long)]
     command: Option<String>,
     /// Any arguments to called functions.
@@ -261,10 +257,9 @@ fn main() -> anyhow::Result<()> {
         Mode::Compile
     };
 
-    // This actually provides a pretty poor example of how you'd use
-    // the VM in practice. Normally you would just call
-    // `machine.call_command_policy()` or `machine.call_action()`,
-    // which will return the commands or effects produced.
+    // This actually provides a pretty poor example of how you'd use the VM in practice. Normally
+    // you would just call `machine.call_command_policy()` or `machine.call_action()`, which will
+    // return the commands or effects produced.
     match mode {
         Mode::Exec | Mode::Debug => {
             let name;

--- a/crates/aranya-policy-vm/rustfmt.toml
+++ b/crates/aranya-policy-vm/rustfmt.toml
@@ -1,0 +1,7 @@
+unstable_features = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+format_generated_files = false
+wrap_comments = true
+comment_width = 100
+format_code_in_doc_comments = true

--- a/crates/aranya-policy-vm/src/bench.rs
+++ b/crates/aranya-policy-vm/src/bench.rs
@@ -26,7 +26,7 @@
 //! Collect measurements from multiple stopwatches
 //!
 //! ```
-//! use aranya_policy_vm::{Stopwatch, bench_aggregate, bench_measurements};
+//! use aranya_policy_vm::{bench_aggregate, bench_measurements, Stopwatch};
 //!
 //! let mut sw1 = Stopwatch::new();
 //! let mut sw2 = Stopwatch::new();
@@ -110,7 +110,8 @@ impl BenchMeasurements {
         self.0.entry(name).or_default().push(duration);
     }
 
-    /// Computes benchmarking statistics from the accumulated measurements. The returned values are sorted by mean time, in descending order.
+    /// Computes benchmarking statistics from the accumulated measurements. The returned values are
+    /// sorted by mean time, in descending order.
     pub fn stats(&self) -> Vec<BenchStat> {
         if self.0.is_empty() {
             return vec![];

--- a/crates/aranya-policy-vm/src/data.rs
+++ b/crates/aranya-policy-vm/src/data.rs
@@ -56,8 +56,8 @@ pub enum CommandContext<'a> {
 }
 
 impl<'a> CommandContext<'a> {
-    /// Try to create a new command context with a new `head_id` that uses the same name as the original
-    /// This method will fail if it's not called on an [`CommandContext::Action`]
+    /// Try to create a new command context with a new `head_id` that uses the same name as the
+    /// original. This method will fail if it's not called on an [`CommandContext::Action`]
     pub fn with_new_head(&self, new_head_id: Id) -> Result<CommandContext<'a>, Bug> {
         match &self {
             Self::Action(ref ctx) => Ok(Self::Action(ActionContext {

--- a/crates/aranya-policy-vm/src/derive.rs
+++ b/crates/aranya-policy-vm/src/derive.rs
@@ -3,28 +3,25 @@
 #![cfg(feature = "derive")]
 #![cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 
-/// When applied to an `impl` block, [`macro@ffi`] generates an
-/// implementation of  [`FfiModule`][crate::ffi::FfiModule].
+/// When applied to an `impl` block, [`macro@ffi`] generates an implementation of
+/// [`FfiModule`][crate::ffi::FfiModule].
 ///
 /// It accepts the following arguments:
 ///
-/// - `name`: the name of the FFI module (e.g., everything before
-///   the `::` in `aranya_crypto::encrypt_data`).
+/// - `name`: the name of the FFI module (e.g., everything before the `::` in
+///   `aranya_crypto::encrypt_data`).
 ///
-/// Methods and associated functions in the `impl` block with the
-/// `#[ffi_export]` attribute are included in the FFI module's
-/// function table. Methods and associated functions without the
+/// Methods and associated functions in the `impl` block with the `#[ffi_export]` attribute are
+/// included in the FFI module's function table. Methods and associated functions without the
 /// attribute are ignored.
 ///
-/// The `#[ffi_export]` attribute has the following required
-/// arguments:
+/// The `#[ffi_export]` attribute has the following required arguments:
 ///
 /// - `def`: the definition of the function in policy DSL.
 ///
 /// # Arguments and Results
 ///
-/// Each method or associated function must take the generic
-/// parameter `E: Engine` (see
+/// Each method or associated function must take the generic parameter `E: Engine` (see
 /// [`Engine`][aranya_crypto::Engine]):
 ///
 /// ```ignore
@@ -40,21 +37,18 @@
 /// fn bar<E: Engine>(self: Box<Self>, ...)
 /// ```
 ///
-/// The parameter following the receiver, if any, must be
-/// `&CommandContext<'_, E>`:
+/// The parameter following the receiver, if any, must be `&CommandContext<'_, E>`:
 ///
 /// ```ignore
 /// fn foo<E: Engine>(&self, ctx: &CommandContext<'_, E>, ...)
 /// fn bar<E: Engine>(ctx: &CommandContext<'_, E>, ...)
 /// ```
 ///
-/// Parameters (other than the receiver and
-/// [`CommandContext`][crate::CommandContext]) must implement
-/// [`TryFrom<Value, Error = MachineErrorType>`][TryFrom].
+/// Parameters (other than the receiver and [`CommandContext`][crate::CommandContext]) must
+/// implement [`TryFrom<Value, Error = MachineErrorType>`][TryFrom].
 ///
-/// The result must be either [`()`][unit] or [`Result<T, E>`]
-/// where `T` is either [`()`][unit] or [`Into<Value>`] (see
-/// [`Value`][crate::Value]) and `E` is [`Into<MachineError>`].
+/// The result must be either [`()`][unit] or [`Result<T, E>`] where `T` is either [`()`][unit] or
+/// [`Into<Value>`] (see [`Value`][crate::Value]) and `E` is [`Into<MachineError>`].
 ///
 /// # Example
 ///
@@ -65,12 +59,7 @@
 /// use core::{convert::Infallible, marker::PhantomData};
 ///
 /// use aranya_crypto::Engine;
-/// use aranya_policy_vm::{
-///     CommandContext,
-///     ffi::ffi,
-///     MachineError,
-///     MachineErrorType,
-/// };
+/// use aranya_policy_vm::{ffi::ffi, CommandContext, MachineError, MachineErrorType};
 ///
 /// #[derive(Copy, Clone, Debug)]
 /// struct Overflow;
@@ -150,8 +139,7 @@
 ///         Ok(S1 { x })
 ///     }
 ///
-///     /// Functions without the `#[ffi_export]` macro are
-///     /// ignored.
+///     /// Functions without the `#[ffi_export]` macro are ignored.
 ///     fn ignored() {}
 /// }
 /// ```

--- a/crates/aranya-policy-vm/src/derive.rs
+++ b/crates/aranya-policy-vm/src/derive.rs
@@ -47,8 +47,8 @@
 /// Parameters (other than the receiver and [`CommandContext`][crate::CommandContext]) must
 /// implement [`TryFrom<Value, Error = MachineErrorType>`][TryFrom].
 ///
-/// The result must be either [`()`][unit] or [`Result<T, E>`] where `T` is either [`()`][unit] or
-/// [`Into<Value>`] (see [`Value`][crate::Value]) and `E` is [`Into<MachineError>`].
+/// The result must be either [`()`][unit] or [`Result<T, E>`] where `T` is either [`()`][unit]
+/// or [`Into<Value>`] (see [`Value`][crate::Value]) and `E` is [`Into<MachineError>`].
 ///
 /// # Example
 ///

--- a/crates/aranya-policy-vm/src/error.rs
+++ b/crates/aranya-policy-vm/src/error.rs
@@ -26,8 +26,7 @@ pub enum MachineErrorType {
     /// Parameter is the name.
     #[error("name `{0}` not defined")]
     NotDefined(String),
-    /// Invalid type - An operation was given a value of the wrong type, e.g. addition with
-    /// strings.
+    /// Invalid type - Tried to do an operation with the wrong type, e.g. addition with strings.
     #[error("expected type {want}, but got {got}: {msg}")]
     InvalidType {
         /// Expected type name
@@ -67,8 +66,7 @@ pub enum MachineErrorType {
     /// encoded into an instruction is invalid, e.g. a Swap(0)
     #[error("invalid instruction")]
     InvalidInstruction,
-    /// An instruction has done something bad with the call stack, like `Return`ed without a
-    /// `Call`.
+    /// The program tried to do something bad with the call stack, like `Return` without a `Call`.
     #[error("call stack")]
     CallStack,
     /// IO Error - Some machine I/O operation caused an error

--- a/crates/aranya-policy-vm/src/error.rs
+++ b/crates/aranya-policy-vm/src/error.rs
@@ -22,11 +22,12 @@ pub enum MachineErrorType {
     /// Parameter is the name.
     #[error("name `{0}` already defined")]
     AlreadyDefined(String),
-    /// Name not defined - an attempt was made to access a name that has not been defined. Parameter
-    /// is the name.
+    /// Name not defined - an attempt was made to access a name that has not been defined.
+    /// Parameter is the name.
     #[error("name `{0}` not defined")]
     NotDefined(String),
-    /// Invalid type - An operation was given a value of the wrong type, e.g. addition with strings.
+    /// Invalid type - An operation was given a value of the wrong type, e.g. addition with
+    /// strings.
     #[error("expected type {want}, but got {got}: {msg}")]
     InvalidType {
         /// Expected type name
@@ -51,22 +52,23 @@ pub enum MachineErrorType {
     /// not yet been resolved.
     #[error("unresolved branch/jump target: {0}")]
     UnresolvedTarget(Label),
-    /// Invalid address - An attempt to execute an instruction went beyond instruction bounds, or an
-    /// action/command lookup did not find an address for the given name.
+    /// Invalid address - An attempt to execute an instruction went beyond instruction bounds, or
+    /// an action/command lookup did not find an address for the given name.
     #[error("invalid address: {0}")]
     InvalidAddress(String),
     /// Bad state - Some internal state is invalid and execution cannot continue.
     #[error("bad state: {0}")]
     BadState(&'static str),
-    /// IntegerOverflow occurs when an instruction wraps an integer above the max value or below the
-    /// min value.
+    /// IntegerOverflow occurs when an instruction wraps an integer above the max value or below
+    /// the min value.
     #[error("integer wrap")]
     IntegerOverflow,
     /// Invalid instruction - An instruction was used in the wrong context, or some information
     /// encoded into an instruction is invalid, e.g. a Swap(0)
     #[error("invalid instruction")]
     InvalidInstruction,
-    /// An instruction has done something bad with the call stack, like `Return`ed without a `Call`.
+    /// An instruction has done something bad with the call stack, like `Return`ed without a
+    /// `Call`.
     #[error("call stack")]
     CallStack,
     /// IO Error - Some machine I/O operation caused an error

--- a/crates/aranya-policy-vm/src/error.rs
+++ b/crates/aranya-policy-vm/src/error.rs
@@ -9,28 +9,24 @@ use buggy::Bug;
 use crate::io::MachineIOError;
 
 /// Possible machine errors.
-// TODO(chip): These should be elaborated with additional data, and/or
-// more fine grained types.
+// TODO(chip): These should be elaborated with additional data, and/or more fine grained types.
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum MachineErrorType {
-    /// Stack underflow - an operation tried to consume a value from an
-    /// empty stack.
+    /// Stack underflow - an operation tried to consume a value from an empty stack.
     #[error("stack underflow")]
     StackUnderflow,
-    /// Stack overflow - an operation tried to push a value onto a full
-    /// stack.
+    /// Stack overflow - an operation tried to push a value onto a full stack.
     #[error("stack overflow")]
     StackOverflow,
-    /// Name already defined - an attempt was made to define a name
-    /// that was already defined. Parameter is the name.
+    /// Name already defined - an attempt was made to define a name that was already defined.
+    /// Parameter is the name.
     #[error("name `{0}` already defined")]
     AlreadyDefined(String),
-    /// Name not defined - an attempt was made to access a name that
-    /// has not been defined. Parameter is the name.
+    /// Name not defined - an attempt was made to access a name that has not been defined. Parameter
+    /// is the name.
     #[error("name `{0}` not defined")]
     NotDefined(String),
-    /// Invalid type - An operation was given a value of the wrong
-    /// type. E.g. addition with strings.
+    /// Invalid type - An operation was given a value of the wrong type, e.g. addition with strings.
     #[error("expected type {want}, but got {got}: {msg}")]
     InvalidType {
         /// Expected type name
@@ -40,42 +36,37 @@ pub enum MachineErrorType {
         /// Extra information
         msg: String,
     },
-    /// Invalid struct member - An attempt to access a member not
-    /// present in a struct. Parameter is the key name.
+    /// Invalid struct member - An attempt to access a member not present in a struct. Parameter is
+    /// the key name.
     #[error("invalid struct member `{0}`")]
     InvalidStructMember(String),
-    /// Invalid fact - An attempt was made to use a fact in a way
-    /// that does not match the Fact schema.
+    /// Invalid fact - An attempt to use a fact in a way that doesn't match the Fact schema.
     #[error("invalid fact: {0}")]
     InvalidFact(String),
-    /// Invalid schema - An attempt to publish a Command struct or emit
-    /// an Effect that does not match its definition.
+    /// Invalid schema - An attempt to publish a Command struct or emit an Effect that does not
+    /// match its definition.
     #[error("invalid schema: {0}")]
     InvalidSchema(String),
-    /// Unresolved target - A branching instruction attempted to jump
-    /// to a target whose address has not yet been resolved.
+    /// Unresolved target - A branching instruction attempted to jump to a target whose address has
+    /// not yet been resolved.
     #[error("unresolved branch/jump target: {0}")]
     UnresolvedTarget(Label),
-    /// Invalid address - An attempt to execute an instruction went
-    /// beyond instruction bounds, or an action/command lookup did not
-    /// find an address for the given name.
+    /// Invalid address - An attempt to execute an instruction went beyond instruction bounds, or an
+    /// action/command lookup did not find an address for the given name.
     #[error("invalid address: {0}")]
     InvalidAddress(String),
-    /// Bad state - Some internal state is invalid and execution cannot
-    /// continue.
+    /// Bad state - Some internal state is invalid and execution cannot continue.
     #[error("bad state: {0}")]
     BadState(&'static str),
-    /// IntegerOverflow occurs when an instruction wraps an integer above
-    /// the max value or below the min value.
+    /// IntegerOverflow occurs when an instruction wraps an integer above the max value or below the
+    /// min value.
     #[error("integer wrap")]
     IntegerOverflow,
-    /// Invalid instruction - An instruction was used in the wrong
-    /// context, or some information encoded into an instruction is
-    /// invalid. E.g. a Swap(0)
+    /// Invalid instruction - An instruction was used in the wrong context, or some information
+    /// encoded into an instruction is invalid, e.g. a Swap(0)
     #[error("invalid instruction")]
     InvalidInstruction,
-    /// An instruction has done something wrong with the call stack, like
-    /// `Return`ed without a `Call`.
+    /// An instruction has done something bad with the call stack, like `Return`ed without a `Call`.
     #[error("call stack")]
     CallStack,
     /// IO Error - Some machine I/O operation caused an error

--- a/crates/aranya-policy-vm/src/ffi.rs
+++ b/crates/aranya-policy-vm/src/ffi.rs
@@ -12,13 +12,11 @@ pub trait FfiModule {
     /// The error result from [`FfiModule::call`].
     type Error: Into<MachineError>;
 
-    /// A list of function definitions. Used by the
-    /// compiler to emit the stack instructions needed for
-    /// a call.
+    /// A list of function definitions. Used by the compiler to emit the stack instructions needed
+    /// for a call.
     const SCHEMA: ModuleSchema<'static>;
 
-    /// Invokes a function in the module.
-    /// `procedure` is the index in [`functions`][Self::SCHEMA].
+    /// Invokes a function in the module. `procedure` is the index in [`functions`][Self::SCHEMA].
     fn call<E: Engine>(
         &self,
         procedure: usize,

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -73,7 +73,7 @@ fn validate_fact_schema(fact: &Fact, schema: &ast::FactDefinition) -> bool {
 }
 
 /// Compares a fact to the given keys and values.
-/// 
+///
 /// NOTE that Bind keys/values are not included in the fact literal (see compile_fact_literal), so
 /// we only compare key/value pairs with exact values.
 ///
@@ -1108,7 +1108,7 @@ where
 
     /// Call an action loaded into the VM by name. Accepts a list of arguments to the function,
     /// which must match the number of arguments expected. Returns a MachineError on failure.
-    // 
+    //
     // TODO(chip): I don't really like how V: Into<Value> works here because it still means all of
     // the args have to have the same type.
     pub fn call_action<Args>(&mut self, name: &str, args: Args) -> Result<ExitReason, MachineError>

--- a/crates/aranya-policy-vm/src/stack.rs
+++ b/crates/aranya-policy-vm/src/stack.rs
@@ -10,8 +10,7 @@ pub trait Stack {
     /// Pop a value (as a [Value]) from the stack.
     fn pop_value(&mut self) -> Result<Value, MachineErrorType>;
 
-    /// Peek a value (as a mutable reference to a [Value]) on the top
-    /// of the stack.
+    /// Peek a value (as a mutable reference to a [Value]) on the top of the stack.
     fn peek_value(&mut self) -> Result<&mut Value, MachineErrorType>;
 
     /// Push a value onto the stack.

--- a/crates/aranya-policy-vm/src/tests.rs
+++ b/crates/aranya-policy-vm/src/tests.rs
@@ -424,20 +424,17 @@ fn test_span_lookup() -> anyhow::Result<()> {
     let test_str = "I've got a lovely bunch of coconuts";
     let ranges = vec![(0, 8), (9, 23), (24, 34)];
     let mut cm = CodeMap::new(test_str, ranges);
-    // instruction ranges are inclusive of the instruction, up until
-    // the next instruction, and must be inserted in order. So the
-    // first range is 0-11, the second is 12-21, etc.
+    // instruction ranges are inclusive of the instruction, up until the next instruction, and must
+    // be inserted in order. So the first range is 0-11, the second is 12-21, etc.
     cm.map_instruction_range(0, 0)?;
     cm.map_instruction_range(12, 9)?;
     cm.map_instruction_range(22, 24)?;
 
-    // An instruction at the boundary returns the range starting
-    // at that boundary.
+    // An instruction at the boundary returns a range starting at that boundary.
     let s = cm.span_from_instruction(0)?;
     assert_eq!(s.start(), 0);
 
-    // An instruction between boundaries returns the range starting
-    // at the last instruction boundary.
+    // An instruction between boundaries returns a range starting at the last instruction boundary.
     let s = cm.span_from_instruction(3)?;
     assert_eq!(s.start(), 0);
 
@@ -450,8 +447,7 @@ fn test_span_lookup() -> anyhow::Result<()> {
     let s = cm.span_from_instruction(22)?;
     assert_eq!(s.start(), 24);
 
-    // An instruction beyond the last instruction boundary always
-    // returns the last range.
+    // An instruction beyond the last instruction boundary always returns the last range.
     let s = cm.span_from_instruction(30)?;
     assert_eq!(s.start(), 24);
 
@@ -486,9 +482,8 @@ fn error_test_harness(instructions: &[Instruction], error_type: MachineErrorType
 }
 
 #[test]
-// There are a lot of clones in here. Technically the last one isn't
-// needed, but maintenance is easier when you don't need to worry about
-// it.
+// There are a lot of clones in here. Technically the last one isn't needed, but maintenance is
+// easier when you don't need to worry about it.
 #[allow(clippy::redundant_clone)]
 fn test_errors() {
     let ctx = dummy_ctx_policy("test");
@@ -707,9 +702,9 @@ fn test_errors() {
     );
 
     // IO: Create a fact that already exists
-    // This _should_ be failing because the fact has not been declared
-    // in schema, but TestIO does not care about fact schema and the
-    // machine does not check it.
+    //
+    // This _should_ be failing because the fact has not been declared in schema, but TestIO does
+    // not care about fact schema and the machine does not check it.
     error_test_harness(
         &[
             Instruction::Const(Value::Fact(Fact {

--- a/crates/aranya-policy-vm/src/tests/ffi.rs
+++ b/crates/aranya-policy-vm/src/tests/ffi.rs
@@ -35,7 +35,8 @@ impl FfiModule for PrintFfi {
                 // pop args off the stack
                 let s: String = stack.pop()?;
 
-                // Push something (the uppercased value) back onto the stack so the caller can verify this function was called.
+                // Push something (the uppercased value) back onto the stack so the caller can
+                // verify this function was called.
                 stack
                     .push(Value::String(s.to_uppercase()))
                     .expect("can't push");

--- a/crates/aranya-policy-vm/tests/bits/printffi.rs
+++ b/crates/aranya-policy-vm/tests/bits/printffi.rs
@@ -34,7 +34,8 @@ impl FfiModule for PrintFfi {
                 // pop args off the stack
                 let s: String = stack.pop()?;
 
-                // Push something (the uppercased value) back onto the stack so the caller can verify this function was called.
+                // Push something (the uppercased value) back onto the stack so the caller can
+                // verify this function was called.
                 stack
                     .push(Value::String(s.to_uppercase()))
                     .expect("can't push");

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -470,8 +470,8 @@ fn test_fact_create_delete() -> anyhow::Result<()> {
     let mut machine = Machine::from_module(module)?;
     let io = RefCell::new(TestIO::new());
 
-    // We have to scope the RunState so that it and its mutable
-    // reference to IO is dropped before we inspect the IO struct.
+    // We have to scope the RunState so that it and its mutable reference to IO is dropped before we
+    // inspect the IO struct.
     {
         let name = "Set";
         let ctx = dummy_ctx_policy(name);
@@ -1492,9 +1492,8 @@ fn test_serialize_deserialize() -> anyhow::Result<()> {
     {
         let ctx = dummy_ctx_open(name);
         let mut rs = machine.create_run_state(&io, ctx);
-        // call_open expects an envelope struct, so we smuggle the bytes
-        // in through a field. The payload would normally be accessed
-        // through an FFI module.
+        // call_open expects an envelope struct, so we smuggle the bytes in through a field. The
+        // payload would normally be accessed through an FFI module.
         let envelope = Struct::new("Env", [KVPair::new("payload", Value::Bytes(this_bytes))]);
         rs.call_open(name, envelope)?.success();
         let result = rs.consume_return()?;


### PR DESCRIPTION
This adds a rustfmt override to all policy crates and includes all formatting changes. The goal is to open separate PRs addressing the other crates, and at the end a single commit that unifies all rustfmt.toml back into root, once we've approved all changes.