### PR TITLE
aranya-capi-codegen: Apply `#[cfg()]` Attributes To FFI Wrapper

### DIFF
--- a/crates/aranya-capi-codegen-test/Cargo.toml
+++ b/crates/aranya-capi-codegen-test/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+test_cfg = []
+
 [dependencies]
 aranya-capi-core = { version = "0.2.1", path = "../aranya-capi-core", features = ["debug"] }
 buggy = { version = "0.1.0" }

--- a/crates/aranya-capi-codegen-test/src/defs.rs
+++ b/crates/aranya-capi-codegen-test/src/defs.rs
@@ -219,12 +219,14 @@ impl From<&crate::Error> for Error {
 }
 
 #[cfg(feature = "test_cfg")]
+#[repr(transparent)]
 struct TestConfigInheritance(());
 
 #[cfg(feature = "test_cfg")]
 fn test_cfg_inheritance_fn() {}
 
 #[cfg(not(feature = "test_cfg"))]
+#[repr(transparent)]
 pub struct TestConfigInheritance2(());
 
 #[cfg(not(feature = "test_cfg"))]

--- a/crates/aranya-capi-codegen-test/src/defs.rs
+++ b/crates/aranya-capi-codegen-test/src/defs.rs
@@ -220,14 +220,14 @@ impl From<&crate::Error> for Error {
 
 #[cfg(feature = "test_cfg")]
 #[repr(transparent)]
-struct TestConfigInheritance(());
+pub struct TestConfigInheritance(u8);
 
 #[cfg(feature = "test_cfg")]
-fn test_cfg_inheritance_fn() {}
+pub fn test_cfg_inheritance() {}
 
 #[cfg(not(feature = "test_cfg"))]
 #[repr(transparent)]
-pub struct TestConfigInheritance2(());
+pub struct TestConfigInheritance2(u8);
 
 #[cfg(not(feature = "test_cfg"))]
-fn test_cfg_inheritance2() {}
+pub fn test_cfg_inheritance2() {}

--- a/crates/aranya-capi-codegen-test/src/defs.rs
+++ b/crates/aranya-capi-codegen-test/src/defs.rs
@@ -217,3 +217,15 @@ impl From<&crate::Error> for Error {
         unimplemented!()
     }
 }
+
+#[cfg(feature = "test_cfg")]
+struct TestConfigInheritance(());
+
+#[cfg(feature = "test_cfg")]
+fn test_cfg_inheritance_fn() {}
+
+#[cfg(not(feature = "test_cfg"))]
+pub struct TestConfigInheritance2(());
+
+#[cfg(not(feature = "test_cfg"))]
+fn test_cfg_inheritance2() {}

--- a/crates/aranya-capi-codegen-test/src/generated.rs
+++ b/crates/aranya-capi-codegen-test/src/generated.rs
@@ -55,6 +55,20 @@ pub enum PrefixError {
     #[capi(msg = "invalid argument")]
     InvalidArg,
 }
+#[repr(transparent)]
+#[cfg(feature = "test_cfg")]
+#[cfg(cbindgen)]
+pub struct PrefixTestConfigInheritance(::core::primitive::u8);
+#[cfg(feature = "test_cfg")]
+#[cfg(not(cbindgen))]
+pub type PrefixTestConfigInheritance = self::__hidden::PrefixTestConfigInheritance;
+#[repr(transparent)]
+#[cfg(not(feature = "test_cfg"))]
+#[cfg(cbindgen)]
+pub struct PrefixTestConfigInheritance2(::core::primitive::u8);
+#[cfg(not(feature = "test_cfg"))]
+#[cfg(not(cbindgen))]
+pub type PrefixTestConfigInheritance2 = self::__hidden::PrefixTestConfigInheritance2;
 #[no_mangle]
 #[::tracing::instrument(level = "trace")]
 pub extern "C" fn prefix_test_unit_unit0() {
@@ -2162,6 +2176,44 @@ fn ext_error_cleanup(
     }
     ::core::result::Result::Ok(())
 }
+#[no_mangle]
+#[cfg(feature = "test_cfg")]
+#[::tracing::instrument(level = "trace")]
+pub extern "C" fn prefix_test_cfg_inheritance() {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match { __tramp_prefix_test_cfg_inheritance() } {
+        __pattern => __pattern,
+    }
+}
+#[cfg(feature = "test_cfg")]
+#[allow(clippy::unused_unit)]
+fn __tramp_prefix_test_cfg_inheritance() -> () {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match { crate::defs::test_cfg_inheritance() } {
+        __pattern => __pattern,
+    }
+}
+#[no_mangle]
+#[cfg(not(feature = "test_cfg"))]
+#[::tracing::instrument(level = "trace")]
+pub extern "C" fn prefix_test_cfg_inheritance2() {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match { __tramp_prefix_test_cfg_inheritance2() } {
+        __pattern => __pattern,
+    }
+}
+#[cfg(not(feature = "test_cfg"))]
+#[allow(clippy::unused_unit)]
+fn __tramp_prefix_test_cfg_inheritance2() -> () {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match { crate::defs::test_cfg_inheritance2() } {
+        __pattern => __pattern,
+    }
+}
 #[cfg(not(cbindgen))]
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -2241,6 +2293,7 @@ mod __hidden {
             }
         }
     };
+    #[cfg(not(cbindgen))]
     pub type PrefixStruct = __PrefixStructFfiWrapper<
         crate::defs::Struct,
         ::core::primitive::u32,
@@ -2310,6 +2363,7 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     unsafe impl<_0> __capi::internal::conv::newtype::NewType
     for __PrefixStructFfiWrapper<crate::defs::Struct, _0> {
         type Inner = crate::defs::Struct;
@@ -2342,6 +2396,7 @@ mod __hidden {
     where
         _0: __capi::types::ByMutPtr,
     {}
+    #[cfg(not(cbindgen))]
     const _: () = {
         const GOT: usize = ::core::mem::size_of::<PrefixStruct>();
         const WANT: usize = ::core::mem::size_of::<crate::defs::Struct>();
@@ -2350,6 +2405,7 @@ mod __hidden {
         );
         ::core::assert!(GOT == WANT, "{}", MSG);
     };
+    #[cfg(not(cbindgen))]
     const _: () = {
         const GOT: usize = ::core::mem::align_of::<PrefixStruct>();
         const WANT: usize = ::core::mem::align_of::<crate::defs::Struct>();
@@ -2358,6 +2414,7 @@ mod __hidden {
         );
         ::core::assert!(GOT == WANT, "{}", MSG);
     };
+    #[cfg(not(cbindgen))]
     const _: () = {
         const GOT: bool = ::core::mem::needs_drop::<PrefixStruct>();
         const WANT: bool = ::core::mem::needs_drop::<crate::defs::Struct>();
@@ -2366,6 +2423,7 @@ mod __hidden {
         );
         ::core::assert!(GOT == WANT, "{}", MSG);
     };
+    #[cfg(not(cbindgen))]
     pub type PrefixSafeStruct = __PrefixSafeStructFfiWrapper<crate::defs::SafeStruct>;
     #[repr(transparent)]
     #[derive(Debug)]
@@ -2430,6 +2488,7 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     unsafe impl __capi::internal::conv::newtype::NewType
     for __PrefixSafeStructFfiWrapper<crate::defs::SafeStruct> {
         type Inner = crate::defs::SafeStruct;
@@ -2451,6 +2510,7 @@ mod __hidden {
     for __PrefixSafeStructFfiWrapper<Inner> {}
     #[automatically_derived]
     unsafe impl<Inner> __capi::types::ByMutPtr for __PrefixSafeStructFfiWrapper<Inner> {}
+    #[cfg(not(cbindgen))]
     const _: () = {
         const GOT: usize = ::core::mem::size_of::<PrefixSafeStruct>();
         const WANT: usize = ::core::mem::size_of::<crate::defs::SafeStruct>();
@@ -2459,6 +2519,7 @@ mod __hidden {
         );
         ::core::assert!(GOT == WANT, "{}", MSG);
     };
+    #[cfg(not(cbindgen))]
     const _: () = {
         const GOT: usize = ::core::mem::align_of::<PrefixSafeStruct>();
         const WANT: usize = ::core::mem::align_of::<crate::defs::SafeStruct>();
@@ -2467,6 +2528,7 @@ mod __hidden {
         );
         ::core::assert!(GOT == WANT, "{}", MSG);
     };
+    #[cfg(not(cbindgen))]
     const _: () = {
         const GOT: bool = ::core::mem::needs_drop::<PrefixSafeStruct>();
         const WANT: bool = ::core::mem::needs_drop::<crate::defs::SafeStruct>();
@@ -2637,5 +2699,265 @@ mod __hidden {
                 Self::from_underlying(other)
             }
         }
+    };
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
+    pub type PrefixTestConfigInheritance = __PrefixTestConfigInheritanceFfiWrapper<
+        crate::defs::TestConfigInheritance,
+    >;
+    #[repr(transparent)]
+    #[derive(Debug)]
+    pub struct __PrefixTestConfigInheritanceFfiWrapper<Inner> {
+        pub inner: Inner,
+    }
+    #[automatically_derived]
+    impl<Inner> __capi::InitDefault for __PrefixTestConfigInheritanceFfiWrapper<Inner>
+    where
+        Inner: __capi::InitDefault,
+    {
+        fn init_default(out: &mut ::core::mem::MaybeUninit<Self>) {
+            <Inner as __capi::InitDefault>::init_default(unsafe {
+                ::core::mem::transmute::<
+                    &mut ::core::mem::MaybeUninit<Self>,
+                    &mut ::core::mem::MaybeUninit<Inner>,
+                >(out)
+            })
+        }
+    }
+    #[automatically_derived]
+    impl<Inner> ::core::marker::Copy for __PrefixTestConfigInheritanceFfiWrapper<Inner>
+    where
+        Inner: ::core::marker::Copy,
+    {}
+    #[automatically_derived]
+    impl<Inner> ::core::clone::Clone for __PrefixTestConfigInheritanceFfiWrapper<Inner>
+    where
+        Inner: ::core::clone::Clone,
+    {
+        fn clone(&self) -> Self {
+            Self {
+                inner: ::core::clone::Clone::clone(&self.inner),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl<Inner> ::core::ops::Deref for __PrefixTestConfigInheritanceFfiWrapper<Inner> {
+        type Target = Inner;
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+    #[automatically_derived]
+    impl<Inner> ::core::ops::DerefMut
+    for __PrefixTestConfigInheritanceFfiWrapper<Inner> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.inner
+        }
+    }
+    #[automatically_derived]
+    impl<Inner> __capi::Builder for __PrefixTestConfigInheritanceFfiWrapper<Inner>
+    where
+        Inner: __capi::Builder,
+    {
+        type Output = <Inner as __capi::Builder>::Output;
+        type Error = <Inner as __capi::Builder>::Error;
+        unsafe fn build(
+            self,
+            out: &mut ::core::mem::MaybeUninit<Self::Output>,
+        ) -> ::core::result::Result<(), Self::Error> {
+            unsafe { __capi::Builder::build(self.inner, out) }
+        }
+    }
+    #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
+    unsafe impl __capi::internal::conv::newtype::NewType
+    for __PrefixTestConfigInheritanceFfiWrapper<crate::defs::TestConfigInheritance> {
+        type Inner = crate::defs::TestConfigInheritance;
+    }
+    #[automatically_derived]
+    impl<Inner> __capi::types::Opaque for __PrefixTestConfigInheritanceFfiWrapper<Inner>
+    where
+        Inner: __capi::types::Opaque,
+    {}
+    #[automatically_derived]
+    unsafe impl<Inner> __capi::types::Input
+    for __PrefixTestConfigInheritanceFfiWrapper<Inner> {}
+    #[automatically_derived]
+    unsafe impl<Inner> __capi::types::ByValue
+    for __PrefixTestConfigInheritanceFfiWrapper<Inner>
+    where
+        Inner: ::core::marker::Copy,
+    {}
+    #[automatically_derived]
+    unsafe impl<Inner> __capi::types::ByConstPtr
+    for __PrefixTestConfigInheritanceFfiWrapper<Inner> {}
+    #[automatically_derived]
+    unsafe impl<Inner> __capi::types::ByMutPtr
+    for __PrefixTestConfigInheritanceFfiWrapper<Inner> {}
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
+    const _: () = {
+        const GOT: usize = ::core::mem::size_of::<PrefixTestConfigInheritance>();
+        const WANT: usize = ::core::mem::size_of::<crate::defs::TestConfigInheritance>();
+        const MSG: &str = __capi::internal::const_format::formatcp!(
+            "BUG: invalid size: {GOT} != {WANT}"
+        );
+        ::core::assert!(GOT == WANT, "{}", MSG);
+    };
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
+    const _: () = {
+        const GOT: usize = ::core::mem::align_of::<PrefixTestConfigInheritance>();
+        const WANT: usize = ::core::mem::align_of::<
+            crate::defs::TestConfigInheritance,
+        >();
+        const MSG: &str = __capi::internal::const_format::formatcp!(
+            "BUG: invalid alignment: {GOT} != {WANT}"
+        );
+        ::core::assert!(GOT == WANT, "{}", MSG);
+    };
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
+    const _: () = {
+        const GOT: bool = ::core::mem::needs_drop::<PrefixTestConfigInheritance>();
+        const WANT: bool = ::core::mem::needs_drop::<
+            crate::defs::TestConfigInheritance,
+        >();
+        const MSG: &str = __capi::internal::const_format::formatcp!(
+            "BUG: invalid `Drop` impl: {GOT} != {WANT}"
+        );
+        ::core::assert!(GOT == WANT, "{}", MSG);
+    };
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
+    pub type PrefixTestConfigInheritance2 = __PrefixTestConfigInheritance2FfiWrapper<
+        crate::defs::TestConfigInheritance2,
+    >;
+    #[repr(transparent)]
+    #[derive(Debug)]
+    pub struct __PrefixTestConfigInheritance2FfiWrapper<Inner> {
+        pub inner: Inner,
+    }
+    #[automatically_derived]
+    impl<Inner> __capi::InitDefault for __PrefixTestConfigInheritance2FfiWrapper<Inner>
+    where
+        Inner: __capi::InitDefault,
+    {
+        fn init_default(out: &mut ::core::mem::MaybeUninit<Self>) {
+            <Inner as __capi::InitDefault>::init_default(unsafe {
+                ::core::mem::transmute::<
+                    &mut ::core::mem::MaybeUninit<Self>,
+                    &mut ::core::mem::MaybeUninit<Inner>,
+                >(out)
+            })
+        }
+    }
+    #[automatically_derived]
+    impl<Inner> ::core::marker::Copy for __PrefixTestConfigInheritance2FfiWrapper<Inner>
+    where
+        Inner: ::core::marker::Copy,
+    {}
+    #[automatically_derived]
+    impl<Inner> ::core::clone::Clone for __PrefixTestConfigInheritance2FfiWrapper<Inner>
+    where
+        Inner: ::core::clone::Clone,
+    {
+        fn clone(&self) -> Self {
+            Self {
+                inner: ::core::clone::Clone::clone(&self.inner),
+            }
+        }
+    }
+    #[automatically_derived]
+    impl<Inner> ::core::ops::Deref for __PrefixTestConfigInheritance2FfiWrapper<Inner> {
+        type Target = Inner;
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+    #[automatically_derived]
+    impl<Inner> ::core::ops::DerefMut
+    for __PrefixTestConfigInheritance2FfiWrapper<Inner> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.inner
+        }
+    }
+    #[automatically_derived]
+    impl<Inner> __capi::Builder for __PrefixTestConfigInheritance2FfiWrapper<Inner>
+    where
+        Inner: __capi::Builder,
+    {
+        type Output = <Inner as __capi::Builder>::Output;
+        type Error = <Inner as __capi::Builder>::Error;
+        unsafe fn build(
+            self,
+            out: &mut ::core::mem::MaybeUninit<Self::Output>,
+        ) -> ::core::result::Result<(), Self::Error> {
+            unsafe { __capi::Builder::build(self.inner, out) }
+        }
+    }
+    #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
+    unsafe impl __capi::internal::conv::newtype::NewType
+    for __PrefixTestConfigInheritance2FfiWrapper<crate::defs::TestConfigInheritance2> {
+        type Inner = crate::defs::TestConfigInheritance2;
+    }
+    #[automatically_derived]
+    impl<Inner> __capi::types::Opaque for __PrefixTestConfigInheritance2FfiWrapper<Inner>
+    where
+        Inner: __capi::types::Opaque,
+    {}
+    #[automatically_derived]
+    unsafe impl<Inner> __capi::types::Input
+    for __PrefixTestConfigInheritance2FfiWrapper<Inner> {}
+    #[automatically_derived]
+    unsafe impl<Inner> __capi::types::ByValue
+    for __PrefixTestConfigInheritance2FfiWrapper<Inner>
+    where
+        Inner: ::core::marker::Copy,
+    {}
+    #[automatically_derived]
+    unsafe impl<Inner> __capi::types::ByConstPtr
+    for __PrefixTestConfigInheritance2FfiWrapper<Inner> {}
+    #[automatically_derived]
+    unsafe impl<Inner> __capi::types::ByMutPtr
+    for __PrefixTestConfigInheritance2FfiWrapper<Inner> {}
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
+    const _: () = {
+        const GOT: usize = ::core::mem::size_of::<PrefixTestConfigInheritance2>();
+        const WANT: usize = ::core::mem::size_of::<
+            crate::defs::TestConfigInheritance2,
+        >();
+        const MSG: &str = __capi::internal::const_format::formatcp!(
+            "BUG: invalid size: {GOT} != {WANT}"
+        );
+        ::core::assert!(GOT == WANT, "{}", MSG);
+    };
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
+    const _: () = {
+        const GOT: usize = ::core::mem::align_of::<PrefixTestConfigInheritance2>();
+        const WANT: usize = ::core::mem::align_of::<
+            crate::defs::TestConfigInheritance2,
+        >();
+        const MSG: &str = __capi::internal::const_format::formatcp!(
+            "BUG: invalid alignment: {GOT} != {WANT}"
+        );
+        ::core::assert!(GOT == WANT, "{}", MSG);
+    };
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
+    const _: () = {
+        const GOT: bool = ::core::mem::needs_drop::<PrefixTestConfigInheritance2>();
+        const WANT: bool = ::core::mem::needs_drop::<
+            crate::defs::TestConfigInheritance2,
+        >();
+        const MSG: &str = __capi::internal::const_format::formatcp!(
+            "BUG: invalid `Drop` impl: {GOT} != {WANT}"
+        );
+        ::core::assert!(GOT == WANT, "{}", MSG);
     };
 }

--- a/crates/aranya-capi-codegen-test/src/generated.rs
+++ b/crates/aranya-capi-codegen-test/src/generated.rs
@@ -2300,11 +2300,13 @@ mod __hidden {
     >;
     #[repr(transparent)]
     #[derive(Debug)]
+    #[cfg(not(cbindgen))]
     pub struct __PrefixStructFfiWrapper<Inner, _0> {
         pub inner: Inner,
         _0: ::core::marker::PhantomData<_0>,
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner, _0> __capi::InitDefault for __PrefixStructFfiWrapper<Inner, _0>
     where
         Inner: __capi::InitDefault,
@@ -2319,11 +2321,13 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner, _0> ::core::marker::Copy for __PrefixStructFfiWrapper<Inner, _0>
     where
         Inner: ::core::marker::Copy,
     {}
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner, _0> ::core::clone::Clone for __PrefixStructFfiWrapper<Inner, _0>
     where
         Inner: ::core::clone::Clone,
@@ -2336,6 +2340,7 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner, _0> ::core::ops::Deref for __PrefixStructFfiWrapper<Inner, _0> {
         type Target = Inner;
         fn deref(&self) -> &Self::Target {
@@ -2343,12 +2348,14 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner, _0> ::core::ops::DerefMut for __PrefixStructFfiWrapper<Inner, _0> {
         fn deref_mut(&mut self) -> &mut Self::Target {
             &mut self.inner
         }
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner, _0> __capi::Builder for __PrefixStructFfiWrapper<Inner, _0>
     where
         Inner: __capi::Builder,
@@ -2369,28 +2376,33 @@ mod __hidden {
         type Inner = crate::defs::Struct;
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner, _0> __capi::types::Opaque for __PrefixStructFfiWrapper<Inner, _0>
     where
         Inner: __capi::types::Opaque,
     {}
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner, _0> __capi::types::Input for __PrefixStructFfiWrapper<Inner, _0>
     where
         _0: __capi::types::Input,
     {}
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner, _0> __capi::types::ByValue for __PrefixStructFfiWrapper<Inner, _0>
     where
         Inner: ::core::marker::Copy,
         _0: __capi::types::ByValue,
     {}
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner, _0> __capi::types::ByConstPtr
     for __PrefixStructFfiWrapper<Inner, _0>
     where
         _0: __capi::types::ByConstPtr,
     {}
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner, _0> __capi::types::ByMutPtr
     for __PrefixStructFfiWrapper<Inner, _0>
     where
@@ -2427,10 +2439,12 @@ mod __hidden {
     pub type PrefixSafeStruct = __PrefixSafeStructFfiWrapper<crate::defs::SafeStruct>;
     #[repr(transparent)]
     #[derive(Debug)]
+    #[cfg(not(cbindgen))]
     pub struct __PrefixSafeStructFfiWrapper<Inner> {
         pub inner: Inner,
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner> __capi::InitDefault for __PrefixSafeStructFfiWrapper<Inner>
     where
         Inner: __capi::InitDefault,
@@ -2445,11 +2459,13 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::marker::Copy for __PrefixSafeStructFfiWrapper<Inner>
     where
         Inner: ::core::marker::Copy,
     {}
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::clone::Clone for __PrefixSafeStructFfiWrapper<Inner>
     where
         Inner: ::core::clone::Clone,
@@ -2461,6 +2477,7 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::ops::Deref for __PrefixSafeStructFfiWrapper<Inner> {
         type Target = Inner;
         fn deref(&self) -> &Self::Target {
@@ -2468,12 +2485,14 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::ops::DerefMut for __PrefixSafeStructFfiWrapper<Inner> {
         fn deref_mut(&mut self) -> &mut Self::Target {
             &mut self.inner
         }
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner> __capi::Builder for __PrefixSafeStructFfiWrapper<Inner>
     where
         Inner: __capi::Builder,
@@ -2494,21 +2513,26 @@ mod __hidden {
         type Inner = crate::defs::SafeStruct;
     }
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     impl<Inner> __capi::types::Opaque for __PrefixSafeStructFfiWrapper<Inner>
     where
         Inner: __capi::types::Opaque,
     {}
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::Input for __PrefixSafeStructFfiWrapper<Inner> {}
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::ByValue for __PrefixSafeStructFfiWrapper<Inner>
     where
         Inner: ::core::marker::Copy,
     {}
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::ByConstPtr
     for __PrefixSafeStructFfiWrapper<Inner> {}
     #[automatically_derived]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::ByMutPtr for __PrefixSafeStructFfiWrapper<Inner> {}
     #[cfg(not(cbindgen))]
     const _: () = {
@@ -2707,10 +2731,14 @@ mod __hidden {
     >;
     #[repr(transparent)]
     #[derive(Debug)]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     pub struct __PrefixTestConfigInheritanceFfiWrapper<Inner> {
         pub inner: Inner,
     }
     #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     impl<Inner> __capi::InitDefault for __PrefixTestConfigInheritanceFfiWrapper<Inner>
     where
         Inner: __capi::InitDefault,
@@ -2725,11 +2753,15 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::marker::Copy for __PrefixTestConfigInheritanceFfiWrapper<Inner>
     where
         Inner: ::core::marker::Copy,
     {}
     #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::clone::Clone for __PrefixTestConfigInheritanceFfiWrapper<Inner>
     where
         Inner: ::core::clone::Clone,
@@ -2741,6 +2773,8 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::ops::Deref for __PrefixTestConfigInheritanceFfiWrapper<Inner> {
         type Target = Inner;
         fn deref(&self) -> &Self::Target {
@@ -2748,6 +2782,8 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::ops::DerefMut
     for __PrefixTestConfigInheritanceFfiWrapper<Inner> {
         fn deref_mut(&mut self) -> &mut Self::Target {
@@ -2755,6 +2791,8 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     impl<Inner> __capi::Builder for __PrefixTestConfigInheritanceFfiWrapper<Inner>
     where
         Inner: __capi::Builder,
@@ -2776,23 +2814,33 @@ mod __hidden {
         type Inner = crate::defs::TestConfigInheritance;
     }
     #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     impl<Inner> __capi::types::Opaque for __PrefixTestConfigInheritanceFfiWrapper<Inner>
     where
         Inner: __capi::types::Opaque,
     {}
     #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::Input
     for __PrefixTestConfigInheritanceFfiWrapper<Inner> {}
     #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::ByValue
     for __PrefixTestConfigInheritanceFfiWrapper<Inner>
     where
         Inner: ::core::marker::Copy,
     {}
     #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::ByConstPtr
     for __PrefixTestConfigInheritanceFfiWrapper<Inner> {}
     #[automatically_derived]
+    #[cfg(feature = "test_cfg")]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::ByMutPtr
     for __PrefixTestConfigInheritanceFfiWrapper<Inner> {}
     #[cfg(feature = "test_cfg")]
@@ -2836,10 +2884,14 @@ mod __hidden {
     >;
     #[repr(transparent)]
     #[derive(Debug)]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     pub struct __PrefixTestConfigInheritance2FfiWrapper<Inner> {
         pub inner: Inner,
     }
     #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     impl<Inner> __capi::InitDefault for __PrefixTestConfigInheritance2FfiWrapper<Inner>
     where
         Inner: __capi::InitDefault,
@@ -2854,11 +2906,15 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::marker::Copy for __PrefixTestConfigInheritance2FfiWrapper<Inner>
     where
         Inner: ::core::marker::Copy,
     {}
     #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::clone::Clone for __PrefixTestConfigInheritance2FfiWrapper<Inner>
     where
         Inner: ::core::clone::Clone,
@@ -2870,6 +2926,8 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::ops::Deref for __PrefixTestConfigInheritance2FfiWrapper<Inner> {
         type Target = Inner;
         fn deref(&self) -> &Self::Target {
@@ -2877,6 +2935,8 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     impl<Inner> ::core::ops::DerefMut
     for __PrefixTestConfigInheritance2FfiWrapper<Inner> {
         fn deref_mut(&mut self) -> &mut Self::Target {
@@ -2884,6 +2944,8 @@ mod __hidden {
         }
     }
     #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     impl<Inner> __capi::Builder for __PrefixTestConfigInheritance2FfiWrapper<Inner>
     where
         Inner: __capi::Builder,
@@ -2905,23 +2967,33 @@ mod __hidden {
         type Inner = crate::defs::TestConfigInheritance2;
     }
     #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     impl<Inner> __capi::types::Opaque for __PrefixTestConfigInheritance2FfiWrapper<Inner>
     where
         Inner: __capi::types::Opaque,
     {}
     #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::Input
     for __PrefixTestConfigInheritance2FfiWrapper<Inner> {}
     #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::ByValue
     for __PrefixTestConfigInheritance2FfiWrapper<Inner>
     where
         Inner: ::core::marker::Copy,
     {}
     #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::ByConstPtr
     for __PrefixTestConfigInheritance2FfiWrapper<Inner> {}
     #[automatically_derived]
+    #[cfg(not(feature = "test_cfg"))]
+    #[cfg(not(cbindgen))]
     unsafe impl<Inner> __capi::types::ByMutPtr
     for __PrefixTestConfigInheritance2FfiWrapper<Inner> {}
     #[cfg(not(feature = "test_cfg"))]

--- a/crates/aranya-capi-codegen/src/ast/expand.rs
+++ b/crates/aranya-capi-codegen/src/ast/expand.rs
@@ -1646,12 +1646,14 @@ fn ffi_wrapper(ctx: &Ctx, strukt: &Struct, underlying: &Path) -> TokenStream {
 
         #[repr(transparent)]
         #[derive(Debug)]
+        #(#attrs)*
         pub struct #wrapper<#generics> {
             pub inner: #inner,
             #(#fields : ::core::marker::PhantomData<#fields>),*
         }
 
         #[automatically_derived]
+        #(#attrs)*
         impl<#generics> #capi::InitDefault for #wrapper<#generics>
         where
             #inner: #capi::InitDefault,
@@ -1670,12 +1672,14 @@ fn ffi_wrapper(ctx: &Ctx, strukt: &Struct, underlying: &Path) -> TokenStream {
         }
 
         #[automatically_derived]
+        #(#attrs)*
         impl<#generics> ::core::marker::Copy for #wrapper<#generics>
         where
             #inner: ::core::marker::Copy
         {}
 
         #[automatically_derived]
+        #(#attrs)*
         impl<#generics> ::core::clone::Clone for #wrapper<#generics>
         where
             #inner: ::core::clone::Clone
@@ -1689,6 +1693,7 @@ fn ffi_wrapper(ctx: &Ctx, strukt: &Struct, underlying: &Path) -> TokenStream {
         }
 
         #[automatically_derived]
+        #(#attrs)*
         impl<#generics> ::core::ops::Deref for #wrapper<#generics> {
             type Target = #inner;
 
@@ -1698,6 +1703,7 @@ fn ffi_wrapper(ctx: &Ctx, strukt: &Struct, underlying: &Path) -> TokenStream {
         }
 
         #[automatically_derived]
+        #(#attrs)*
         impl<#generics> ::core::ops::DerefMut for #wrapper<#generics> {
             fn deref_mut(&mut self) -> &mut Self::Target {
                 &mut self.inner
@@ -1705,6 +1711,7 @@ fn ffi_wrapper(ctx: &Ctx, strukt: &Struct, underlying: &Path) -> TokenStream {
         }
 
         #[automatically_derived]
+        #(#attrs)*
         impl<#generics> #capi::Builder for #wrapper<#generics>
         where
             #inner: #capi::Builder,
@@ -1727,18 +1734,21 @@ fn ffi_wrapper(ctx: &Ctx, strukt: &Struct, underlying: &Path) -> TokenStream {
         }
 
         #[automatically_derived]
+        #(#attrs)*
         impl<#generics> #capi::types::Opaque for #wrapper<#generics>
         where
             #inner: #capi::types::Opaque,
         {}
 
         #[automatically_derived]
+        #(#attrs)*
         unsafe impl<#generics> #capi::types::Input for #wrapper<#generics>
         where
             #(#fields : #capi::types::Input),*
         {}
 
         #[automatically_derived]
+        #(#attrs)*
         unsafe impl<#generics> #capi::types::ByValue for #wrapper<#generics>
         where
             #inner: ::core::marker::Copy,
@@ -1746,12 +1756,14 @@ fn ffi_wrapper(ctx: &Ctx, strukt: &Struct, underlying: &Path) -> TokenStream {
         {}
 
         #[automatically_derived]
+        #(#attrs)*
         unsafe impl<#generics> #capi::types::ByConstPtr for #wrapper<#generics>
         where
             #(#fields : #capi::types::ByConstPtr),*
         {}
 
         #[automatically_derived]
+        #(#attrs)*
         unsafe impl<#generics> #capi::types::ByMutPtr for #wrapper<#generics>
         where
             #(#fields : #capi::types::ByMutPtr),*

--- a/crates/aranya-capi-codegen/src/ast/expand.rs
+++ b/crates/aranya-capi-codegen/src/ast/expand.rs
@@ -1626,7 +1626,7 @@ fn ffi_wrapper(ctx: &Ctx, strukt: &Struct, underlying: &Path) -> TokenStream {
     let attrs = strukt
         .attrs
         .iter()
-        .filter(|attr| attr.path().is_ident("cfg"))
+        .filter(|attr| attr.path().is_ident("cfg") || attr.path().is_ident("cfg_attr"))
         .collect::<Vec<_>>();
 
     // All generic arguments.


### PR DESCRIPTION
Since we're making AFC experimental, some types are now conditionally defined, which causes errors in our FFI wrapper since the type path doesn't exist. This should fix that by copying the same `#[cfg()]` flags over.