### PR TITLE
(capi-codegen) Enum return types

### DIFF
--- a/crates/aranya-capi-codegen-test/src/defs.rs
+++ b/crates/aranya-capi-codegen-test/src/defs.rs
@@ -99,11 +99,14 @@ pub fn test_enum_unit(_a: Enum) {}
 pub fn test_unit_enum() -> Enum {
     Enum::A
 }
-// pub fn test_enum_enum(a: Enum) -> Enum {
-//     a
-// }
-// pub fn test_enum_result_enum_error(a: Enum) -> Result<Enum, crate::Error> {
-//     Ok(a)
+pub fn test_enum_enum(a: Enum) -> Enum {
+    a
+}
+pub fn test_enum_result_enum_error(a: Enum) -> Result<Enum, crate::Error> {
+    Ok(a)
+}
+// pub fn test_mut_ref_enum_enum(a: &mut Enum) -> Enum {
+//     a.clone()
 // }
 
 #[derive(Copy, Clone, Debug, Default)]

--- a/crates/aranya-capi-codegen-test/src/defs.rs
+++ b/crates/aranya-capi-codegen-test/src/defs.rs
@@ -96,9 +96,9 @@ pub enum Enum {
 }
 
 pub fn test_enum_unit(_a: Enum) {}
-// pub fn test_unit_enum() -> Enum {
-//     Enum::A
-// }
+pub fn test_unit_enum() -> Enum {
+    Enum::A
+}
 // pub fn test_enum_enum(a: Enum) -> Enum {
 //     a
 // }

--- a/crates/aranya-capi-codegen-test/src/generated.rs
+++ b/crates/aranya-capi-codegen-test/src/generated.rs
@@ -83,7 +83,7 @@ fn __tramp_prefix_test_unit_unit0() -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_unit_unit0() } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -100,7 +100,7 @@ fn __tramp_prefix_test_unit_unit1() -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_unit_unit1() } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -156,7 +156,7 @@ fn __tramp_prefix_test_unit_result_unit_error() -> ::core::result::Result<
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_unit_result_unit_error() } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -175,7 +175,7 @@ fn __tramp_prefix_test_u8_unit(_a: ::core::primitive::u8) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u8_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -196,7 +196,7 @@ fn __tramp_prefix_test_u16_unit(_a: ::core::primitive::u16) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u16_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -217,7 +217,7 @@ fn __tramp_prefix_test_u32_unit(_a: ::core::primitive::u32) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u32_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -238,7 +238,7 @@ fn __tramp_prefix_test_u64_unit(_a: ::core::primitive::u64) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u64_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -259,7 +259,7 @@ fn __tramp_prefix_test_usize_unit(_a: ::core::primitive::usize) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_usize_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -278,7 +278,7 @@ fn __tramp_prefix_test_i8_unit(_a: ::core::primitive::i8) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i8_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -299,7 +299,7 @@ fn __tramp_prefix_test_i16_unit(_a: ::core::primitive::i16) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i16_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -320,7 +320,7 @@ fn __tramp_prefix_test_i32_unit(_a: ::core::primitive::i32) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i32_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -341,7 +341,7 @@ fn __tramp_prefix_test_i64_unit(_a: ::core::primitive::i64) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i64_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -362,7 +362,7 @@ fn __tramp_prefix_test_isize_unit(_a: ::core::primitive::isize) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_isize_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -381,7 +381,7 @@ fn __tramp_prefix_test_u8_u8(_a: ::core::primitive::u8) -> ::core::primitive::u8
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u8_u8(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -402,7 +402,7 @@ fn __tramp_prefix_test_u16_u16(_a: ::core::primitive::u16) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u16_u16(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -423,7 +423,7 @@ fn __tramp_prefix_test_u32_u32(_a: ::core::primitive::u32) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u32_u32(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -444,7 +444,7 @@ fn __tramp_prefix_test_u64_u64(_a: ::core::primitive::u64) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u64_u64(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -469,7 +469,7 @@ fn __tramp_prefix_test_usize_usize(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_usize_usize(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -488,7 +488,7 @@ fn __tramp_prefix_test_i8_i8(_a: ::core::primitive::i8) -> ::core::primitive::i8
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i8_i8(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -509,7 +509,7 @@ fn __tramp_prefix_test_i16_i16(_a: ::core::primitive::i16) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i16_i16(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -530,7 +530,7 @@ fn __tramp_prefix_test_i32_i32(_a: ::core::primitive::i32) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i32_i32(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -551,7 +551,7 @@ fn __tramp_prefix_test_i64_i64(_a: ::core::primitive::i64) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i64_i64(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -576,7 +576,7 @@ fn __tramp_prefix_test_isize_isize(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_isize_isize(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -604,7 +604,7 @@ fn __tramp_prefix_test_u8_u8_u8(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u8_u8_u8(_a, _b) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -632,7 +632,7 @@ fn __tramp_prefix_test_u16_u16_u16(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u16_u16_u16(_a, _b) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -660,7 +660,7 @@ fn __tramp_prefix_test_u32_u32_u32(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u32_u32_u32(_a, _b) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -688,7 +688,7 @@ fn __tramp_prefix_test_u64_u64_u64(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u64_u64_u64(_a, _b) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -716,7 +716,7 @@ fn __tramp_prefix_test_usize_usize_usize(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_usize_usize_usize(_a, _b) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -744,7 +744,7 @@ fn __tramp_prefix_test_i8_i8_i8(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i8_i8_i8(_a, _b) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -772,7 +772,7 @@ fn __tramp_prefix_test_i16_i16_i16(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i16_i16_i16(_a, _b) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -800,7 +800,7 @@ fn __tramp_prefix_test_i32_i32_i32(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i32_i32_i32(_a, _b) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -828,7 +828,7 @@ fn __tramp_prefix_test_i64_i64_i64(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i64_i64_i64(_a, _b) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -856,7 +856,7 @@ fn __tramp_prefix_test_isize_isize_isize(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_isize_isize_isize(_a, _b) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -928,7 +928,7 @@ fn __tramp_prefix_test_enum_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_enum_unit(_a) } {
-        __pattern => ::core::result::Result::Ok(__pattern),
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
 #[no_mangle]
@@ -946,6 +946,222 @@ fn __tramp_prefix_test_unit_enum() -> PrefixEnum {
     #[allow(unused_braces)]
     match { crate::defs::test_unit_enum() } {
         __pattern => PrefixEnum::from(__pattern),
+    }
+}
+#[no_mangle]
+#[::tracing::instrument(
+    level = "trace",
+    fields(
+        a = ::tracing::field::Empty,
+        __output = %__capi::internal::util::Addr::from_ptr(__output)
+    )
+)]
+pub extern "C" fn prefix_test_enum_enum(
+    a: PrefixEnum,
+    __output: *mut ::core::mem::MaybeUninit<PrefixEnum>,
+) -> PrefixError {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match {
+        __tramp_prefix_test_enum_enum(
+            __capi::internal::util::check_valid_input_ty_val(a),
+            __capi::internal::util::check_valid_input_ty_mut_ptr(__output),
+        )
+    } {
+        __pattern => {
+            match __pattern {
+                ::core::result::Result::Ok(__pattern) => {
+                    <PrefixError as __capi::ErrorCode>::SUCCESS
+                }
+                ::core::result::Result::Err(ref err) => {
+                    __capi::internal::error::convert_err(err)
+                }
+            }
+        }
+    }
+}
+#[no_mangle]
+#[::tracing::instrument(
+    level = "trace",
+    fields(
+        a = ::tracing::field::Empty,
+        __output = %__capi::internal::util::Addr::from_ptr(__output),
+        __ext_err = %__capi::internal::util::Addr::from_ptr(__ext_err)
+    )
+)]
+pub extern "C" fn prefix_test_enum_enum_ext(
+    a: PrefixEnum,
+    __output: *mut ::core::mem::MaybeUninit<PrefixEnum>,
+    __ext_err: *mut PrefixExtError,
+) -> PrefixError {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match {
+        __tramp_prefix_test_enum_enum(
+            __capi::internal::util::check_valid_input_ty_val(a),
+            __capi::internal::util::check_valid_input_ty_mut_ptr(__output),
+        )
+    } {
+        __pattern => {
+            match __pattern {
+                ::core::result::Result::Ok(__pattern) => {
+                    <PrefixError as __capi::ErrorCode>::SUCCESS
+                }
+                ::core::result::Result::Err(err) => {
+                    type __ExtErrTy = PrefixExtError;
+                    __capi::internal::error::handle_ext_error(
+                        err,
+                        __capi::from_inner_mut_ptr!(__ext_err => __ExtErrTy),
+                    )
+                }
+            }
+        }
+    }
+}
+#[allow(clippy::unused_unit)]
+fn __tramp_prefix_test_enum_enum(
+    a: PrefixEnum,
+    __output: *mut ::core::mem::MaybeUninit<PrefixEnum>,
+) -> ::core::result::Result<(), __capi::InvalidArg<'static>> {
+    #[allow(clippy::let_with_type_underscore)]
+    let a: _ = {
+        let a = __capi::try_as_enum!(crate ::defs::Enum, a);
+        __capi::to_inner!(a)
+    };
+    #[allow(clippy::let_with_type_underscore)]
+    let __output: &mut ::core::mem::MaybeUninit<_> = {
+        let __output = __capi::try_as_uninit_mut!(__output);
+        __capi::to_inner_mut!(__output)
+    };
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match { crate::defs::test_enum_enum(a) } {
+        __pattern => {
+            ::core::mem::MaybeUninit::write(__output, __pattern.into());
+            ::core::result::Result::Ok(())
+        }
+    }
+}
+#[no_mangle]
+#[::tracing::instrument(
+    level = "trace",
+    fields(
+        a = ::tracing::field::Empty,
+        __output = %__capi::internal::util::Addr::from_ptr(__output)
+    )
+)]
+pub extern "C" fn prefix_test_enum_result_enum_error(
+    a: PrefixEnum,
+    __output: *mut ::core::mem::MaybeUninit<PrefixEnum>,
+) -> PrefixError {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match {
+        __tramp_prefix_test_enum_result_enum_error(
+            __capi::internal::util::check_valid_input_ty_val(a),
+            __capi::internal::util::check_valid_input_ty_mut_ptr(__output),
+        )
+    } {
+        __pattern => {
+            match __pattern {
+                ::core::result::Result::Ok(__pattern) => {
+                    match __pattern {
+                        ::core::result::Result::Ok(()) => {
+                            <PrefixError as __capi::ErrorCode>::SUCCESS
+                        }
+                        ::core::result::Result::Err(ref err) => {
+                            __capi::internal::error::convert_err(err)
+                        }
+                    }
+                }
+                ::core::result::Result::Err(ref err) => {
+                    __capi::internal::error::convert_err(err)
+                }
+            }
+        }
+    }
+}
+#[no_mangle]
+#[::tracing::instrument(
+    level = "trace",
+    fields(
+        a = ::tracing::field::Empty,
+        __output = %__capi::internal::util::Addr::from_ptr(__output),
+        __ext_err = %__capi::internal::util::Addr::from_ptr(__ext_err)
+    )
+)]
+pub extern "C" fn prefix_test_enum_result_enum_error_ext(
+    a: PrefixEnum,
+    __output: *mut ::core::mem::MaybeUninit<PrefixEnum>,
+    __ext_err: *mut PrefixExtError,
+) -> PrefixError {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match {
+        __tramp_prefix_test_enum_result_enum_error(
+            __capi::internal::util::check_valid_input_ty_val(a),
+            __capi::internal::util::check_valid_input_ty_mut_ptr(__output),
+        )
+    } {
+        __pattern => {
+            match __pattern {
+                ::core::result::Result::Ok(__pattern) => {
+                    match __pattern {
+                        ::core::result::Result::Ok(()) => {
+                            <PrefixError as __capi::ErrorCode>::SUCCESS
+                        }
+                        ::core::result::Result::Err(err) => {
+                            type __ExtErrTy = PrefixExtError;
+                            __capi::internal::error::handle_ext_error(
+                                err,
+                                __capi::from_inner_mut_ptr!(__ext_err => __ExtErrTy),
+                            )
+                        }
+                    }
+                }
+                ::core::result::Result::Err(err) => {
+                    type __ExtErrTy = PrefixExtError;
+                    __capi::internal::error::handle_ext_error(
+                        err,
+                        __capi::from_inner_mut_ptr!(__ext_err => __ExtErrTy),
+                    )
+                }
+            }
+        }
+    }
+}
+#[allow(clippy::unused_unit)]
+fn __tramp_prefix_test_enum_result_enum_error(
+    a: PrefixEnum,
+    __output: *mut ::core::mem::MaybeUninit<PrefixEnum>,
+) -> ::core::result::Result<
+    ::core::result::Result<(), crate::Error>,
+    __capi::InvalidArg<'static>,
+> {
+    #[allow(clippy::let_with_type_underscore)]
+    let a: _ = {
+        let a = __capi::try_as_enum!(crate ::defs::Enum, a);
+        __capi::to_inner!(a)
+    };
+    #[allow(clippy::let_with_type_underscore)]
+    let __output: &mut ::core::mem::MaybeUninit<_> = {
+        let __output = __capi::try_as_uninit_mut!(__output);
+        __capi::to_inner_mut!(__output)
+    };
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match { crate::defs::test_enum_result_enum_error(a) } {
+        __pattern => {
+            match __pattern {
+                ::core::result::Result::Ok(__pattern) => {
+                    ::core::mem::MaybeUninit::write(__output, __pattern.into());
+                    ::core::result::Result::Ok(::core::result::Result::Ok(()))
+                }
+                ::core::result::Result::Err(err) => {
+                    ::core::result::Result::Ok(::core::result::Result::Err(err))
+                }
+            }
+        }
     }
 }
 #[no_mangle]
@@ -968,7 +1184,7 @@ fn __tramp_prefix_test_struct_unit(_a: PrefixStruct) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_struct_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -1063,7 +1279,7 @@ fn __tramp_prefix_test_ref_struct_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ref_struct_unit(_a) } {
-        __pattern => ::core::result::Result::Ok(__pattern),
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
 #[no_mangle]
@@ -1089,7 +1305,7 @@ fn __tramp_prefix_test_ptr_struct_unit(_a: *const PrefixStruct) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ptr_struct_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -1216,7 +1432,7 @@ fn __tramp_prefix_test_unit_result_struct_error(
         __pattern => {
             match __pattern {
                 ::core::result::Result::Ok(__pattern) => {
-                    ::core::mem::MaybeUninit::write(__output, __pattern);
+                    ::core::mem::MaybeUninit::write(__output, __pattern.into());
                     ::core::result::Result::Ok(::core::result::Result::Ok(()))
                 }
                 ::core::result::Result::Err(err) => {
@@ -1300,7 +1516,7 @@ fn __tramp_prefix_test_optional_ref_struct(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_optional_ref_struct(_a) } {
-        __pattern => ::core::result::Result::Ok(__pattern),
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
 #[no_mangle]
@@ -1377,7 +1593,7 @@ fn __tramp_prefix_test_optional_mut_ref_struct(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_optional_mut_ref_struct(_a) } {
-        __pattern => ::core::result::Result::Ok(__pattern),
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
 #[no_mangle]
@@ -1454,7 +1670,7 @@ fn __tramp_prefix_test_ref_safestruct_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ref_safestruct_unit(_a) } {
-        __pattern => ::core::result::Result::Ok(__pattern),
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
 #[no_mangle]
@@ -1480,7 +1696,7 @@ fn __tramp_prefix_test_ptr_safestruct_unit(_a: *const PrefixSafeStruct) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ptr_safestruct_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -1581,7 +1797,7 @@ fn __tramp_prefix_test_unit_result_safestruct_error(
         __pattern => {
             match __pattern {
                 ::core::result::Result::Ok(__pattern) => {
-                    ::core::mem::MaybeUninit::write(__output, __pattern);
+                    ::core::mem::MaybeUninit::write(__output, __pattern.into());
                     ::core::result::Result::Ok(::core::result::Result::Ok(()))
                 }
                 ::core::result::Result::Err(err) => {
@@ -1665,7 +1881,7 @@ fn __tramp_prefix_test_ownedptr_u32_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ownedptr_u32_unit(_a) } {
-        __pattern => ::core::result::Result::Ok(__pattern),
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
 #[no_mangle]
@@ -1742,7 +1958,7 @@ fn __tramp_prefix_test_ownedptr_struct_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ownedptr_struct_unit(_a) } {
-        __pattern => ::core::result::Result::Ok(__pattern),
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
 #[no_mangle]
@@ -1819,7 +2035,7 @@ fn __tramp_prefix_test_ownedptr_safestruct_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ownedptr_safestruct_unit(_a) } {
-        __pattern => ::core::result::Result::Ok(__pattern),
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
 #[no_mangle]
@@ -1847,7 +2063,7 @@ fn __tramp_prefix_test_ptr_ptr_ptr_ptr_u32_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ptr_ptr_ptr_ptr_u32_unit(_a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -1875,7 +2091,7 @@ fn __tramp_prefix_test_ptr_ptr_ptr_ptr_u32_ptr_ptr_ptr_ptr_u32(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ptr_ptr_ptr_ptr_u32_ptr_ptr_ptr_ptr_u32(a) } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -1958,7 +2174,7 @@ fn __tramp_prefix_test_slice_u8_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_slice_u8_unit(_a) } {
-        __pattern => ::core::result::Result::Ok(__pattern),
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
 /// Initializes `PrefixExtError`.
@@ -2066,7 +2282,7 @@ fn __tramp_prefix_ext_error_init(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { self::ext_error_init(out) } {
-        __pattern => ::core::result::Result::Ok(__pattern),
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
 #[::tracing::instrument(fields(out = %__capi::internal::util::Addr::from_mut(out)))]
@@ -2177,7 +2393,7 @@ fn __tramp_prefix_ext_error_cleanup(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { self::ext_error_cleanup(ptr) } {
-        __pattern => ::core::result::Result::Ok(__pattern),
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
 #[__capi::internal::tracing::instrument(
@@ -2209,7 +2425,7 @@ fn __tramp_prefix_test_cfg_inheritance() -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_cfg_inheritance() } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[no_mangle]
@@ -2228,7 +2444,7 @@ fn __tramp_prefix_test_cfg_inheritance2() -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_cfg_inheritance2() } {
-        __pattern => __pattern,
+        __pattern => __pattern.into(),
     }
 }
 #[cfg(not(cbindgen))]
@@ -2286,6 +2502,11 @@ mod __hidden {
         /// invalid representations, so it is FFI safe.
         #[automatically_derived]
         unsafe impl __capi::types::ByValue for PrefixEnum {}
+        /// SAFETY: The type is a unit-only enumeration
+        /// with a `#[repr(...)]`, and we check for
+        /// invalid representations, so it is FFI safe.
+        #[automatically_derived]
+        unsafe impl __capi::types::ByMutPtr for PrefixEnum {}
         #[automatically_derived]
         impl<T> ::core::convert::From<T> for PrefixEnum
         where
@@ -2728,6 +2949,11 @@ mod __hidden {
         /// invalid representations, so it is FFI safe.
         #[automatically_derived]
         unsafe impl __capi::types::ByValue for PrefixError {}
+        /// SAFETY: The type is a unit-only enumeration
+        /// with a `#[repr(...)]`, and we check for
+        /// invalid representations, so it is FFI safe.
+        #[automatically_derived]
+        unsafe impl __capi::types::ByMutPtr for PrefixError {}
         #[automatically_derived]
         impl<T> ::core::convert::From<T> for PrefixError
         where

--- a/crates/aranya-capi-codegen-test/src/generated.rs
+++ b/crates/aranya-capi-codegen-test/src/generated.rs
@@ -932,6 +932,23 @@ fn __tramp_prefix_test_enum_unit(
     }
 }
 #[no_mangle]
+#[::tracing::instrument(level = "trace")]
+pub extern "C" fn prefix_test_unit_enum() -> PrefixEnum {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match { __tramp_prefix_test_unit_enum() } {
+        __pattern => __pattern,
+    }
+}
+#[allow(clippy::unused_unit)]
+fn __tramp_prefix_test_unit_enum() -> PrefixEnum {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match { crate::defs::test_unit_enum() } {
+        __pattern => PrefixEnum::from(__pattern),
+    }
+}
+#[no_mangle]
 #[::tracing::instrument(level = "trace", fields(_a = ::tracing::field::Empty))]
 pub extern "C" fn prefix_test_struct_unit(_a: PrefixStruct) {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]

--- a/crates/aranya-capi-codegen-test/src/generated.rs
+++ b/crates/aranya-capi-codegen-test/src/generated.rs
@@ -83,6 +83,8 @@ fn __tramp_prefix_test_unit_unit0() -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_unit_unit0() } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -100,6 +102,8 @@ fn __tramp_prefix_test_unit_unit1() -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_unit_unit1() } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -156,6 +160,8 @@ fn __tramp_prefix_test_unit_result_unit_error() -> ::core::result::Result<
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_unit_result_unit_error() } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -175,6 +181,8 @@ fn __tramp_prefix_test_u8_unit(_a: ::core::primitive::u8) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u8_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -196,6 +204,8 @@ fn __tramp_prefix_test_u16_unit(_a: ::core::primitive::u16) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u16_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -217,6 +227,8 @@ fn __tramp_prefix_test_u32_unit(_a: ::core::primitive::u32) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u32_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -238,6 +250,8 @@ fn __tramp_prefix_test_u64_unit(_a: ::core::primitive::u64) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u64_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -259,6 +273,8 @@ fn __tramp_prefix_test_usize_unit(_a: ::core::primitive::usize) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_usize_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -278,6 +294,8 @@ fn __tramp_prefix_test_i8_unit(_a: ::core::primitive::i8) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i8_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -299,6 +317,8 @@ fn __tramp_prefix_test_i16_unit(_a: ::core::primitive::i16) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i16_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -320,6 +340,8 @@ fn __tramp_prefix_test_i32_unit(_a: ::core::primitive::i32) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i32_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -341,6 +363,8 @@ fn __tramp_prefix_test_i64_unit(_a: ::core::primitive::i64) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i64_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -362,6 +386,8 @@ fn __tramp_prefix_test_isize_unit(_a: ::core::primitive::isize) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_isize_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -381,6 +407,8 @@ fn __tramp_prefix_test_u8_u8(_a: ::core::primitive::u8) -> ::core::primitive::u8
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u8_u8(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -402,6 +430,8 @@ fn __tramp_prefix_test_u16_u16(_a: ::core::primitive::u16) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u16_u16(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -423,6 +453,8 @@ fn __tramp_prefix_test_u32_u32(_a: ::core::primitive::u32) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u32_u32(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -444,6 +476,8 @@ fn __tramp_prefix_test_u64_u64(_a: ::core::primitive::u64) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u64_u64(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -469,6 +503,8 @@ fn __tramp_prefix_test_usize_usize(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_usize_usize(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -488,6 +524,8 @@ fn __tramp_prefix_test_i8_i8(_a: ::core::primitive::i8) -> ::core::primitive::i8
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i8_i8(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -509,6 +547,8 @@ fn __tramp_prefix_test_i16_i16(_a: ::core::primitive::i16) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i16_i16(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -530,6 +570,8 @@ fn __tramp_prefix_test_i32_i32(_a: ::core::primitive::i32) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i32_i32(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -551,6 +593,8 @@ fn __tramp_prefix_test_i64_i64(_a: ::core::primitive::i64) -> ::core::primitive:
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i64_i64(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -576,6 +620,8 @@ fn __tramp_prefix_test_isize_isize(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_isize_isize(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -604,6 +650,8 @@ fn __tramp_prefix_test_u8_u8_u8(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u8_u8_u8(_a, _b) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -632,6 +680,8 @@ fn __tramp_prefix_test_u16_u16_u16(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u16_u16_u16(_a, _b) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -660,6 +710,8 @@ fn __tramp_prefix_test_u32_u32_u32(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u32_u32_u32(_a, _b) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -688,6 +740,8 @@ fn __tramp_prefix_test_u64_u64_u64(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_u64_u64_u64(_a, _b) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -716,6 +770,8 @@ fn __tramp_prefix_test_usize_usize_usize(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_usize_usize_usize(_a, _b) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -744,6 +800,8 @@ fn __tramp_prefix_test_i8_i8_i8(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i8_i8_i8(_a, _b) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -772,6 +830,8 @@ fn __tramp_prefix_test_i16_i16_i16(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i16_i16_i16(_a, _b) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -800,6 +860,8 @@ fn __tramp_prefix_test_i32_i32_i32(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i32_i32_i32(_a, _b) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -828,6 +890,8 @@ fn __tramp_prefix_test_i64_i64_i64(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_i64_i64_i64(_a, _b) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -856,6 +920,8 @@ fn __tramp_prefix_test_isize_isize_isize(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_isize_isize_isize(_a, _b) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -928,6 +994,8 @@ fn __tramp_prefix_test_enum_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_enum_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
@@ -945,6 +1013,8 @@ fn __tramp_prefix_test_unit_enum() -> PrefixEnum {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_unit_enum() } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => PrefixEnum::from(__pattern),
     }
 }
@@ -1036,6 +1106,8 @@ fn __tramp_prefix_test_enum_enum(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_enum_enum(a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => {
             ::core::mem::MaybeUninit::write(__output, __pattern.into());
             ::core::result::Result::Ok(())
@@ -1151,6 +1223,8 @@ fn __tramp_prefix_test_enum_result_enum_error(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_enum_result_enum_error(a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => {
             match __pattern {
                 ::core::result::Result::Ok(__pattern) => {
@@ -1184,6 +1258,8 @@ fn __tramp_prefix_test_struct_unit(_a: PrefixStruct) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_struct_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -1201,6 +1277,8 @@ fn __tramp_prefix_test_unit_struct() -> PrefixStruct {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_unit_struct() } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => {
             type __Result = PrefixStruct;
             __capi::from_inner!(__pattern => __Result)
@@ -1279,6 +1357,8 @@ fn __tramp_prefix_test_ref_struct_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ref_struct_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
@@ -1305,6 +1385,8 @@ fn __tramp_prefix_test_ptr_struct_unit(_a: *const PrefixStruct) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ptr_struct_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -1328,6 +1410,8 @@ fn __tramp_prefix_test_struct_struct(a: PrefixStruct) -> PrefixStruct {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_struct_struct(a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => {
             type __Result = PrefixStruct;
             __capi::from_inner!(__pattern => __Result)
@@ -1429,6 +1513,8 @@ fn __tramp_prefix_test_unit_result_struct_error(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_unit_result_struct_error() } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => {
             match __pattern {
                 ::core::result::Result::Ok(__pattern) => {
@@ -1516,6 +1602,8 @@ fn __tramp_prefix_test_optional_ref_struct(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_optional_ref_struct(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
@@ -1593,6 +1681,8 @@ fn __tramp_prefix_test_optional_mut_ref_struct(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_optional_mut_ref_struct(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
@@ -1670,6 +1760,8 @@ fn __tramp_prefix_test_ref_safestruct_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ref_safestruct_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
@@ -1696,6 +1788,8 @@ fn __tramp_prefix_test_ptr_safestruct_unit(_a: *const PrefixSafeStruct) -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ptr_safestruct_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -1794,6 +1888,8 @@ fn __tramp_prefix_test_unit_result_safestruct_error(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_unit_result_safestruct_error() } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => {
             match __pattern {
                 ::core::result::Result::Ok(__pattern) => {
@@ -1881,6 +1977,8 @@ fn __tramp_prefix_test_ownedptr_u32_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ownedptr_u32_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
@@ -1958,6 +2056,8 @@ fn __tramp_prefix_test_ownedptr_struct_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ownedptr_struct_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
@@ -2035,6 +2135,8 @@ fn __tramp_prefix_test_ownedptr_safestruct_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ownedptr_safestruct_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
@@ -2063,6 +2165,8 @@ fn __tramp_prefix_test_ptr_ptr_ptr_ptr_u32_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ptr_ptr_ptr_ptr_u32_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -2091,6 +2195,8 @@ fn __tramp_prefix_test_ptr_ptr_ptr_ptr_u32_ptr_ptr_ptr_ptr_u32(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_ptr_ptr_ptr_ptr_u32_ptr_ptr_ptr_ptr_u32(a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -2174,6 +2280,8 @@ fn __tramp_prefix_test_slice_u8_unit(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_slice_u8_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
@@ -2282,6 +2390,8 @@ fn __tramp_prefix_ext_error_init(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { self::ext_error_init(out) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
@@ -2393,6 +2503,8 @@ fn __tramp_prefix_ext_error_cleanup(
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { self::ext_error_cleanup(ptr) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
@@ -2425,6 +2537,8 @@ fn __tramp_prefix_test_cfg_inheritance() -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_cfg_inheritance() } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }
@@ -2444,6 +2558,8 @@ fn __tramp_prefix_test_cfg_inheritance2() -> () {
     #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
     #[allow(unused_braces)]
     match { crate::defs::test_cfg_inheritance2() } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
         __pattern => __pattern.into(),
     }
 }

--- a/crates/aranya-capi-codegen/src/ast/expand.rs
+++ b/crates/aranya-capi-codegen/src/ast/expand.rs
@@ -240,6 +240,14 @@ impl Ast {
                 unsafe impl #capi::types::ByValue for #name {}
             });
 
+            items.push(parse_quote! {
+                /// SAFETY: The type is a unit-only enumeration
+                /// with a `#[repr(...)]`, and we check for
+                /// invalid representations, so it is FFI safe.
+                #[automatically_derived]
+                unsafe impl #capi::types::ByMutPtr for #name {}
+            });
+
             // Forward `From` impls needed to implement
             // `ErrorCode`.
             items.push(parse_quote! {
@@ -575,7 +583,7 @@ impl Ast {
                         cast_output_ty(ctx, ty, &pattern, &self.types, &self.idents)
                     }
                 })
-                .unwrap_or_else(|| quote!(#pattern));
+                .unwrap_or_else(|| quote!(#pattern.into()));
 
             let block = if f_is_infallible {
                 // Output params are `*mut T`, which should make

--- a/crates/aranya-capi-codegen/src/ast/expand.rs
+++ b/crates/aranya-capi-codegen/src/ast/expand.rs
@@ -719,6 +719,8 @@ impl Ast {
                     #[allow(clippy::match_single_binding)]
                     #[allow(unused_braces)]
                     match #unsafety { #orig(#(#args),*) } {
+                        #[allow(clippy::useless_conversion)]
+                        #[allow(clippy::unit_arg)]
                         #pattern => { #block }
                     }
                 }


### PR DESCRIPTION
Closes #160

## Changes
- Convert to a "FFI enum" using it's `From` impl when a trampoline function returns the underlying enum type
- When there's an output param, try to convert to a "FFI enum" from it's underlying type by calling `Into::into`
- Add `ByMutPtr` impl for "FFI enums"