### PR TITLE
release: bump aranya-capi-codegen to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-codegen"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -192,7 +192,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aranya-capi-macro",
  "aranya-libc",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-macro"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aranya-capi-codegen",
  "proc-macro2",

--- a/crates/aranya-capi-codegen-test/Cargo.toml
+++ b/crates/aranya-capi-codegen-test/Cargo.toml
@@ -15,14 +15,14 @@ default = []
 test_cfg = []
 
 [dependencies]
-aranya-capi-core = { version = "0.2.1", path = "../aranya-capi-core", features = ["debug"] }
+aranya-capi-core = { version = "0.2.2", path = "../aranya-capi-core", features = ["debug"] }
 buggy = { version = "0.1.0" }
 
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [build-dependencies]
-aranya-capi-codegen = { version = "0.2.2", path = "../aranya-capi-codegen" }
+aranya-capi-codegen = { version = "0.2.3", path = "../aranya-capi-codegen" }
 
 anyhow = { workspace = true }
 quote = { workspace = true }

--- a/crates/aranya-capi-codegen/CHANGELOG.md
+++ b/crates/aranya-capi-codegen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://aranya.github.com/aranya-project/aranya-core/compare/aranya-capi-codegen-v0.2.2...aranya-capi-codegen-v0.2.3) - 2025-04-08
+
+### Other
+
+- (capi-codegen) Enum return types ([#195](https://github.com/aranya-project/aranya-core/pull/195))
+
 ## [0.2.2](https://github.com/aranya-project/aranya-core/compare/aranya-capi-codegen-v0.2.1...aranya-capi-codegen-v0.2.2) - 2025-03-27
 
 ### Other

--- a/crates/aranya-capi-codegen/Cargo.toml
+++ b/crates/aranya-capi-codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-capi-codegen"
 description = "Code generation for Aranya's C API tooling"
-version = "0.2.2"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-capi-core/CHANGELOG.md
+++ b/crates/aranya-capi-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/aranya-project/aranya-core/compare/aranya-capi-core-v0.2.1...aranya-capi-core-v0.2.2) - 2025-04-07
+
+### Other
+
+- updated the following local packages: aranya-capi-macro
+
 ## [0.2.1](https://aranya.github.com/aranya-project/aranya-core/compare/aranya-capi-core-v0.2.0...aranya-capi-core-v0.2.1) - 2025-03-21
 
 ### Other

--- a/crates/aranya-capi-core/Cargo.toml
+++ b/crates/aranya-capi-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-capi-core"
 description = "Aranya's C API tooling"
-version = "0.2.1"
+version = "0.2.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -31,7 +31,7 @@ std = [
 ]
 
 [dependencies]
-aranya-capi-macro = { version = "0.2.0", path = "../aranya-capi-macro", default-features = false }
+aranya-capi-macro = { version = "0.2.2", path = "../aranya-capi-macro", default-features = false }
 aranya-libc = { version = "0.1.1", path = "../aranya-libc", default-features = false }
 buggy = { version = "0.1.0", default-features = false }
 

--- a/crates/aranya-capi-macro/CHANGELOG.md
+++ b/crates/aranya-capi-macro/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/aranya-project/aranya-core/compare/aranya-capi-macro-v0.2.1...aranya-capi-macro-v0.2.2) - 2025-04-07
+
+### Other
+
+- bump `aranya-capi-codegen` to 0.2.3
+- bump `aranya-capi-codegen` to 0.2.2 (#189)
+
 ## [0.2.0](https://github.com/aranya-project/aranya-core/compare/aranya-capi-macro-v0.1.0...aranya-capi-macro-v0.2.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-capi-macro/Cargo.toml
+++ b/crates/aranya-capi-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-capi-macro"
 description = "Proc macros for Aranya's C API tooling"
-version = "0.2.1"
+version = "0.2.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -20,7 +20,7 @@ default = []
 debug = ["aranya-capi-codegen/debug"]
 
 [dependencies]
-aranya-capi-codegen = { version = "0.2.2", path = "../aranya-capi-codegen" }
+aranya-capi-codegen = { version = "0.2.3", path = "../aranya-capi-codegen" }
 
 proc-macro2 = { workspace = true }
 quote = { workspace = true }


### PR DESCRIPTION
Release `aranya-capi-codegen` to use return enums feature from:
https://github.com/aranya-project/aranya-core/pull/195

This PR can be referenced for the last time this crate was released:
https://github.com/aranya-project/aranya-core/pull/189