### PR TITLE
(capi-codegen) Implement ByMutPtr trait for Arrays

### DIFF
--- a/crates/aranya-capi-codegen-test/src/defs.rs
+++ b/crates/aranya-capi-codegen-test/src/defs.rs
@@ -194,6 +194,12 @@ pub fn test_ptr_ptr_ptr_ptr_u32_ptr_ptr_ptr_ptr_u32(
 
 pub fn test_slice_u8_unit(_a: &[u8]) {}
 
+pub fn test_ref_arr_u8_unit(_a: &[u8; 64]) {}
+pub fn test_ref_arr_u8_ret(a: &[u8; 64]) -> [u8; 64] {
+    *a
+}
+pub fn test_mut_ref_arr_u8_unit(_a: &mut [u8; 64]) {}
+
 /// Extended error information.
 #[aranya_capi_core::derive(Init, Cleanup)]
 #[aranya_capi_core::opaque(size = 72, align = 8)]

--- a/crates/aranya-capi-codegen-test/src/generated.rs
+++ b/crates/aranya-capi-codegen-test/src/generated.rs
@@ -2285,6 +2285,244 @@ fn __tramp_prefix_test_slice_u8_unit(
         __pattern => ::core::result::Result::Ok(__pattern.into()),
     }
 }
+#[no_mangle]
+#[::tracing::instrument(
+    level = "trace",
+    fields(_a = %__capi::internal::util::Addr::from_ptr(_a))
+)]
+pub extern "C" fn prefix_test_ref_arr_u8_unit(_a: *const [u8; 64]) -> PrefixError {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match {
+        __tramp_prefix_test_ref_arr_u8_unit(
+            __capi::internal::util::check_valid_input_ty_const_ptr(_a),
+        )
+    } {
+        __pattern => {
+            match __pattern {
+                ::core::result::Result::Ok(__pattern) => {
+                    <PrefixError as __capi::ErrorCode>::SUCCESS
+                }
+                ::core::result::Result::Err(ref err) => {
+                    __capi::internal::error::convert_err(err)
+                }
+            }
+        }
+    }
+}
+#[no_mangle]
+#[::tracing::instrument(
+    level = "trace",
+    fields(
+        _a = %__capi::internal::util::Addr::from_ptr(_a),
+        __ext_err = %__capi::internal::util::Addr::from_ptr(__ext_err)
+    )
+)]
+pub extern "C" fn prefix_test_ref_arr_u8_unit_ext(
+    _a: *const [u8; 64],
+    __ext_err: *mut PrefixExtError,
+) -> PrefixError {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match {
+        __tramp_prefix_test_ref_arr_u8_unit(
+            __capi::internal::util::check_valid_input_ty_const_ptr(_a),
+        )
+    } {
+        __pattern => {
+            match __pattern {
+                ::core::result::Result::Ok(__pattern) => {
+                    <PrefixError as __capi::ErrorCode>::SUCCESS
+                }
+                ::core::result::Result::Err(err) => {
+                    type __ExtErrTy = PrefixExtError;
+                    __capi::internal::error::handle_ext_error(
+                        err,
+                        __capi::from_inner_mut_ptr!(__ext_err => __ExtErrTy),
+                    )
+                }
+            }
+        }
+    }
+}
+#[allow(clippy::unused_unit)]
+fn __tramp_prefix_test_ref_arr_u8_unit(
+    _a: *const [u8; 64],
+) -> ::core::result::Result<(), __capi::InvalidArg<'static>> {
+    let _a: &[u8; 64] = __capi::try_as_ref!(_a);
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match { crate::defs::test_ref_arr_u8_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
+    }
+}
+#[no_mangle]
+#[::tracing::instrument(
+    level = "trace",
+    fields(
+        a = %__capi::internal::util::Addr::from_ptr(a),
+        __output = %__capi::internal::util::Addr::from_ptr(__output)
+    )
+)]
+pub extern "C" fn prefix_test_ref_arr_u8_ret(
+    a: *const [u8; 64],
+    __output: *mut ::core::mem::MaybeUninit<[u8; 64]>,
+) -> PrefixError {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match {
+        __tramp_prefix_test_ref_arr_u8_ret(
+            __capi::internal::util::check_valid_input_ty_const_ptr(a),
+            __capi::internal::util::check_valid_input_ty_mut_ptr(__output),
+        )
+    } {
+        __pattern => {
+            match __pattern {
+                ::core::result::Result::Ok(__pattern) => {
+                    <PrefixError as __capi::ErrorCode>::SUCCESS
+                }
+                ::core::result::Result::Err(ref err) => {
+                    __capi::internal::error::convert_err(err)
+                }
+            }
+        }
+    }
+}
+#[no_mangle]
+#[::tracing::instrument(
+    level = "trace",
+    fields(
+        a = %__capi::internal::util::Addr::from_ptr(a),
+        __output = %__capi::internal::util::Addr::from_ptr(__output),
+        __ext_err = %__capi::internal::util::Addr::from_ptr(__ext_err)
+    )
+)]
+pub extern "C" fn prefix_test_ref_arr_u8_ret_ext(
+    a: *const [u8; 64],
+    __output: *mut ::core::mem::MaybeUninit<[u8; 64]>,
+    __ext_err: *mut PrefixExtError,
+) -> PrefixError {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match {
+        __tramp_prefix_test_ref_arr_u8_ret(
+            __capi::internal::util::check_valid_input_ty_const_ptr(a),
+            __capi::internal::util::check_valid_input_ty_mut_ptr(__output),
+        )
+    } {
+        __pattern => {
+            match __pattern {
+                ::core::result::Result::Ok(__pattern) => {
+                    <PrefixError as __capi::ErrorCode>::SUCCESS
+                }
+                ::core::result::Result::Err(err) => {
+                    type __ExtErrTy = PrefixExtError;
+                    __capi::internal::error::handle_ext_error(
+                        err,
+                        __capi::from_inner_mut_ptr!(__ext_err => __ExtErrTy),
+                    )
+                }
+            }
+        }
+    }
+}
+#[allow(clippy::unused_unit)]
+fn __tramp_prefix_test_ref_arr_u8_ret(
+    a: *const [u8; 64],
+    __output: *mut ::core::mem::MaybeUninit<[u8; 64]>,
+) -> ::core::result::Result<(), __capi::InvalidArg<'static>> {
+    let a: &[u8; 64] = __capi::try_as_ref!(a);
+    #[allow(clippy::let_with_type_underscore)]
+    let __output: &mut ::core::mem::MaybeUninit<[u8; 64]> = {
+        let __output = __capi::try_as_uninit_mut!(__output);
+        __capi::to_inner_mut!(__output)
+    };
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match { crate::defs::test_ref_arr_u8_ret(a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
+        __pattern => {
+            ::core::mem::MaybeUninit::write(__output, __pattern.into());
+            ::core::result::Result::Ok(())
+        }
+    }
+}
+#[no_mangle]
+#[::tracing::instrument(
+    level = "trace",
+    fields(_a = %__capi::internal::util::Addr::from_ptr(_a))
+)]
+pub extern "C" fn prefix_test_mut_ref_arr_u8_unit(_a: *mut [u8; 64]) -> PrefixError {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match {
+        __tramp_prefix_test_mut_ref_arr_u8_unit(
+            __capi::internal::util::check_valid_input_ty_mut_ptr(_a),
+        )
+    } {
+        __pattern => {
+            match __pattern {
+                ::core::result::Result::Ok(__pattern) => {
+                    <PrefixError as __capi::ErrorCode>::SUCCESS
+                }
+                ::core::result::Result::Err(ref err) => {
+                    __capi::internal::error::convert_err(err)
+                }
+            }
+        }
+    }
+}
+#[no_mangle]
+#[::tracing::instrument(
+    level = "trace",
+    fields(
+        _a = %__capi::internal::util::Addr::from_ptr(_a),
+        __ext_err = %__capi::internal::util::Addr::from_ptr(__ext_err)
+    )
+)]
+pub extern "C" fn prefix_test_mut_ref_arr_u8_unit_ext(
+    _a: *mut [u8; 64],
+    __ext_err: *mut PrefixExtError,
+) -> PrefixError {
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match {
+        __tramp_prefix_test_mut_ref_arr_u8_unit(
+            __capi::internal::util::check_valid_input_ty_mut_ptr(_a),
+        )
+    } {
+        __pattern => {
+            match __pattern {
+                ::core::result::Result::Ok(__pattern) => {
+                    <PrefixError as __capi::ErrorCode>::SUCCESS
+                }
+                ::core::result::Result::Err(err) => {
+                    type __ExtErrTy = PrefixExtError;
+                    __capi::internal::error::handle_ext_error(
+                        err,
+                        __capi::from_inner_mut_ptr!(__ext_err => __ExtErrTy),
+                    )
+                }
+            }
+        }
+    }
+}
+#[allow(clippy::unused_unit)]
+fn __tramp_prefix_test_mut_ref_arr_u8_unit(
+    _a: *mut [u8; 64],
+) -> ::core::result::Result<(), __capi::InvalidArg<'static>> {
+    let _a: &mut [u8; 64] = __capi::try_as_mut!(_a);
+    #[allow(clippy::blocks_in_conditions)] #[allow(clippy::match_single_binding)]
+    #[allow(unused_braces)]
+    match { crate::defs::test_mut_ref_arr_u8_unit(_a) } {
+        #[allow(clippy::useless_conversion)]
+        #[allow(clippy::unit_arg)]
+        __pattern => ::core::result::Result::Ok(__pattern.into()),
+    }
+}
 /// Initializes `PrefixExtError`.
 ///
 /// When no longer needed, `out`'s resources must be released

--- a/crates/aranya-capi-core/src/types/allowed.rs
+++ b/crates/aranya-capi-core/src/types/allowed.rs
@@ -81,6 +81,8 @@ unsafe impl<T: Typed> Input for Safe<T> {}
 // this.
 unsafe impl<T> Input for Option<T> {}
 
+unsafe impl<T: Input, const N: usize> Input for [T; N] {}
+
 /// A marker trait for FFI safe result types.
 ///
 /// # Safety
@@ -148,6 +150,8 @@ impl_trait! {
 unsafe impl<T: ByConstPtr> ByConstPtr for *const T {}
 unsafe impl<T: ByConstPtr> ByMutPtr for *const T {}
 
+unsafe impl<T: ByConstPtr, const N: usize> ByConstPtr for [T; N] {}
+
 // Wrapper types.
 unsafe impl<T: Typed> ByConstPtr for Safe<T> {}
 unsafe impl<T: ByConstPtr> ByConstPtr for ManuallyDrop<T> {}
@@ -174,6 +178,8 @@ impl_trait! {
 }
 
 unsafe impl<T: ByMutPtr> ByMutPtr for *mut T {}
+
+unsafe impl<T: ByMutPtr, const N: usize> ByMutPtr for [T; N] {}
 
 // Wrapper types.
 unsafe impl<T: Typed> ByMutPtr for Safe<T> {}


### PR DESCRIPTION
As well as ByInput and ByConstPtr.

To support https://github.com/aranya-project/aranya/pull/183/files#r2036026419