### PR TITLE
aqc: release crypto & ffi crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "aranya-afc-util"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aranya-afc-util",
  "aranya-crypto",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-crypto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aranya-crypto",
  "buggy",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-crypto-ffi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aranya-crypto",
  "aranya-crypto-ffi",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-device-ffi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-envelope-ffi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-fast-channels"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aranya-crypto",
  "aranya-fast-channels",
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-idam-ffi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aranya-crypto",
  "aranya-idam-ffi",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-perspective-ffi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ast"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "thiserror 2.0.7",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-compiler"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-derive"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aranya-policy-lang",
  "prettyplease",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aranya-policy-ifgen-build",
  "aranya-policy-ifgen-macro",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen-build"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-lang"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-module"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-ast",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-vm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-runtime"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aranya-crypto",
  "aranya-libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aranya-capi-macro",
  "aranya-libc",

--- a/crates/aranya-afc-util/CHANGELOG.md
+++ b/crates/aranya-afc-util/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-afc-util-v0.5.0...aranya-afc-util-v0.6.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-crypto, aranya-policy-vm
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-afc-util-v0.4.0...aranya-afc-util-v0.5.0) - 2025-03-19
 
 ### Other

--- a/crates/aranya-afc-util/Cargo.toml
+++ b/crates/aranya-afc-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-afc-util"
 description = "Utilities for using Aranya Fast Channels"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -43,9 +43,9 @@ testing = [
 ]
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-fast-channels = { version = "0.5.0", path = "../aranya-fast-channels", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-fast-channels = { version = "0.6.0", path = "../aranya-fast-channels", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 buggy = { version = "0.1.0", default-features = false }
 indexmap = { version = "2.1", default-features = false, optional = true }
 postcard = { workspace = true, default-features = false, features = ["heapless"] }

--- a/crates/aranya-aqc-util/CHANGELOG.md
+++ b/crates/aranya-aqc-util/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/aranya-project/aranya-core/releases/tag/aranya-aqc-util-v0.1.0) - 2025-04-10
+
+### Other
+
+- implement aranya-crypto support, FFI, handler (#184)

--- a/crates/aranya-aqc-util/Cargo.toml
+++ b/crates/aranya-aqc-util/Cargo.toml
@@ -37,8 +37,8 @@ testing = [
 ]
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 buggy = { version = "0.1.0", default-features = false }
 postcard = { workspace = true, default-features = false, features = ["heapless"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }
@@ -49,7 +49,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 aranya-aqc-util = { path = ".", features = ["testing"] }
 
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["getrandom"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false, features = ["getrandom"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/aranya-capi-codegen-test/Cargo.toml
+++ b/crates/aranya-capi-codegen-test/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 test_cfg = []
 
 [dependencies]
-aranya-capi-core = { version = "0.2.2", path = "../aranya-capi-core", features = ["debug"] }
+aranya-capi-core = { version = "0.2.3", path = "../aranya-capi-core", features = ["debug"] }
 buggy = { version = "0.1.0" }
 
 thiserror = { workspace = true }

--- a/crates/aranya-capi-core/CHANGELOG.md
+++ b/crates/aranya-capi-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/aranya-project/aranya-core/compare/aranya-capi-core-v0.2.2...aranya-capi-core-v0.2.3) - 2025-04-10
+
+### Other
+
+- (capi-codegen) Implement ByMutPtr trait for Arrays ([#205](https://github.com/aranya-project/aranya-core/pull/205))
+
 ## [0.2.2](https://github.com/aranya-project/aranya-core/compare/aranya-capi-core-v0.2.1...aranya-capi-core-v0.2.2) - 2025-04-07
 
 ### Other

--- a/crates/aranya-capi-core/Cargo.toml
+++ b/crates/aranya-capi-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-capi-core"
 description = "Aranya's C API tooling"
-version = "0.2.2"
+version = "0.2.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-crypto-ffi/CHANGELOG.md
+++ b/crates/aranya-crypto-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-ffi-v0.5.0...aranya-crypto-ffi-v0.6.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-crypto, aranya-policy-vm
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-ffi-v0.4.0...aranya-crypto-ffi-v0.5.0) - 2025-03-19
 
 ### Other

--- a/crates/aranya-crypto-ffi/Cargo.toml
+++ b/crates/aranya-crypto-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-crypto-ffi"
 description = "The crypto FFI for Aranya Policy"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -41,8 +41,8 @@ testing = [
 ]
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 postcard = { workspace = true, default-features = false, features = ["heapless"] }
 serde = { workspace = true, default-features = false, features = ["derive"], optional = true }

--- a/crates/aranya-crypto/CHANGELOG.md
+++ b/crates/aranya-crypto/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-v0.4.0...aranya-crypto-v0.5.0) - 2025-04-10
+
+### Other
+
+- implement aranya-crypto support, FFI, handler (#184)
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-v0.3.0...aranya-crypto-v0.4.0) - 2025-03-19
 
 ### Other
 
 - rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
 
-## [0.3.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-v0.2.1...aranya-crypto-v0.3.0) - 2025-03-11
+## [0.3.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-v0.3.0...aranya-crypto-v0.3.0) - 2025-03-11
 
 ### Other
 

--- a/crates/aranya-crypto/CHANGELOG.md
+++ b/crates/aranya-crypto/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
 
-## [0.3.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-v0.3.0...aranya-crypto-v0.3.0) - 2025-03-11
+## [0.3.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-v0.2.1...aranya-crypto-v0.3.0) - 2025-03-11
 
 ### Other
 

--- a/crates/aranya-crypto/Cargo.toml
+++ b/crates/aranya-crypto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-crypto"
 description = "The Aranya Cryptography Engine"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-device-ffi/CHANGELOG.md
+++ b/crates/aranya-device-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-device-ffi-v0.5.0...aranya-device-ffi-v0.6.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-crypto, aranya-policy-vm
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-device-ffi-v0.4.0...aranya-device-ffi-v0.5.0) - 2025-03-19
 
 ### Other

--- a/crates/aranya-device-ffi/Cargo.toml
+++ b/crates/aranya-device-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-device-ffi"
 description = "The device FFI for Aranya Policy"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -24,8 +24,8 @@ std = ["alloc"]
 testing = []
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false }
-aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false }
+aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 aranya-crypto = { path = "../aranya-crypto", features = ["getrandom"] }

--- a/crates/aranya-envelope-ffi/CHANGELOG.md
+++ b/crates/aranya-envelope-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-envelope-ffi-v0.5.0...aranya-envelope-ffi-v0.6.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-crypto, aranya-policy-vm
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-envelope-ffi-v0.4.0...aranya-envelope-ffi-v0.5.0) - 2025-03-19
 
 ### Other

--- a/crates/aranya-envelope-ffi/Cargo.toml
+++ b/crates/aranya-envelope-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-envelope-ffi"
 description = "The envelope FFI for Aranya Policy"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -28,8 +28,8 @@ std = [
 ]
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/aranya-fast-channels/CHANGELOG.md
+++ b/crates/aranya-fast-channels/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-fast-channels-v0.5.0...aranya-fast-channels-v0.6.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-crypto
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-fast-channels-v0.4.0...aranya-fast-channels-v0.5.0) - 2025-03-19
 
 ### Other

--- a/crates/aranya-fast-channels/Cargo.toml
+++ b/crates/aranya-fast-channels/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-fast-channels"
 description = "High throughput, low latency encryption protected by Aranya Policy"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -79,7 +79,7 @@ core_intrinsics = []
 try_find = []
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["getrandom"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false, features = ["getrandom"] }
 buggy = { version = "0.1.0", default-features = false }
 
 byteorder = { version = "1", default-features = false }

--- a/crates/aranya-idam-ffi/CHANGELOG.md
+++ b/crates/aranya-idam-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-idam-ffi-v0.5.0...aranya-idam-ffi-v0.6.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-crypto, aranya-policy-vm
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-idam-ffi-v0.4.0...aranya-idam-ffi-v0.5.0) - 2025-03-19
 
 ### Other

--- a/crates/aranya-idam-ffi/Cargo.toml
+++ b/crates/aranya-idam-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-idam-ffi"
 description = "The IDAM FFI for Aranya Policy"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -33,8 +33,8 @@ std = [
 testing = []
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", features = ["derive"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm", features = ["derive"] }
 postcard = { workspace = true, default-features = false, features = ["heapless"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/aranya-model/Cargo.toml
+++ b/crates/aranya-model/Cargo.toml
@@ -8,11 +8,11 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "fs-keystore"] }
-aranya-policy-compiler = { version = "0.5.0", path = "../aranya-policy-compiler" }
-aranya-policy-lang = { version = "0.2.0", path = "../aranya-policy-lang" }
-aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm" }
-aranya-runtime = { version = "0.5.0", path = "../aranya-runtime", features = ["testing"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "fs-keystore"] }
+aranya-policy-compiler = { version = "0.6.0", path = "../aranya-policy-compiler" }
+aranya-policy-lang = { version = "0.3.0", path = "../aranya-policy-lang" }
+aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm" }
+aranya-runtime = { version = "0.6.0", path = "../aranya-runtime", features = ["testing"] }
 
 anyhow = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aranya-perspective-ffi/CHANGELOG.md
+++ b/crates/aranya-perspective-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-perspective-ffi-v0.5.0...aranya-perspective-ffi-v0.6.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-crypto, aranya-policy-vm
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-perspective-ffi-v0.4.0...aranya-perspective-ffi-v0.5.0) - 2025-03-19
 
 ### Other

--- a/crates/aranya-perspective-ffi/Cargo.toml
+++ b/crates/aranya-perspective-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-perspective-ffi"
 description = "The perspective FFI for Aranya Policy"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -26,8 +26,8 @@ std = []
 testing = []
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false }
-aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false }
+aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 aranya-crypto = { path = "../aranya-crypto", features = ["getrandom"] }

--- a/crates/aranya-policy-ast/CHANGELOG.md
+++ b/crates/aranya-policy-ast/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ast-v0.2.0...aranya-policy-ast-v0.3.0) - 2025-04-10
+
+### Other
+
+- Close [#110](https://github.com/aranya-project/aranya-core/pull/110): Add match expressions. ([#119](https://github.com/aranya-project/aranya-core/pull/119))
+
 ## [0.2.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ast-v0.1.0...aranya-policy-ast-v0.2.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-policy-ast/Cargo.toml
+++ b/crates/aranya-policy-ast/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ast"
 description = "The Aranya Policy Language AST"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-policy-compiler/CHANGELOG.md
+++ b/crates/aranya-policy-compiler/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-compiler-v0.5.0...aranya-policy-compiler-v0.6.0) - 2025-04-10
+
+### Other
+
+- allow block expressions in `if` expressions. (#176)
+- Close [#103](https://github.com/aranya-project/aranya-core/pull/103): `if`, `match` statements now limit scope to their blocks. ([#109](https://github.com/aranya-project/aranya-core/pull/109))
+- Close [#110](https://github.com/aranya-project/aranya-core/pull/110): Add match expressions. ([#119](https://github.com/aranya-project/aranya-core/pull/119))
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-compiler-v0.4.0...aranya-policy-compiler-v0.5.0) - 2025-03-19
 
 ### Other

--- a/crates/aranya-policy-compiler/Cargo.toml
+++ b/crates/aranya-policy-compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-compiler"
 description = "The Aranya Policy Compiler"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -15,9 +15,9 @@ workspace = true
 default = []
 
 [dependencies]
-aranya-policy-ast = { version = "0.2.0", path = "../aranya-policy-ast" }
-aranya-policy-lang = { version = "0.2.0", path = "../aranya-policy-lang" }
-aranya-policy-module = { version = "0.5.0", path = "../aranya-policy-module", features = ["std"] }
+aranya-policy-ast = { version = "0.3.0", path = "../aranya-policy-ast" }
+aranya-policy-lang = { version = "0.3.0", path = "../aranya-policy-lang" }
+aranya-policy-module = { version = "0.6.0", path = "../aranya-policy-module", features = ["std"] }
 buggy = { version = "0.1.0", features = ["std"] }
 
 ciborium = { version = "0.2" }

--- a/crates/aranya-policy-derive/CHANGELOG.md
+++ b/crates/aranya-policy-derive/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-derive-v0.3.0...aranya-policy-derive-v0.4.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-policy-lang
+
 ## [0.3.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-derive-v0.2.0...aranya-policy-derive-v0.3.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-policy-derive/Cargo.toml
+++ b/crates/aranya-policy-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-derive"
 description = "Proc macros for generating Aranya Policy Langauge FFIs"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ proc-macro = true
 default = []
 
 [dependencies]
-aranya-policy-lang = { version = "0.2.0", path = "../aranya-policy-lang" }
+aranya-policy-lang = { version = "0.3.0", path = "../aranya-policy-lang" }
 
 prettyplease = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/crates/aranya-policy-ifgen-build/CHANGELOG.md
+++ b/crates/aranya-policy-ifgen-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-build-v0.2.0...aranya-policy-ifgen-build-v0.3.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-policy-ast, aranya-policy-lang
+
 ## [0.2.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-build-v0.1.0...aranya-policy-ifgen-build-v0.2.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-policy-ifgen-build/Cargo.toml
+++ b/crates/aranya-policy-ifgen-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ifgen-build"
 description = "Code generator for aranya-policy-ifgen"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -12,8 +12,8 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aranya-policy-ast = { version = "0.2.0", path = "../aranya-policy-ast" }
-aranya-policy-lang = { version = "0.2.0", path = "../aranya-policy-lang" }
+aranya-policy-ast = { version = "0.3.0", path = "../aranya-policy-ast" }
+aranya-policy-lang = { version = "0.3.0", path = "../aranya-policy-lang" }
 
 anyhow = { workspace = true }
 prettyplease = { workspace = true }

--- a/crates/aranya-policy-ifgen/CHANGELOG.md
+++ b/crates/aranya-policy-ifgen/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.5.0...aranya-policy-ifgen-v0.6.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-policy-vm
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.4.0...aranya-policy-ifgen-v0.5.0) - 2025-03-19
 
 ### Other
 
 - rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
 
-## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.3.1...aranya-policy-ifgen-v0.4.0) - 2025-03-11
+## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.4.0...aranya-policy-ifgen-v0.4.0) - 2025-03-11
 
 ### Other
 

--- a/crates/aranya-policy-ifgen/CHANGELOG.md
+++ b/crates/aranya-policy-ifgen/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
 
-## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.4.0...aranya-policy-ifgen-v0.4.0) - 2025-03-11
+## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.3.1...aranya-policy-ifgen-v0.4.0) - 2025-03-11
 
 ### Other
 

--- a/crates/aranya-policy-ifgen/Cargo.toml
+++ b/crates/aranya-policy-ifgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ifgen"
 description = "Tools for generating Rust interfaces to Aranya Policies"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -19,8 +19,8 @@ serde = [
 
 [dependencies]
 aranya-policy-ifgen-macro = { version = "0.3.0", path = "../aranya-policy-ifgen-macro" }
-aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm" }
-aranya-runtime = { version = "0.5.0", path = "../aranya-runtime" }
+aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm" }
+aranya-runtime = { version = "0.6.0", path = "../aranya-runtime" }
 
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/crates/aranya-policy-lang/CHANGELOG.md
+++ b/crates/aranya-policy-lang/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-lang-v0.2.0...aranya-policy-lang-v0.3.0) - 2025-04-10
+
+### Other
+
+- allow block expressions in `if` expressions. (#176)
+- Close [#110](https://github.com/aranya-project/aranya-core/pull/110): Add match expressions. ([#119](https://github.com/aranya-project/aranya-core/pull/119))
+
 ## [0.2.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-lang-v0.1.0...aranya-policy-lang-v0.2.0) - 2025-03-11
 
 ### Other

--- a/crates/aranya-policy-lang/Cargo.toml
+++ b/crates/aranya-policy-lang/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-lang"
 description = "The Aranya Policy Language parser"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ default = []
 buggy = { version = "0.1.0", features = ["std"] }
 # `std` is required because bin/parser-explorer uses `clap` which
 # requires it for arg parsing.
-aranya-policy-ast = { version = "0.2.0", path = "../aranya-policy-ast", features = ["std"] }
+aranya-policy-ast = { version = "0.3.0", path = "../aranya-policy-ast", features = ["std"] }
 
 anyhow = { workspace = true }
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/aranya-policy-module/CHANGELOG.md
+++ b/crates/aranya-policy-module/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-module-v0.5.0...aranya-policy-module-v0.6.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-crypto, aranya-policy-ast
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-module-v0.4.0...aranya-policy-module-v0.5.0) - 2025-03-19
 
 ### Other

--- a/crates/aranya-policy-module/Cargo.toml
+++ b/crates/aranya-policy-module/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-module"
 description = "The Aranya Policy module format"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -9,8 +9,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false }
-aranya-policy-ast = { version = "0.2.0", path = "../aranya-policy-ast" }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false }
+aranya-policy-ast = { version = "0.3.0", path = "../aranya-policy-ast" }
 
 proptest = { workspace = true, default-features = false, features = ["std"], optional = true }
 proptest-derive = { workspace = true, optional = true }

--- a/crates/aranya-policy-vm-explorer/Cargo.toml
+++ b/crates/aranya-policy-vm-explorer/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 default = []
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto" }
-aranya-policy-compiler = { version = "0.5.0", path = "../aranya-policy-compiler" }
-aranya-policy-lang = { version = "0.2.0", path = "../aranya-policy-lang" }
-aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm", features = ["std"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto" }
+aranya-policy-compiler = { version = "0.6.0", path = "../aranya-policy-compiler" }
+aranya-policy-lang = { version = "0.3.0", path = "../aranya-policy-lang" }
+aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm", features = ["std"] }
 
 anyhow = { workspace = true }
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/aranya-policy-vm/CHANGELOG.md
+++ b/crates/aranya-policy-vm/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
 
-## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.4.0...aranya-policy-vm-v0.4.0) - 2025-03-11
+## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.3.1...aranya-policy-vm-v0.4.0) - 2025-03-11
 
 ### Other
 

--- a/crates/aranya-policy-vm/CHANGELOG.md
+++ b/crates/aranya-policy-vm/CHANGELOG.md
@@ -7,13 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.5.0...aranya-policy-vm-v0.6.0) - 2025-04-10
+
+### Other
+
+- allow block expressions in `if` expressions. (#176)
+- Close [#110](https://github.com/aranya-project/aranya-core/pull/110): Add match expressions. ([#119](https://github.com/aranya-project/aranya-core/pull/119))
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.4.0...aranya-policy-vm-v0.5.0) - 2025-03-19
 
 ### Other
 
 - rename Aranya "user" to "device" ([#122](https://github.com/aranya-project/aranya-core/pull/122))
 
-## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.3.1...aranya-policy-vm-v0.4.0) - 2025-03-11
+## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.4.0...aranya-policy-vm-v0.4.0) - 2025-03-11
 
 ### Other
 

--- a/crates/aranya-policy-vm/Cargo.toml
+++ b/crates/aranya-policy-vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-vm"
 description = "The Aranya Policy Virtual Machine"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -30,10 +30,10 @@ std = [
 bench = ["dep:table_formatter", "std"]
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false }
-aranya-policy-ast = { version = "0.2.0", path = "../aranya-policy-ast" }
-aranya-policy-derive = { version = "0.3.0", path = "../aranya-policy-derive" }
-aranya-policy-module = { version = "0.5.0", path = "../aranya-policy-module" }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false }
+aranya-policy-ast = { version = "0.3.0", path = "../aranya-policy-ast" }
+aranya-policy-derive = { version = "0.4.0", path = "../aranya-policy-derive" }
+aranya-policy-module = { version = "0.6.0", path = "../aranya-policy-module" }
 buggy = { version = "0.1.0", features = ["alloc"] }
 
 heapless = { workspace = true }

--- a/crates/aranya-quic-syncer/Cargo.toml
+++ b/crates/aranya-quic-syncer/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", features = ["std"] }
-aranya-runtime = { version = "0.5.0", path = "../aranya-runtime", features = ["std"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", features = ["std"] }
+aranya-runtime = { version = "0.6.0", path = "../aranya-runtime", features = ["std"] }
 buggy = { version = "0.1.0", features = ["std"] }
 
 heapless = { workspace = true, features = ["serde"] }

--- a/crates/aranya-runtime/CHANGELOG.md
+++ b/crates/aranya-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-runtime-v0.5.0...aranya-runtime-v0.6.0) - 2025-04-10
+
+### Other
+
+- updated the following local packages: aranya-crypto, aranya-policy-vm
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-runtime-v0.4.0...aranya-runtime-v0.5.0) - 2025-03-19
 
 ### Other

--- a/crates/aranya-runtime/Cargo.toml
+++ b/crates/aranya-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-runtime"
 description = "The Aranya core runtime"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -14,9 +14,9 @@ workspace = true
 [dependencies]
 buggy = { version = "0.1.0", features = ["alloc"] }
 # `aranya-crypto` enables `getrandom` by default.
-aranya-crypto = { version = "0.4.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "rand_compat"] }
+aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "rand_compat"] }
 aranya-libc = { version = "0.1.1", path = "../aranya-libc", default-features = false, optional = true }
-aranya-policy-vm = { version = "0.5.0", path = "../aranya-policy-vm" }
+aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm" }
 
 heapless = { workspace = true, features = ["serde"] }
 postcard = { workspace = true, features = ["alloc"] }
@@ -27,7 +27,7 @@ tracing = { workspace = true }
 vec1 = { version = "1.10.1", default-features = false, features = ["serde"] }
 
 # Used by `testing`.
-aranya-policy-module = { version = "0.5.0", path = "../aranya-policy-module", optional = true }
+aranya-policy-module = { version = "0.6.0", path = "../aranya-policy-module", optional = true }
 serde_json = { version = "1.0.117", default-features = false, features = ["alloc"], optional = true }
 
 # graphviz


### PR DESCRIPTION
Release AQC crypto & ffi crates.

Generated this PR with:
`release-plz update`

There's a good chance there could be breaking changes that weren't caught by the tool.

AQC crypto & ffi PR where changes are that are being released (plus whatever else changed on the `main` branch since the last release):
https://github.com/aranya-project/aranya-core/pull/184