### PR TITLE
chore: fix vet config and remove unused path dep versions

### DIFF
--- a/crates/aranya-aqc-util/Cargo.toml
+++ b/crates/aranya-aqc-util/Cargo.toml
@@ -49,7 +49,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 aranya-aqc-util = { path = ".", features = ["testing"] }
 
-aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false, features = ["getrandom"] }
+aranya-crypto = { path = "../aranya-crypto", default-features = false, features = ["getrandom"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/aranya-capi-codegen-test/Cargo.toml
+++ b/crates/aranya-capi-codegen-test/Cargo.toml
@@ -15,14 +15,14 @@ default = []
 test_cfg = []
 
 [dependencies]
-aranya-capi-core = { version = "0.2.3", path = "../aranya-capi-core", features = ["debug"] }
+aranya-capi-core = { path = "../aranya-capi-core", features = ["debug"] }
 buggy = { version = "0.1.0" }
 
 thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [build-dependencies]
-aranya-capi-codegen = { version = "0.2.3", path = "../aranya-capi-codegen" }
+aranya-capi-codegen = { path = "../aranya-capi-codegen" }
 
 anyhow = { workspace = true }
 quote = { workspace = true }

--- a/crates/aranya-model/Cargo.toml
+++ b/crates/aranya-model/Cargo.toml
@@ -8,11 +8,11 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "fs-keystore"] }
-aranya-policy-compiler = { version = "0.6.0", path = "../aranya-policy-compiler" }
-aranya-policy-lang = { version = "0.3.0", path = "../aranya-policy-lang" }
-aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm" }
-aranya-runtime = { version = "0.6.0", path = "../aranya-runtime", features = ["testing"] }
+aranya-crypto = { path = "../aranya-crypto", default-features = false, features = ["alloc", "fs-keystore"] }
+aranya-policy-compiler = { path = "../aranya-policy-compiler" }
+aranya-policy-lang = { path = "../aranya-policy-lang" }
+aranya-policy-vm = { path = "../aranya-policy-vm" }
+aranya-runtime = { path = "../aranya-runtime", features = ["testing"] }
 
 anyhow = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aranya-policy-vm-explorer/Cargo.toml
+++ b/crates/aranya-policy-vm-explorer/Cargo.toml
@@ -14,10 +14,10 @@ workspace = true
 default = []
 
 [dependencies]
-aranya-crypto = { version = "0.5.0", path = "../aranya-crypto" }
-aranya-policy-compiler = { version = "0.6.0", path = "../aranya-policy-compiler" }
-aranya-policy-lang = { version = "0.3.0", path = "../aranya-policy-lang" }
-aranya-policy-vm = { version = "0.6.0", path = "../aranya-policy-vm", features = ["std"] }
+aranya-crypto = { path = "../aranya-crypto" }
+aranya-policy-compiler = { path = "../aranya-policy-compiler" }
+aranya-policy-lang = { path = "../aranya-policy-lang" }
+aranya-policy-vm = { path = "../aranya-policy-vm", features = ["std"] }
 
 anyhow = { workspace = true }
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/aranya-quic-syncer/Cargo.toml
+++ b/crates/aranya-quic-syncer/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aranya-crypto = { version = "0.5.0", path = "../aranya-crypto", features = ["std"] }
-aranya-runtime = { version = "0.6.0", path = "../aranya-runtime", features = ["std"] }
+aranya-crypto = { path = "../aranya-crypto", features = ["std"] }
+aranya-runtime = { path = "../aranya-runtime", features = ["std"] }
 buggy = { version = "0.1.0", features = ["std"] }
 
 heapless = { workspace = true, features = ["serde"] }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -34,6 +34,9 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 [policy.aranya-afc-util]
 audit-as-crates-io = false
 
+[policy.aranya-aqc-util]
+audit-as-crates-io = false
+
 [policy.aranya-capi-codegen]
 audit-as-crates-io = false
 


### PR DESCRIPTION
Fixes `cargo vet` check: https://github.com/aranya-project/aranya-core/actions/runs/14389133920/job/40351787630

Removes `version` from `path` dependencies in crates that have not been published and from `dev-dependencies`.