### PR TITLE
Switch to 32 byte IDs

### DIFF
--- a/crates/aranya-crypto/examples/hsm/hsm.rs
+++ b/crates/aranya-crypto/examples/hsm/hsm.rs
@@ -13,7 +13,7 @@ use aranya_crypto::{
     hash::tuple_hash,
     import::{Import, ImportError},
     keys::{PublicKey, SecretKey},
-    rust::{Aes256Gcm, Sha512},
+    rust::{Aes256Gcm, Sha256},
     signer::PkError,
     Rng,
 };
@@ -151,7 +151,7 @@ struct AuthData<'a> {
 // Signer impl.
 impl Hsm {
     fn signer_key_id(pk: &VerifyingKey) -> KeyId {
-        let id = tuple_hash::<Sha512, _>(["HSM-v1".as_bytes(), "Ed25519".as_bytes(), &pk.export()])
+        let id = tuple_hash::<Sha256, _>(["HSM-v1".as_bytes(), "Ed25519".as_bytes(), &pk.export()])
             .into_array()
             .into();
         KeyId(id)

--- a/crates/aranya-crypto/examples/hsm/main.rs
+++ b/crates/aranya-crypto/examples/hsm/main.rs
@@ -60,7 +60,7 @@ impl Csprng for HsmEngine {
 
 impl CipherSuite for HsmEngine {
     type Aead = rust::Aes256Gcm;
-    type Hash = rust::Sha512;
+    type Hash = rust::Sha256;
     type Kdf = rust::HkdfSha512;
     type Kem = rust::DhKemP256HkdfSha256;
     type Mac = rust::HmacSha512;

--- a/crates/aranya-crypto/src/ciphersuite.rs
+++ b/crates/aranya-crypto/src/ciphersuite.rs
@@ -28,7 +28,7 @@ use crate::{
     kem::{Kem, KemId},
     mac::{Mac, MacId},
     signer::{Signer, SignerId},
-    typenum::U64,
+    typenum::{U32, U64},
 };
 
 /// The cryptographic primitives used by the cryptography engine.
@@ -54,7 +54,7 @@ pub trait CipherSuite {
     /// See [`Aead`] for more information.
     type Aead: Aead + IndCca2;
     /// See [`Hash`] for more information.
-    type Hash: Hash<DigestSize = U64>;
+    type Hash: Hash<DigestSize = U32>;
     /// See [`Kdf`] for more information.
     type Kdf: Kdf;
     /// See [`Kem`] for more information.
@@ -118,14 +118,14 @@ mod tests {
         use crate::{
             bearssl::{
                 Aes256Gcm, DhKemP256HkdfSha256, DhKemP521HkdfSha512, HkdfSha256, HkdfSha384,
-                HkdfSha512, HmacSha512, Sha512, P256, P384, P521,
+                HkdfSha512, HmacSha512, Sha256, P256, P384, P521,
             },
             test_util::{test_ciphersuite, TestCs},
         };
 
         test_ciphersuite!(p256, TestCs<
             Aes256Gcm,
-            Sha512,
+            Sha256,
             HkdfSha256,
             DhKemP256HkdfSha256,
             HmacSha512,
@@ -133,7 +133,7 @@ mod tests {
         >);
         test_ciphersuite!(p384, TestCs<
             Aes256Gcm,
-            Sha512,
+            Sha256,
             HkdfSha384,
             DhKemP256HkdfSha256, // DhKemP384HkdfSha384 does not exist
             HmacSha512,
@@ -141,7 +141,7 @@ mod tests {
         >);
         test_ciphersuite!(p521, TestCs<
             Aes256Gcm,
-            Sha512,
+            Sha256,
             HkdfSha512,
             DhKemP521HkdfSha512,
             HmacSha512,
@@ -152,7 +152,7 @@ mod tests {
     mod rust {
         use crate::{
             rust::{
-                Aes256Gcm, DhKemP256HkdfSha256, HkdfSha256, HkdfSha384, HmacSha512, Sha512, P256,
+                Aes256Gcm, DhKemP256HkdfSha256, HkdfSha256, HkdfSha384, HmacSha512, Sha256, P256,
                 P384,
             },
             test_util::{test_ciphersuite, TestCs},
@@ -160,7 +160,7 @@ mod tests {
 
         test_ciphersuite!(p256, TestCs<
             Aes256Gcm,
-            Sha512,
+            Sha256,
             HkdfSha256,
             DhKemP256HkdfSha256,
             HmacSha512,
@@ -168,7 +168,7 @@ mod tests {
         >);
         test_ciphersuite!(p384, TestCs<
             Aes256Gcm,
-            Sha512,
+            Sha256,
             HkdfSha384,
             DhKemP256HkdfSha256, // DhKemP384HkdfSha384 does not exist
             HmacSha512,

--- a/crates/aranya-crypto/src/default.rs
+++ b/crates/aranya-crypto/src/default.rs
@@ -38,7 +38,7 @@ pub struct DefaultCipherSuite;
 
 impl CipherSuite for DefaultCipherSuite {
     type Aead = crate::rust::Aes256Gcm;
-    type Hash = crate::rust::Sha512;
+    type Hash = crate::rust::Sha256;
     type Kdf = crate::rust::HkdfSha512;
     type Kem = crate::rust::DhKemP256HkdfSha256;
     type Mac = crate::rust::HmacSha512;

--- a/crates/aranya-crypto/src/id.rs
+++ b/crates/aranya-crypto/src/id.rs
@@ -17,7 +17,7 @@ use serde::{
     ser::SerializeTuple,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-pub use spideroak_base58::{DecodeError, String64, ToBase58};
+pub use spideroak_base58::{DecodeError, String32, ToBase58};
 
 use crate::{
     ciphersuite::SuiteIds,
@@ -26,7 +26,7 @@ use crate::{
     hash::tuple_hash,
     signer::PkError,
     subtle::{Choice, ConstantTimeEq},
-    typenum::U64,
+    typenum::U32,
     CipherSuite,
 };
 
@@ -34,7 +34,7 @@ use crate::{
 #[repr(C)]
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, MaxSize)]
 #[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
-pub struct Id([u8; 64]);
+pub struct Id([u8; 32]);
 
 impl Id {
     /// Derives an [`Id`] from the hash of some data.
@@ -53,18 +53,18 @@ impl Id {
     /// Same as [`Default`], but const.
     #[inline]
     pub const fn default() -> Self {
-        Self([0u8; 64])
+        Self([0u8; 32])
     }
 
     /// Creates itself from a byte array.
     #[inline]
-    pub const fn from_bytes(bytes: [u8; 64]) -> Self {
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
         Self(bytes)
     }
 
     /// Creates a random ID.
     pub fn random<R: Csprng>(rng: &mut R) -> Self {
-        let mut b = [0u8; 64];
+        let mut b = [0u8; 32];
         rng.fill_bytes(&mut b);
         Self(b)
     }
@@ -77,20 +77,20 @@ impl Id {
 
     /// Returns the [`Id`] as a byte array.
     #[inline]
-    pub const fn as_array(&self) -> &[u8; 64] {
+    pub const fn as_array(&self) -> &[u8; 32] {
         &self.0
     }
 
     /// Decode the [`Id`] from a base58 string.
     pub fn decode<T: AsRef<[u8]>>(s: T) -> Result<Self, DecodeError> {
-        String64::decode(s).map(Self::from)
+        String32::decode(s).map(Self::from)
     }
 }
 
 impl Default for Id {
     #[inline]
     fn default() -> Self {
-        Self([0u8; 64])
+        Self([0u8; 32])
     }
 }
 
@@ -108,21 +108,21 @@ impl AsRef<[u8]> for Id {
     }
 }
 
-impl From<GenericArray<u8, U64>> for Id {
+impl From<GenericArray<u8, U32>> for Id {
     #[inline]
-    fn from(id: GenericArray<u8, U64>) -> Self {
+    fn from(id: GenericArray<u8, U32>) -> Self {
         Self(id.into())
     }
 }
 
-impl From<[u8; 64]> for Id {
+impl From<[u8; 32]> for Id {
     #[inline]
-    fn from(id: [u8; 64]) -> Self {
+    fn from(id: [u8; 32]) -> Self {
         Self(id)
     }
 }
 
-impl From<Id> for [u8; 64] {
+impl From<Id> for [u8; 32] {
     #[inline]
     fn from(id: Id) -> Self {
         id.0
@@ -150,7 +150,7 @@ impl Display for Id {
 }
 
 impl ToBase58 for Id {
-    type Output = String64;
+    type Output = String32;
 
     fn to_base58(&self) -> Self::Output {
         self.0.to_base58()
@@ -272,7 +272,7 @@ macro_rules! custom_id {
 
             /// Returns itself as a byte array.
             #[inline]
-            pub const fn as_array(&self) -> &[u8; 64] {
+            pub const fn as_array(&self) -> &[u8; 32] {
                 self.0.as_array()
             }
 
@@ -304,23 +304,23 @@ macro_rules! custom_id {
             }
         }
 
-        impl ::core::convert::From<$crate::generic_array::GenericArray<u8, $crate::typenum::U64>>
+        impl ::core::convert::From<$crate::generic_array::GenericArray<u8, $crate::typenum::U32>>
             for $name
         {
             #[inline]
-            fn from(id: $crate::generic_array::GenericArray<u8, $crate::typenum::U64>) -> Self {
+            fn from(id: $crate::generic_array::GenericArray<u8, $crate::typenum::U32>) -> Self {
                 Self(id.into())
             }
         }
 
-        impl ::core::convert::From<[u8; 64]> for $name {
+        impl ::core::convert::From<[u8; 32]> for $name {
             #[inline]
-            fn from(id: [u8; 64]) -> Self {
+            fn from(id: [u8; 32]) -> Self {
                 Self(id.into())
             }
         }
 
-        impl ::core::convert::From<$name> for [u8; 64] {
+        impl ::core::convert::From<$name> for [u8; 32] {
             #[inline]
             fn from(id: $name) -> Self {
                 id.0.into()
@@ -362,7 +362,7 @@ macro_rules! custom_id {
         }
 
         impl $crate::id::ToBase58 for $name {
-            type Output = $crate::id::String64;
+            type Output = $crate::id::String32;
 
             fn to_base58(&self) -> Self::Output {
                 $crate::id::ToBase58::to_base58(&self.0)

--- a/crates/aranya-crypto/src/keystore/fs_keystore/store.rs
+++ b/crates/aranya-crypto/src/keystore/fs_keystore/store.rs
@@ -12,7 +12,7 @@ use rustix::{
     io::{self, Errno},
     path::Arg,
 };
-use spideroak_base58::{String64, ToBase58};
+use spideroak_base58::{String32, ToBase58};
 
 use super::error::{Error, RootDeleted, UnexpectedEof};
 use crate::{
@@ -162,7 +162,7 @@ impl KeyStore for Store {
 /// The path to an entry, relative to the root in [`Store`].
 // TODO(eric): the resulting string might be cause us to exceed
 // PATH_MAX, should we truncate it?
-struct Alias(String64);
+struct Alias(String32);
 
 impl Deref for Alias {
     type Target = str;

--- a/crates/aranya-crypto/src/test_util/engine.rs
+++ b/crates/aranya-crypto/src/test_util/engine.rs
@@ -518,7 +518,7 @@ pub fn test_group_key_open_wrong_context<E: Engine>(eng: &mut E) {
         "wrong `parent`",
         Context {
             label: "some label",
-            parent: [1u8; 64].into(),
+            parent: [1u8; 32].into(),
             author_sign_pk: &author_pk1,
         }
     );

--- a/crates/aranya-crypto/src/test_util/mod.rs
+++ b/crates/aranya-crypto/src/test_util/mod.rs
@@ -42,7 +42,7 @@ use crate::{
     mac::{Mac, MacId},
     signer::{Signature, Signer, SignerError, SignerId, SigningKey, VerifyingKey},
     subtle::{Choice, ConstantTimeEq},
-    typenum::U64,
+    typenum::{U32, U64},
     zeroize::ZeroizeOnDrop,
 };
 
@@ -331,19 +331,12 @@ impl<'a, T: Signer + ?Sized> Import<&'a [u8]> for SignatureWithDefaults<T> {
 }
 
 /// A test [`CipherSuite`].
-pub struct TestCs<
-    A: Aead + IndCca2,
-    H: Hash<DigestSize = U64>,
-    F: Kdf,
-    K: Kem,
-    M: Mac<KeySize = U64, TagSize = U64>,
-    S: Signer,
->(PhantomData<(A, H, F, K, M, S)>);
+pub struct TestCs<A, H, F, K, M, S>(PhantomData<(A, H, F, K, M, S)>);
 
 impl<A, H, F, K, M, S> CipherSuite for TestCs<A, H, F, K, M, S>
 where
     A: Aead + IndCca2,
-    H: Hash<DigestSize = U64>,
+    H: Hash<DigestSize = U32>,
     F: Kdf,
     K: Kem,
     M: Mac<KeySize = U64, TagSize = U64>,

--- a/crates/aranya-quic-syncer/tests/test.rs
+++ b/crates/aranya-quic-syncer/tests/test.rs
@@ -194,7 +194,7 @@ async fn test_sync_subscribe() -> Result<()> {
             client2.lock().await.deref_mut(),
             SyncRequester::new(storage_id, &mut Rng, addr2),
             5,
-            503, // The exact number of bytes to be sent
+            279, // The exact number of bytes to be sent
             addr1,
         )
         .await?;

--- a/crates/aranya-runtime/src/client/transaction.rs
+++ b/crates/aranya-runtime/src/client/transaction.rs
@@ -523,9 +523,9 @@ mod test {
             ids: MergeIds,
         ) -> Result<Self::Command<'a>, EngineError> {
             let (left, right): (Address, Address) = ids.into();
-            let mut buf = [0u8; 128];
-            buf[..64].copy_from_slice(left.id.as_bytes());
-            buf[64..].copy_from_slice(right.id.as_bytes());
+            let mut buf = [0u8; 64];
+            buf[..32].copy_from_slice(left.id.as_bytes());
+            buf[32..].copy_from_slice(right.id.as_bytes());
             let id = CommandId::hash_for_testing_only(&buf);
 
             Ok(SeqCommand::new(

--- a/crates/aranya-runtime/src/command.rs
+++ b/crates/aranya-runtime/src/command.rs
@@ -19,8 +19,8 @@ impl CommandId {
     /// This is for testing only. It's not `#[cfg(test)]` because
     /// (unfortunately) some code already depends on it.
     pub fn hash_for_testing_only(data: &[u8]) -> Self {
-        use aranya_crypto::{hash::Hash, rust::Sha512};
-        Sha512::hash(data).into_array().into()
+        use aranya_crypto::{hash::Hash, rust::Sha256};
+        Sha256::hash(data).into_array().into()
     }
 
     pub fn short_b58(&self) -> String {

--- a/crates/aranya-runtime/src/protocol.rs
+++ b/crates/aranya-runtime/src/protocol.rs
@@ -257,8 +257,13 @@ impl Sink<TestEffect> for TestSink {
     fn consume(&mut self, effect: TestEffect) {
         trace!(?effect, "consume");
         if !self.ignore_expect {
+            assert!(!self.expect.is_empty(), "consumed {effect:?} while empty");
             let expect = self.expect.remove(0);
-            assert_eq!(effect, expect);
+            trace!(consuming = ?effect, expected = ?expect, remainder = ?self.expect);
+            assert_eq!(
+                effect, expect,
+                "consumed {effect:?} while expecting {expect:?}"
+            );
         }
     }
 

--- a/crates/aranya-runtime/src/storage/linear/libc/path.rs
+++ b/crates/aranya-runtime/src/storage/linear/libc/path.rs
@@ -5,7 +5,7 @@ extern crate std;
 
 use core::{fmt, ops::Deref};
 
-use aranya_crypto::id::{String64, ToBase58};
+use aranya_crypto::id::{String32, ToBase58};
 pub use aranya_libc::{MissingNullByte, Path, PathBuf};
 use buggy::{Bug, BugExt};
 
@@ -14,7 +14,7 @@ use crate::GraphId;
 /// A [`Path`] created from a [`GraphId`].
 #[derive(Copy, Clone)]
 pub struct IdPath {
-    buf: [u8; String64::MAX_SIZE + 1],
+    buf: [u8; String32::MAX_SIZE + 1],
 }
 
 impl IdPath {
@@ -51,12 +51,12 @@ impl fmt::Debug for IdPath {
 
 impl GraphId {
     pub(super) fn to_path(self) -> Result<IdPath, Bug> {
-        let mut buf = [0u8; String64::MAX_SIZE + 1];
+        let mut buf = [0u8; String32::MAX_SIZE + 1];
         let b58 = self.to_base58();
         let src = b58.as_bytes();
         let dst = buf
-            .get_mut(..String64::MAX_SIZE)
-            .assume("`buf.len()` >= `String64::MAX_SIZE`")?
+            .get_mut(..String32::MAX_SIZE)
+            .assume("`buf.len()` >= `String32::MAX_SIZE`")?
             .get_mut(..src.len())
             .assume("`buf.len()` >= `src.len()`")?;
         dst.copy_from_slice(src);

--- a/crates/aranya-runtime/src/sync/requester.rs
+++ b/crates/aranya-runtime/src/sync/requester.rs
@@ -18,7 +18,7 @@ use crate::{
 // https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant.
 // As the buffer consts will be compile-time variables in the future, we will be
 // able to tune these buffers for smaller footprints. Right now, this enum is not
-// suitable for small devices (`SyncRequest` is 6512 bytes).
+// suitable for small devices (`SyncRequest` is 4080 bytes).
 /// Messages sent from the requester to the responder.
 #[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::large_enum_variant)]

--- a/crates/aranya-runtime/src/sync/responder.rs
+++ b/crates/aranya-runtime/src/sync/responder.rs
@@ -71,7 +71,7 @@ impl PeerCache {
 // https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant.
 // As the buffer consts will be compile-time variables in the future, we will be
 // able to tune these buffers for smaller footprints. Right now, this enum is not
-// suitable for small devices (`SyncResponse` is 14848 bytes).
+// suitable for small devices (`SyncResponse` is 14448 bytes).
 /// Messages sent from the responder to the requester.
 #[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::large_enum_variant)]

--- a/crates/aranya-runtime/src/testing/dsl.rs
+++ b/crates/aranya-runtime/src/testing/dsl.rs
@@ -907,7 +907,7 @@ test_vectors! {
 macro_rules! test_vector {
     ($backend:expr ; $($name:ident),+ $(,)?) => {
         $(
-            #[test]
+            #[::test_log::test]
             fn $name() -> ::core::result::Result<(), $crate::testing::dsl::TestError> {
                 $crate::testing::dsl::vectors::$name($backend)
             }

--- a/crates/aranya-runtime/src/testing/testdata/large_sync.test
+++ b/crates/aranya-runtime/src/testing/testdata/large_sync.test
@@ -39,7 +39,13 @@
   {
     "AddExpectations": {
       "expectation": 3,
-      "repeat": 2
+      "repeat": 1
+    }
+  },
+  {
+    "AddExpectations": {
+      "expectation": 4,
+      "repeat": 1
     }
   },
   {
@@ -55,13 +61,7 @@
   {
     "AddExpectations": {
       "expectation": 4,
-      "repeat": 1
-    }
-  },
-  {
-    "AddExpectations": {
-      "expectation": 3,
-      "repeat": 1
+      "repeat": 2
     }
   },
   {
@@ -174,7 +174,13 @@
   {
     "AddExpectations": {
       "expectation": 3,
-      "repeat": 2
+      "repeat": 1
+    }
+  },
+  {
+    "AddExpectations": {
+      "expectation": 4,
+      "repeat": 1
     }
   },
   {

--- a/crates/aranya-runtime/src/testing/testdata/skip_list.test
+++ b/crates/aranya-runtime/src/testing/testdata/skip_list.test
@@ -71,6 +71,12 @@
     }
   },
   { 
+    "AddExpectations" : {
+      "expectation": 3, 
+      "repeat": 1 
+    }
+  },
+  { 
     "Sync" : {
       "client": 1, 
       "graph": 0, 

--- a/crates/aranya-runtime/src/testing/testdata/three_client_compare_graphs.test
+++ b/crates/aranya-runtime/src/testing/testdata/three_client_compare_graphs.test
@@ -231,9 +231,6 @@
     "AddExpectation": 2
   },
   {
-    "AddExpectation": 5
-  },
-  {
     "AddExpectation": 3
   },
   {
@@ -272,9 +269,6 @@
     "AddExpectation": 2
   },
   {
-    "AddExpectation": 5
-  },
-  {
     "AddExpectation": 3
   },
   {
@@ -301,7 +295,16 @@
     "AddExpectation": 6
   },
   {
-    "AddExpectation": 5
+    "AddExpectation": 2
+  },
+  {
+    "AddExpectation": 3
+  },
+  {
+    "AddExpectation": 4
+  },
+  {
+    "AddExpectation": 6
   },
   {
     "Sync": {
@@ -327,7 +330,13 @@
     "AddExpectation": 2
   },
   {
-    "AddExpectation": 5
+    "AddExpectation": 3
+  },
+  {
+    "AddExpectation": 4
+  },
+  {
+    "AddExpectation": 2
   },
   {
     "AddExpectation": 3
@@ -336,7 +345,7 @@
     "AddExpectation": 4
   },
   {
-    "AddExpectation": 5
+    "AddExpectation": 6
   },
   {
     "Sync": {


### PR DESCRIPTION
Note from @elagergren-spideroak: We chose 512 bit IDs long before NIST’s PQ guidance (flow2, perhaps even flow1). 512 bit IDs don’t provide a meaningful improvement in collision resistance over 256 bit IDs, but they do have a negative performance impact. So, make the switch before MVP. 