### PR TITLE
Close #194: Allow enums in key values.

### DIFF
--- a/crates/aranya-policy-ast/src/util.rs
+++ b/crates/aranya-policy-ast/src/util.rs
@@ -13,11 +13,11 @@ impl FactDefinition {
 }
 
 impl FieldDefinition {
-    /// Is this a hashable type (int, bool, string, or id)?
+    /// Is this a hashable type?
     pub fn is_hashable(&self) -> bool {
         matches!(
             self.field_type,
-            VType::Int | VType::Bool | VType::String | VType::Id
+            VType::Int | VType::Bool | VType::String | VType::Id | VType::Enum(_)
         )
     }
 }

--- a/crates/aranya-policy-module/src/data.rs
+++ b/crates/aranya-policy-module/src/data.rs
@@ -529,6 +529,8 @@ pub enum HashableValue {
     String(String),
     /// A unique identifier.
     Id(Id),
+    /// Enum
+    Enum(String, i64),
 }
 
 impl HashableValue {
@@ -540,6 +542,7 @@ impl HashableValue {
             HashableValue::Bool(_) => VType::Bool,
             HashableValue::String(_) => VType::String,
             HashableValue::Id(_) => VType::Id,
+            HashableValue::Enum(id, _) => VType::Enum(id.clone()),
         }
     }
 }
@@ -553,8 +556,9 @@ impl TryFrom<Value> for HashableValue {
             Value::Bool(v) => Ok(HashableValue::Bool(v)),
             Value::String(v) => Ok(HashableValue::String(v)),
             Value::Id(v) => Ok(HashableValue::Id(v)),
+            Value::Enum(id, value) => Ok(HashableValue::Enum(id, value)),
             _ => Err(ValueConversionError::invalid_type(
-                "Int | Bool | String | Id",
+                "Int | Bool | String | Id | Enum",
                 value.type_name(),
                 "Value -> HashableValue",
             )),
@@ -569,6 +573,7 @@ impl From<HashableValue> for Value {
             HashableValue::Bool(v) => Value::Bool(v),
             HashableValue::String(v) => Value::String(v),
             HashableValue::Id(v) => Value::Id(v),
+            HashableValue::Enum(id, value) => Value::Enum(id, value),
         }
     }
 }

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -926,7 +926,7 @@ fn test_query_enum_keys() -> anyhow::Result<()> {
         }
 
         action test_query() {
-            let f = unwrap query Bar[i:?] => {x: ?}
+            let f = unwrap query Bar[i:Foo::A] => {x: ?}
             check f.x == Foo::A
         }
     "#;
@@ -948,11 +948,6 @@ fn test_query_enum_keys() -> anyhow::Result<()> {
         rs.call_command_policy(cmd_name, &this_data, dummy_envelope())?
             .success();
     }
-
-    let policy = parse_policy_str(text, Version::V2)?;
-    let io = RefCell::new(TestIO::new());
-    let module = Compiler::new(&policy).compile()?;
-    let machine = Machine::from_module(module)?;
 
     {
         let action_name = "test_query";

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -910,11 +910,7 @@ fn test_query_partial_key() -> anyhow::Result<()> {
 #[test]
 fn test_query_enum_keys() -> anyhow::Result<()> {
     let text = r#"
-        enum Foo {
-            A,
-            B,
-        }
-
+        enum Foo { A, B }
         fact Bar[i enum Foo] => {x enum Foo}
 
         command Setup {

--- a/crates/aranya-runtime/src/vm_policy/io.rs
+++ b/crates/aranya-runtime/src/vm_policy/io.rs
@@ -440,7 +440,7 @@ mod test {
                 value: HashableValue::Enum(id1.clone(), v1),
             });
             let b2 = ser_key(&FactKey {
-                identifier: identifier,
+                identifier,
                 value: HashableValue::Enum(id2.clone(), v2),
             });
 

--- a/crates/aranya-runtime/src/vm_policy/io.rs
+++ b/crates/aranya-runtime/src/vm_policy/io.rs
@@ -297,8 +297,10 @@ fn deser_key(bytes: &[u8]) -> Result<FactKey, &'static str> {
             HashableValue::Id(id)
         }
         KeyType::Enum => {
-            let (id, value) = bytes.split_at(8);
-            let value = i64::from_be_bytes(value.try_into().map_err(|_| "invalid enum length")?);
+            let (value_bytes, id) = bytes.split_at(8);
+            let value =
+                i64::from_be_bytes(value_bytes.try_into().map_err(|_| "invalid enum length")?)
+                    ^ (1 << 63);
             let id = core::str::from_utf8(id).map_err(|_| "id not utf8")?;
             HashableValue::Enum(String::from(id), value)
         }
@@ -353,6 +355,18 @@ mod test {
     use proptest::prelude::*;
 
     use super::*;
+
+    // FIXME: This should be covered by `test_round_trip`, but that doesn't seem to receive any enum keys.
+    #[test]
+    fn test_ser_deser() {
+        let fk1 = FactKey {
+            identifier: "test".into(),
+            value: HashableValue::Enum("A".to_string(), 42),
+        };
+        let bytes = ser_key(&fk1);
+        let fk2: FactKey = deser_key(&bytes).unwrap();
+        assert_eq!(fk1, fk2);
+    }
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(10_000))]


### PR DESCRIPTION
```
enum Status { A, B }
fact Foo[s: enum Status] => { s string }
action a() {
    let f = unwrap query Foo[s: Status::A] => {}
}
```