### PR TITLE
capi-core: remove `Safe` `Alias` impl

### DIFF
--- a/crates/aranya-capi-core/src/safe.rs
+++ b/crates/aranya-capi-core/src/safe.rs
@@ -337,14 +337,6 @@ impl<T: Typed> Typed for Safe<T> {
     const TYPE_ID: TypeId = T::TYPE_ID;
 }
 
-// SAFETY: `T: Alias<U>`, so the alias is sound.
-unsafe impl<T, U> Alias<U> for Safe<T>
-where
-    T: Alias<U> + Typed,
-    U: Typed + Sized,
-{
-}
-
 /// Implemented by types that can be used with [`Safe`].
 pub trait Typed {
     /// Uniquely identifies the type.


### PR DESCRIPTION
I think it was meant to be `Alias<Safe<U>> for Safe<T>`, but that also seems not very useful since the type ID will presumably mismatch? I am just removing it for now since it is not needed.