### PR TITLE
Issue #186: use compiled module in ifgen so we can support struct field insertion in macros.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ dependencies = [
 name = "aranya-policy-ifgen"
 version = "0.7.0"
 dependencies = [
+ "aranya-policy-compiler",
  "aranya-policy-ifgen-build",
  "aranya-policy-ifgen-macro",
  "aranya-policy-lang",
@@ -414,7 +415,9 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
+ "aranya-policy-compiler",
  "aranya-policy-lang",
+ "aranya-policy-module",
  "prettyplease",
  "proc-macro2",
  "quote",

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -568,7 +568,7 @@ pub struct CommandDefinition {
     /// The name of the command
     pub identifier: String,
     /// The fields of the command and their types
-    pub fields: Vec<FieldDefinition>,
+    pub fields: Vec<StructItem<FieldDefinition>>,
     /// Statements for sealing the command into an envelope
     pub seal: Vec<AstNode<Statement>>,
     /// Statements for opening the command envelope

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -538,7 +538,16 @@ pub struct StructDefinition {
     /// The name of the struct
     pub identifier: String,
     /// The fields of the struct and their types
-    pub fields: Vec<FieldDefinition>,
+    pub items: Vec<StructItem>,
+}
+
+/// Struct field or insertion reference
+#[derive(Debug, Clone, PartialEq)]
+pub enum StructItem {
+    /// Field definition
+    Field(FieldDefinition),
+    /// Named struct from whose fields to add to the current struct
+    StructRef(String),
 }
 
 /// A command definition

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -529,7 +529,7 @@ pub struct EffectDefinition {
     /// The name of the effect
     pub identifier: String,
     /// The fields of the effect and their types
-    pub fields: Vec<EffectFieldDefinition>,
+    pub items: Vec<StructItem<EffectFieldDefinition>>,
 }
 
 /// A struct definition
@@ -538,16 +538,26 @@ pub struct StructDefinition {
     /// The name of the struct
     pub identifier: String,
     /// The fields of the struct and their types
-    pub items: Vec<StructItem>,
+    pub items: Vec<StructItem<FieldDefinition>>,
 }
 
 /// Struct field or insertion reference
 #[derive(Debug, Clone, PartialEq)]
-pub enum StructItem {
+pub enum StructItem<T> {
     /// Field definition
-    Field(FieldDefinition),
+    Field(T),
     /// Named struct from whose fields to add to the current struct
     StructRef(String),
+}
+
+impl<T> StructItem<T> {
+    /// Get the field definition from this struct item
+    pub fn field(&self) -> Option<&T> {
+        match self {
+            StructItem::Field(f) => Some(f),
+            StructItem::StructRef(_) => None,
+        }
+    }
 }
 
 /// A command definition

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -2162,7 +2162,6 @@ impl<'a> CompileState<'a> {
         // define the structs provided by FFI schema
         for ffi_mod in self.ffi_modules {
             for s in ffi_mod.structs {
-                // TODO(apetkov) implement field insertion for FFI structs
                 let fields: Vec<StructItem<FieldDefinition>> = s
                     .fields
                     .iter()
@@ -2185,7 +2184,6 @@ impl<'a> CompileState<'a> {
         for fact in &self.policy.facts {
             let FactDefinition { key, value, .. } = &fact.inner;
 
-            // TODO(apetkov) implement field insertion for facts
             let fields: Vec<StructItem<FieldDefinition>> = key
                 .iter()
                 .chain(value.iter())
@@ -2199,17 +2197,7 @@ impl<'a> CompileState<'a> {
 
         // Define command structs before compiling functions
         for command in &self.policy.commands {
-            self.define_struct(
-                &command.identifier,
-                &command
-                    .fields
-                    .iter()
-                    .map(|si| match si {
-                        StructItem::Field(fd) => StructItem::Field(fd.clone()),
-                        StructItem::StructRef(s) => StructItem::StructRef(s.clone()),
-                    })
-                    .collect::<Vec<_>>(),
-            )?;
+            self.define_struct(&command.identifier, &command.fields)?;
         }
 
         // Define the finish function signatures before compiling them, so that they can be

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -2157,6 +2157,7 @@ impl<'a> CompileState<'a> {
                 })
                 .collect();
             self.define_struct(&effect.inner.identifier, &fields)?;
+            self.m.effects.push(effect.inner.identifier.clone());
         }
 
         // define the structs provided by FFI schema

--- a/crates/aranya-policy-compiler/src/compile/target.rs
+++ b/crates/aranya-policy-compiler/src/compile/target.rs
@@ -18,6 +18,8 @@ pub struct CompileTarget {
     pub action_defs: BTreeMap<String, Vec<ast::FieldDefinition>>,
     /// Command definitions (`fields`)
     pub command_defs: BTreeMap<String, BTreeMap<String, ast::VType>>,
+    /// Effect identifiers. The effect definitions can be found in `struct_defs`.
+    pub effects: Vec<String>,
     /// Fact schemas
     pub fact_defs: BTreeMap<String, FactDefinition>,
     /// Struct schemas
@@ -40,6 +42,7 @@ impl CompileTarget {
             labels: BTreeMap::new(),
             action_defs: BTreeMap::new(),
             command_defs: BTreeMap::new(),
+            effects: vec![],
             fact_defs: BTreeMap::new(),
             struct_defs: BTreeMap::new(),
             enum_defs: BTreeMap::new(),
@@ -57,6 +60,7 @@ impl CompileTarget {
                 labels: self.labels,
                 action_defs: self.action_defs,
                 command_defs: self.command_defs,
+                effects: self.effects,
                 fact_defs: self.fact_defs,
                 struct_defs: self.struct_defs,
                 enum_defs: self.enum_defs,

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -503,6 +503,10 @@ fn test_struct_field_insertion_errors() {
             struct Foo { +Bar, a string }"#,
             CompileErrorType::AlreadyDefined("a".to_string()),
         ),
+        (
+            r#"struct Foo { +Foo }"#,
+            CompileErrorType::NotDefined("Foo".to_string()),
+        ),
     ];
     for (text, err_type) in cases {
         let policy = parse_policy_str(text, Version::V2).expect("should parse");

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+use std::collections::BTreeMap;
+
 use anyhow::anyhow;
 use aranya_policy_ast::{FieldDefinition, VType, Version};
 use aranya_policy_lang::lang::parse_policy_str;
@@ -428,6 +430,123 @@ fn test_command_attributes_must_be_literals() {
         let err = Compiler::new(&policy).compile().unwrap_err().err_type;
         assert!(matches!(err, CompileErrorType::InvalidExpression(_)))
     }
+}
+
+#[test]
+fn test_command_with_struct_field_insertion() -> anyhow::Result<()> {
+    let text = r#"
+        struct Bar { a int }
+        struct Baz { +Bar, b string }
+        command Foo {
+            fields {
+                +Baz,
+                c bool
+            }
+            seal { return None }
+            open { return None }
+            policy {}
+        }
+    "#;
+
+    let policy = parse_policy_str(text, Version::V2)?;
+    let module = Compiler::new(&policy).compile()?;
+    let ModuleData::V0(module) = module.data;
+
+    let want = BTreeMap::from([
+        ("a".to_string(), VType::Int),
+        ("b".to_string(), VType::String),
+        ("c".to_string(), VType::Bool),
+    ]);
+    let got = module.command_defs.get("Foo").unwrap();
+    assert_eq!(got, &want);
+
+    Ok(())
+}
+
+#[test]
+fn test_invalid_command_field_insertion() -> anyhow::Result<()> {
+    let cases = [
+        (
+            r#"
+            command Foo {
+                fields {
+                    +Bar, // Bar is not defined
+                    b string
+                }
+                seal { return None }
+                open { return None }
+                policy {}
+            }
+            "#,
+            CompileErrorType::NotDefined(String::from("Bar")),
+        ),
+        (
+            r#"
+            struct Bar { a int }
+            command Foo {
+                fields {
+                    +Bar,
+                    a bool // Duplicate field `a`
+                }
+                seal { return None }
+                open { return None }
+                policy {}
+            }
+            "#,
+            CompileErrorType::AlreadyDefined(String::from("a")),
+        ),
+    ];
+
+    for (text, expected_error) in cases {
+        let policy = parse_policy_str(text, Version::V2)?;
+        let err = Compiler::new(&policy).compile().unwrap_err().err_type;
+        assert_eq!(err, expected_error);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_command_duplicate_fields() -> anyhow::Result<()> {
+    let cases = [
+        (
+            r#"
+        command Foo {
+            fields {
+                a int,
+                a string
+            }
+            seal { return None }
+            open { return None }
+            policy {}
+        }
+        "#,
+            CompileErrorType::AlreadyDefined(String::from("a")),
+        ),
+        (
+            r#"
+        struct Bar { a int }
+        command Foo {
+            fields {
+                +Bar,
+                a string
+            }
+            seal { return None }
+            open { return None }
+            policy {}
+        }
+        "#,
+            CompileErrorType::AlreadyDefined(String::from("a")),
+        ),
+    ];
+
+    for (text, e) in cases {
+        let policy = parse_policy_str(text, Version::V2)?;
+        let err = Compiler::new(&policy).compile().unwrap_err().err_type;
+        assert_eq!(err, e);
+    }
+
+    Ok(())
 }
 
 #[test]

--- a/crates/aranya-policy-derive/src/ffi.rs
+++ b/crates/aranya-policy-derive/src/ffi.rs
@@ -76,22 +76,19 @@ pub(crate) fn parse(attr: TokenStream, item: TokenStream) -> syn::Result<TokenSt
     let structs = structs.iter().map(|d| {
         let name = format_ident!("{}", d.identifier);
         let name_str = d.identifier.to_string();
-        let names = d
+        let (names, fields): (Vec<_>, Vec<_>) = d
             .items
             .iter()
             .map(|d| match d {
-                StructItem::Field(d) => format_ident!("{}", d.identifier),
-                StructItem::StructRef(_) => todo!(),
+                StructItem::Field(d) => (
+                    format_ident!("{}", d.identifier),
+                    format_ident!("__field_{}", d.identifier),
+                ),
+                StructItem::StructRef(s) => {
+                    todo!("`+{s}`: Struct field insertion is not implemented for FFI structs.")
+                }
             })
-            .collect::<Vec<_>>();
-        let fields = d
-            .items
-            .iter()
-            .map(|d| match d {
-                StructItem::Field(d) => format_ident!("__field_{}", d.identifier),
-                StructItem::StructRef(_) => todo!(),
-            })
-            .collect::<Vec<_>>();
+            .unzip();
         let types = d.items.iter().map(|d| {
             let vtype = match d {
                 StructItem::Field(f) => TypeTokens::new(&f.field_type, &alloc, &crypto, &vm),

--- a/crates/aranya-policy-ifgen-build/Cargo.toml
+++ b/crates/aranya-policy-ifgen-build/Cargo.toml
@@ -12,8 +12,10 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aranya-policy-ast = { version = "0.4.0", path = "../aranya-policy-ast" }
-aranya-policy-lang = { version = "0.4.0", path = "../aranya-policy-lang" }
+aranya-policy-ast = { path = "../aranya-policy-ast" }
+aranya-policy-compiler = { path = "../aranya-policy-compiler" }
+aranya-policy-lang = { path = "../aranya-policy-lang" }
+aranya-policy-module = { path = "../aranya-policy-module" }
 
 anyhow = { workspace = true }
 prettyplease = { workspace = true }

--- a/crates/aranya-policy-ifgen-build/src/imp.rs
+++ b/crates/aranya-policy-ifgen-build/src/imp.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use aranya_policy_ast::{FieldDefinition, Policy, VType};
+use aranya_policy_ast::{FieldDefinition, Policy, StructItem, VType};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 
@@ -15,8 +15,14 @@ pub fn generate_code(policy: &Policy) -> String {
         .map(|s| {
             let doc = format!(" {} policy struct.", s.identifier);
             let name = mk_ident(&s.identifier);
-            let names = s.fields.iter().map(|f| mk_ident(&f.identifier));
-            let types = s.fields.iter().map(|f| vtype_to_rtype(&f.field_type));
+            let names = s.items.iter().map(|i| match i {
+                StructItem::Field(f) => mk_ident(&f.identifier),
+                StructItem::StructRef(_) => todo!(),
+            });
+            let types = s.items.iter().map(|i| match i {
+                StructItem::Field(f) => vtype_to_rtype(&f.field_type),
+                StructItem::StructRef(_) => todo!(),
+            });
             quote! {
                 #[doc = #doc]
                 #[value]
@@ -145,14 +151,15 @@ fn vtype_to_rtype(ty: &VType) -> TokenStream {
 /// Returns the name of all custom types reachable from actions or effects.
 fn collect_reachable_types(policy: &Policy) -> HashSet<&str> {
     fn visit<'a>(
-        struct_defs: &HashMap<&str, &'a [FieldDefinition]>,
+        // struct_defs: &HashMap<&str, &'a [FieldDefinition]>,
+        struct_defs: &HashMap<&str, Vec<&'a FieldDefinition>>,
         found: &mut HashSet<&'a str>,
         ty: &'a VType,
     ) {
         match ty {
             VType::Struct(s) => {
                 if found.insert(s.as_str()) {
-                    for field in struct_defs[s.as_str()] {
+                    for field in &struct_defs[s.as_str()] {
                         visit(struct_defs, found, &field.field_type);
                     }
                 }
@@ -168,7 +175,18 @@ fn collect_reachable_types(policy: &Policy) -> HashSet<&str> {
     let struct_defs = policy
         .structs
         .iter()
-        .map(|s| (s.identifier.as_str(), s.fields.as_slice()))
+        .map(|s| {
+            (
+                s.identifier.as_str(),
+                s.items
+                    .iter()
+                    .map(|i| match i {
+                        StructItem::Field(f) => f,
+                        StructItem::StructRef(_) => todo!(),
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
         .collect::<HashMap<_, _>>();
 
     let mut found = HashSet::new();

--- a/crates/aranya-policy-ifgen-build/src/imp.rs
+++ b/crates/aranya-policy-ifgen-build/src/imp.rs
@@ -1,34 +1,29 @@
 use std::collections::{HashMap, HashSet};
 
-use aranya_policy_ast::{FieldDefinition, Policy, VType};
+use aranya_policy_ast::{FieldDefinition, VType};
+use aranya_policy_module::{Module, ModuleData, ModuleV0};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 
-/// Generate rust source code from a [`Policy`] AST.
-pub fn generate_code(policy: &Policy) -> String {
-    let reachable = collect_reachable_types(policy);
+/// Generate rust source code from a policy [`Module`].
+pub fn generate_code(module: &Module) -> String {
+    let m = {
+        match &module.data {
+            ModuleData::V0(m) => m,
+        }
+    };
 
-    let structs = policy
-        .structs
+    let reachable = collect_reachable_types(m);
+
+    let structs = m
+        .struct_defs
         .iter()
-        .filter(|s| reachable.contains(s.identifier.as_str()))
-        .map(|s| {
-            let doc = format!(" {} policy struct.", s.identifier);
-            let name = mk_ident(&s.identifier);
-            let names = s.items.iter().map(|i| {
-                mk_ident(
-                    &i.field()
-                        .expect("should not be a struct ref here")
-                        .identifier,
-                )
-            });
-            let types = s.items.iter().map(|i| {
-                vtype_to_rtype(
-                    &i.field()
-                        .expect("should not be a struct ref here")
-                        .field_type,
-                )
-            });
+        .filter(|(id, _fields)| reachable.contains(id.as_str()))
+        .map(|(id, fields)| {
+            let doc = format!(" {} policy struct.", id);
+            let name = mk_ident(&id);
+            let names = fields.iter().map(|f| mk_ident(&f.identifier));
+            let types = fields.iter().map(|f| vtype_to_rtype(&f.field_type));
             quote! {
                 #[doc = #doc]
                 #[value]
@@ -38,14 +33,14 @@ pub fn generate_code(policy: &Policy) -> String {
             }
         });
 
-    let enums = policy
-        .enums
+    let enums = m
+        .enum_defs
         .iter()
-        .filter(|e| reachable.contains(e.identifier.as_str()))
-        .map(|e| {
-            let doc = format!(" {} policy enum.", e.identifier);
-            let name = mk_ident(&e.identifier);
-            let names = e.values.iter().map(|v| mk_ident(v));
+        .filter(|(id, _values)| reachable.contains(id.as_str()))
+        .map(|(id, values)| {
+            let doc = format!(" {} policy enum.", id);
+            let name = mk_ident(&id);
+            let names = values.iter().map(|(id, _)| mk_ident(id));
             quote! {
                 #[doc = #doc]
                 #[value]
@@ -55,17 +50,15 @@ pub fn generate_code(policy: &Policy) -> String {
             }
         });
 
-    let effects = policy.effects.iter().map(|s| {
-        let doc = format!(" {} policy effect.", s.identifier);
-        let ident = mk_ident(&s.identifier);
-        let field_idents = s
-            .items
-            .iter()
-            .map(|i| mk_ident(&i.field().expect("effect item should be a field").identifier));
-        let field_types = s
-            .items
-            .iter()
-            .map(|i| vtype_to_rtype(&i.field().expect("effect item should be a field").field_type));
+    let effects = m.effects.iter().map(|s| {
+        let fields = m
+            .struct_defs
+            .get(s)
+            .expect(format!("Effect not defined: {s}").as_str());
+        let doc = format!(" {} policy effect.", s);
+        let ident = mk_ident(&s);
+        let field_idents = fields.iter().map(|f| mk_ident(&f.identifier));
+        let field_types = fields.iter().map(|f| vtype_to_rtype(&f.field_type));
         quote! {
             #[doc = #doc]
             #[effect]
@@ -76,7 +69,7 @@ pub fn generate_code(policy: &Policy) -> String {
     });
 
     let effect_enum = {
-        let idents = policy.effects.iter().map(|s| mk_ident(&s.identifier));
+        let idents = m.effects.iter().map(|s| mk_ident(&s));
         quote! {
             #[effects]
             pub enum Effect {
@@ -88,13 +81,10 @@ pub fn generate_code(policy: &Policy) -> String {
     };
 
     let actions = {
-        let sigs = policy.actions.iter().map(|action| {
-            let ident = mk_ident(&action.identifier);
-            let argnames = action.arguments.iter().map(|arg| mk_ident(&arg.identifier));
-            let argtypes = action
-                .arguments
-                .iter()
-                .map(|arg| vtype_to_rtype(&arg.field_type));
+        let sigs = m.action_defs.iter().map(|(id, args)| {
+            let ident = mk_ident(&id);
+            let argnames = args.iter().map(|arg| mk_ident(&arg.identifier));
+            let argtypes = args.iter().map(|arg| vtype_to_rtype(&arg.field_type));
             quote! {
                 fn #ident(&mut self, #(#argnames: #argtypes),*) -> Result<(), ClientError>;
             }
@@ -161,16 +151,16 @@ fn vtype_to_rtype(ty: &VType) -> TokenStream {
 }
 
 /// Returns the name of all custom types reachable from actions or effects.
-fn collect_reachable_types(policy: &Policy) -> HashSet<&str> {
+fn collect_reachable_types(module: &ModuleV0) -> HashSet<&str> {
     fn visit<'a>(
-        struct_defs: &HashMap<&str, Vec<&'a FieldDefinition>>,
+        struct_defs: &HashMap<&str, &'a [FieldDefinition]>,
         found: &mut HashSet<&'a str>,
         ty: &'a VType,
     ) {
         match ty {
             VType::Struct(s) => {
                 if found.insert(s.as_str()) {
-                    for field in &struct_defs[s.as_str()] {
+                    for field in struct_defs[s.as_str()] {
                         visit(struct_defs, found, &field.field_type);
                     }
                 }
@@ -183,31 +173,26 @@ fn collect_reachable_types(policy: &Policy) -> HashSet<&str> {
         }
     }
 
-    let struct_defs = policy
-        .structs
+    let struct_defs = module
+        .struct_defs
         .iter()
-        .map(|s| {
-            (
-                s.identifier.as_str(),
-                s.items
-                    .iter()
-                    .map(|i| i.field().expect("should not be a struct ref here"))
-                    .collect::<Vec<_>>(),
-            )
-        })
+        .map(|(id, fields)| (id.as_str(), fields.as_slice()))
         .collect::<HashMap<_, _>>();
 
     let mut found = HashSet::new();
 
-    for action in &policy.actions {
-        for arg in &action.arguments {
+    for (_id, args) in &module.action_defs {
+        for arg in args {
             visit(&struct_defs, &mut found, &arg.field_type);
         }
     }
 
-    for effect in &policy.effects {
-        for item in &effect.items {
-            let field = item.field().expect("Expected field in effect item");
+    for id in &module.effects {
+        let fields = module
+            .struct_defs
+            .get(id)
+            .expect(format!("Effect not defined: {id}").as_str());
+        for field in fields {
             visit(&struct_defs, &mut found, &field.field_type);
         }
     }

--- a/crates/aranya-policy-ifgen-build/src/imp.rs
+++ b/crates/aranya-policy-ifgen-build/src/imp.rs
@@ -61,7 +61,7 @@ pub fn generate_code(policy: &Policy) -> String {
         let field_idents = s
             .items
             .iter()
-            .map(|i| &i.field().expect("effect item should be a field").identifier);
+            .map(|i| mk_ident(&i.field().expect("effect item should be a field").identifier));
         let field_types = s
             .items
             .iter()

--- a/crates/aranya-policy-ifgen-build/src/lib.rs
+++ b/crates/aranya-policy-ifgen-build/src/lib.rs
@@ -7,6 +7,7 @@
 use std::{fs, path::Path};
 
 use anyhow::{Context, Result};
+use aranya_policy_compiler::Compiler;
 use aranya_policy_lang::lang::parse_policy_document;
 
 mod imp;
@@ -19,9 +20,9 @@ pub fn generate(input: impl AsRef<Path>, output: impl AsRef<Path>) -> Result<()>
 
 fn generate_(input: &Path, output: &Path) -> Result<()> {
     let policy_source = fs::read_to_string(input).with_context(|| format!("reading {input:?}"))?;
-
-    let policy_doc = parse_policy_document(&policy_source)?;
-    let rust_code = generate_code(&policy_doc);
+    let policy_ast = parse_policy_document(&policy_source)?;
+    let module = Compiler::new(&policy_ast).compile()?;
+    let rust_code = generate_code(&module);
 
     fs::write(output, rust_code).with_context(|| format!("writing to {output:?}"))?;
 

--- a/crates/aranya-policy-ifgen/Cargo.toml
+++ b/crates/aranya-policy-ifgen/Cargo.toml
@@ -26,6 +26,7 @@ serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+aranya-policy-compiler = { path = "../aranya-policy-compiler" }
 aranya-policy-ifgen-build = { path = "../aranya-policy-ifgen-build" }
 aranya-policy-lang = { path = "../aranya-policy-lang" }
 

--- a/crates/aranya-policy-ifgen/tests/golden.rs
+++ b/crates/aranya-policy-ifgen/tests/golden.rs
@@ -2,6 +2,7 @@
 
 use std::{io::Write, path::Path};
 
+use aranya_policy_compiler::Compiler;
 use aranya_policy_ifgen_build::generate_code;
 use aranya_policy_lang::lang::parse_policy_document;
 
@@ -13,7 +14,8 @@ fn dotest(name: &str) {
     let doc = std::fs::read_to_string(data.join(format!("{name}.md"))).unwrap();
     let doc = parse_policy_document(&doc).unwrap();
 
-    let rust_code = generate_code(&doc);
+    let module = Compiler::new(&doc).compile().unwrap();
+    let rust_code = generate_code(&module);
 
     let mut file = mint.new_goldenfile(format!("{name}.rs")).unwrap();
     write!(file, "{rust_code}").unwrap();

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -1281,7 +1281,24 @@ impl<'a> ChunkParser<'a> {
                 Rule::fields_block => {
                     let pairs = token.into_inner();
                     for field in pairs {
-                        fields.push(Self::parse_field_definition(field)?);
+                        match field.as_rule() {
+                            Rule::field_definition => {
+                                fields.push(ast::StructItem::Field(Self::parse_field_definition(
+                                    field,
+                                )?));
+                            }
+                            Rule::field_insertion => {
+                                let ident = descend(field).consume_identifier()?;
+                                fields.push(ast::StructItem::StructRef(ident));
+                            }
+                            _ => {
+                                return Err(ParseError::new(
+                                    ParseErrorKind::Unknown,
+                                    String::from("invalid token in command definition"),
+                                    Some(field.as_span()),
+                                ))
+                            }
+                        }
                     }
                 }
                 Rule::policy_block => {

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -1182,13 +1182,22 @@ impl<'a> ChunkParser<'a> {
         let identifier = pc.consume_identifier()?;
 
         // All remaining tokens are fields
-        let mut fields = vec![];
+        let mut items = vec![];
         for field in pc.into_inner() {
-            fields.push(Self::parse_field_definition(field)?);
+            match field.as_rule() {
+                Rule::field_definition => {
+                    items.push(ast::StructItem::Field(Self::parse_field_definition(field)?))
+                }
+                Rule::struct_field_insertion => {
+                    let ident = descend(field).consume_identifier()?;
+                    items.push(ast::StructItem::StructRef(ident));
+                }
+                _ => {}
+            }
         }
 
         Ok(AstNode::new(
-            ast::StructDefinition { identifier, fields },
+            ast::StructDefinition { identifier, items },
             locator,
         ))
     }

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -1159,13 +1159,28 @@ impl<'a> ChunkParser<'a> {
         let identifier = pc.consume_identifier()?;
 
         // All remaining tokens are fields
-        let mut fields = vec![];
+        let mut items = vec![];
         for field in pc.into_inner() {
-            fields.push(Self::parse_effect_field_definition(field)?);
+            match field.as_rule() {
+                Rule::effect_field_definition => items.push(ast::StructItem::Field(
+                    Self::parse_effect_field_definition(field)?,
+                )),
+                Rule::field_insertion => {
+                    let ident = descend(field).consume_identifier()?;
+                    items.push(ast::StructItem::StructRef(ident));
+                }
+                _ => {
+                    return Err(ParseError::new(
+                        ParseErrorKind::Unknown,
+                        String::from("invalid token in effect definition"),
+                        Some(field.as_span()),
+                    ));
+                }
+            }
         }
 
         Ok(AstNode::new(
-            ast::EffectDefinition { identifier, fields },
+            ast::EffectDefinition { identifier, items },
             locator,
         ))
     }
@@ -1192,7 +1207,13 @@ impl<'a> ChunkParser<'a> {
                     let ident = descend(field).consume_identifier()?;
                     items.push(ast::StructItem::StructRef(ident));
                 }
-                _ => {}
+                _ => {
+                    return Err(ParseError::new(
+                        ParseErrorKind::Unknown,
+                        String::from("invalid token in struct definition"),
+                        Some(field.as_span()),
+                    ));
+                }
             }
         }
 

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -1188,7 +1188,7 @@ impl<'a> ChunkParser<'a> {
                 Rule::field_definition => {
                     items.push(ast::StructItem::Field(Self::parse_field_definition(field)?))
                 }
-                Rule::struct_field_insertion => {
+                Rule::field_insertion => {
                     let ident = descend(field).consume_identifier()?;
                     items.push(ast::StructItem::StructRef(ident));
                 }

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -42,11 +42,13 @@ vtype = _{ string_t | bytes_t | int_t | bool_t | id_t | struct_t | enum_t | opti
 // A field definition is an identifier followed by a type. Used in
 // struct definitions, function arguments, etc.
 field_definition = { identifier ~ vtype }
-// struct field insertion. Copy fields from another struct
-struct_field_insertion = { "+" ~ identifier }
+// Reference to struct from which to copy fields into the current struct
+field_insertion = { "+" ~ identifier }
 // A field definition list is a list of field definitions. Trailing
 // commas are allowed in any list.
-field_definition_list = _{ (field_definition | struct_field_insertion) ~ ("," ~ (field_definition | struct_field_insertion))* ~ ","? }
+field_definition_list = _{ field_definition ~ ("," ~ field_definition)* ~ ","? }
+// Similar to field_definition_list, but allows field insertion
+field_definition_and_insertion_list = _{ (field_definition | field_insertion) ~ ("," ~ (field_definition | field_insertion))* ~ ","? }
 // Keyword for dynamic effect fields
 dynamic = { "dynamic" }
 // An effect field definition works like a regular field but adds the
@@ -59,7 +61,7 @@ effect_field_definition_list = _{ effect_field_definition ~ ("," ~ effect_field_
 // A struct definition is a list of field definitions surrounded by
 // curly brackets. Note that there are no actual struct types yet -
 // this is only used as a building block for other definitions.
-struct_def = _{ "{" ~ field_definition_list? ~ "}" }
+struct_def = _{ "{" ~ field_definition_and_insertion_list? ~ "}" }
 // An effect struct definition is similar but supports the additional
 // "dynamic" keyword.
 effect_struct_def = _{ "{" ~ effect_field_definition_list? ~ "}" }

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -55,7 +55,7 @@ dynamic = { "dynamic" }
 // optional "dynamic" keyword.
 effect_field_definition = { identifier ~ vtype ~ dynamic? }
 // Ditto the list form
-effect_field_definition_list = _{ effect_field_definition ~ ("," ~ effect_field_definition)* ~ ","? }
+effect_field_definition_list = _{ (effect_field_definition | field_insertion) ~ ("," ~ (effect_field_definition | field_insertion))* ~ ","? }
 
 // ## Structs
 // A struct definition is a list of field definitions surrounded by

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -42,9 +42,11 @@ vtype = _{ string_t | bytes_t | int_t | bool_t | id_t | struct_t | enum_t | opti
 // A field definition is an identifier followed by a type. Used in
 // struct definitions, function arguments, etc.
 field_definition = { identifier ~ vtype }
+// struct field insertion. Copy fields from another struct
+struct_field_insertion = { "+" ~ identifier }
 // A field definition list is a list of field definitions. Trailing
 // commas are allowed in any list.
-field_definition_list = _{ field_definition ~ ("," ~ field_definition)* ~ ","? }
+field_definition_list = _{ (field_definition | struct_field_insertion) ~ ("," ~ (field_definition | struct_field_insertion))* ~ ","? }
 // Keyword for dynamic effect fields
 dynamic = { "dynamic" }
 // An effect field definition works like a regular field but adds the

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -664,10 +664,10 @@ fn parse_policy_test() -> Result<(), ParseError> {
             ast::CommandDefinition {
                 attributes: vec![],
                 identifier: String::from("Add"),
-                fields: vec![ast::FieldDefinition {
+                fields: vec![ast::StructItem::Field(ast::FieldDefinition {
                     identifier: String::from("count"),
                     field_type: ast::VType::Int,
-                }],
+                })],
                 seal: vec![],
                 open: vec![],
                 policy: vec![

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -370,6 +370,33 @@ fn parse_effect() -> Result<(), PestError<Rule>> {
 }
 
 #[test]
+fn test_parse_effect_with_field_insertion() {
+    let cases = [(
+        r#"struct Foo { x int }
+        effect Bar {
+            +Foo,
+            y int
+        }
+        "#,
+        vec![
+            ast::StructItem::StructRef("Foo".to_string()),
+            ast::StructItem::Field(ast::EffectFieldDefinition {
+                identifier: String::from("y"),
+                field_type: ast::VType::Int,
+                dynamic: false,
+            }),
+        ],
+    )];
+    for (case, expected) in cases {
+        let policy = parse_policy_str(case, Version::V2).expect("should parse");
+        assert_eq!(
+            policy.effects[0].inner.items, expected,
+            "case: {case:?} => {expected:?}"
+        );
+    }
+}
+
+#[test]
 #[allow(clippy::result_large_err)]
 fn parse_command() -> Result<(), PestError<Rule>> {
     let src = r#"
@@ -615,17 +642,17 @@ fn parse_policy_test() -> Result<(), ParseError> {
         vec![AstNode::new(
             ast::EffectDefinition {
                 identifier: String::from("Added"),
-                fields: vec![
-                    ast::EffectFieldDefinition {
+                items: vec![
+                    ast::StructItem::Field(ast::EffectFieldDefinition {
                         identifier: String::from("x"),
                         field_type: ast::VType::Int,
                         dynamic: true,
-                    },
-                    ast::EffectFieldDefinition {
+                    }),
+                    ast::StructItem::Field(ast::EffectFieldDefinition {
                         identifier: String::from("y"),
                         field_type: ast::VType::Int,
                         dynamic: false,
-                    },
+                    }),
                 ],
             },
             326,

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -1184,10 +1184,10 @@ fn parse_struct() {
         vec![AstNode::new(
             ast::StructDefinition {
                 identifier: String::from("Foo"),
-                fields: vec![ast::FieldDefinition {
+                items: vec![ast::StructItem::Field(ast::FieldDefinition {
                     identifier: String::from("x"),
                     field_type: ast::VType::Int,
-                }]
+                })]
             },
             0
         )]
@@ -1221,6 +1221,32 @@ fn parse_struct() {
             50
         )]
     );
+}
+
+#[test]
+fn parse_struct_with_field_insertion() {
+    let cases = [(
+        r#"struct Foo { x int }
+        struct Bar {
+            +Foo,
+            y int
+        }
+        "#,
+        vec![
+            ast::StructItem::StructRef("Foo".to_string()),
+            ast::StructItem::Field(ast::FieldDefinition {
+                identifier: String::from("y"),
+                field_type: ast::VType::Int,
+            }),
+        ],
+    )];
+    for (case, expected) in cases {
+        let policy = parse_policy_str(case, Version::V2).expect("should parse");
+        assert_eq!(
+            policy.structs[1].inner.items, expected,
+            "case: {case:?} => {expected:?}"
+        );
+    }
 }
 
 #[test]
@@ -1308,15 +1334,15 @@ fn parse_ffi_structs() {
             AstNode {
                 inner: ast::StructDefinition {
                     identifier: String::from("A"),
-                    fields: vec![
-                        ast::FieldDefinition {
+                    items: vec![
+                        ast::StructItem::Field(ast::FieldDefinition {
                             identifier: String::from("x"),
                             field_type: ast::VType::Int
-                        },
-                        ast::FieldDefinition {
+                        }),
+                        ast::StructItem::Field(ast::FieldDefinition {
                             identifier: String::from("y"),
                             field_type: ast::VType::Bool
-                        }
+                        })
                     ]
                 },
                 locator: 0,
@@ -1324,7 +1350,7 @@ fn parse_ffi_structs() {
             AstNode {
                 inner: ast::StructDefinition {
                     identifier: String::from("B"),
-                    fields: vec![],
+                    items: vec![],
                 },
                 locator: 68,
             },

--- a/crates/aranya-policy-module/src/module.rs
+++ b/crates/aranya-policy-module/src/module.rs
@@ -76,6 +76,8 @@ pub struct ModuleV0 {
     pub action_defs: BTreeMap<String, Vec<ast::FieldDefinition>>,
     /// Command definitions
     pub command_defs: BTreeMap<String, BTreeMap<String, ast::VType>>,
+    /// Effect identifiers. The effect definitions can be found in `struct_defs`.
+    pub effects: Vec<String>,
     /// Fact definitions
     pub fact_defs: BTreeMap<String, FactDefinition>,
     /// Struct definitions

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -209,6 +209,7 @@ impl Machine {
                 labels: self.labels,
                 action_defs: self.action_defs,
                 command_defs: self.command_defs,
+                effects: vec![],
                 fact_defs: self.fact_defs,
                 struct_defs: self.struct_defs,
                 enum_defs: self.enum_defs,


### PR DESCRIPTION
As a bonus, compiling the policy also catches some errors, e.g. there are two failing tests that used undefined/already-defined identifiers.