### PR TITLE
capi: make opaque types an exact size and alignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "cfg-if",
  "ciborium-io",
  "const_format",
+ "elain",
  "libc",
  "thiserror 2.0.7",
  "tracing",
@@ -1239,6 +1240,12 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "elain"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba39bdf557eef05f2c1c2e986cbab6b85329b922e7606e5b63ee4c5037ba77a"
 
 [[package]]
 name = "elliptic-curve"

--- a/crates/aranya-capi-codegen-test/src/generated.rs
+++ b/crates/aranya-capi-codegen-test/src/generated.rs
@@ -38,7 +38,7 @@ pub struct PrefixSafeStruct(crate::defs::SafeStruct);
 #[cfg(not(cbindgen))]
 pub type PrefixSafeStruct = self::__hidden::PrefixSafeStruct;
 /// Extended error information.
-#[aranya_capi_core::opaque(size = 72, align = 8)]
+#[__capi::opaque(size = 72, align = 8, generated = true)]
 pub type PrefixExtError = self::__hidden::PrefixExtError;
 #[derive(::core::marker::Copy)]
 #[derive(::core::clone::Clone)]

--- a/crates/aranya-capi-codegen/src/ast/expand.rs
+++ b/crates/aranya-capi-codegen/src/ast/expand.rs
@@ -61,7 +61,7 @@ impl Ast {
             doc,
             derives,
             ext_error,
-            opaque,
+            mut opaque,
             builds,
             attrs,
             vis,
@@ -70,6 +70,9 @@ impl Ast {
             semi_token,
             ..
         } = alias;
+        if let Some(o) = &mut opaque {
+            o.generated = true;
+        }
         let strukt = Struct {
             doc,
             derives,

--- a/crates/aranya-capi-codegen/src/syntax/attrs.rs
+++ b/crates/aranya-capi-codegen/src/syntax/attrs.rs
@@ -223,7 +223,7 @@ fn parse_capi_attr(ctx: &Ctx, attr: &Attribute, parser: &mut Parser<'_>) -> bool
             Ok(attr) => {
                 if let Some(v) = &mut parser.capi_opaque {
                     **v = Some(attr);
-                    return false; // passthrough
+                    return true;
                 }
             }
             Err(err) => {

--- a/crates/aranya-capi-codegen/src/syntax/node.rs
+++ b/crates/aranya-capi-codegen/src/syntax/node.rs
@@ -261,6 +261,7 @@ impl ToTokens for Alias {
 
         self.doc.to_tokens(tokens);
         tokens.append_all(self.attrs.outer());
+        self.opaque.to_tokens(tokens);
         self.vis.to_tokens(tokens);
         self.type_token.to_tokens(tokens);
         self.ident.to_tokens(tokens);
@@ -351,6 +352,7 @@ impl ToTokens for Struct {
         self.derives.to_tokens(tokens);
         self.repr.to_tokens(tokens);
         tokens.append_all(self.attrs.outer());
+        self.opaque.to_tokens(tokens);
         self.vis.to_tokens(tokens);
         self.struct_token.to_tokens(tokens);
         self.ident.to_tokens(tokens);

--- a/crates/aranya-capi-codegen/src/syntax/opaque.rs
+++ b/crates/aranya-capi-codegen/src/syntax/opaque.rs
@@ -13,7 +13,7 @@ use crate::{
 
 /// The `#[capi::opaque(size = 42, align = 12)]` attribute.
 ///
-/// It can only be applied to structs or aliases.
+/// It can only be applied to aliases.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Opaque {
     /// The size in bytes of the type.

--- a/crates/aranya-capi-core/Cargo.toml
+++ b/crates/aranya-capi-core/Cargo.toml
@@ -35,9 +35,9 @@ aranya-capi-macro = { version = "0.2.2", path = "../aranya-capi-macro", default-
 aranya-libc = { version = "0.2.0", path = "../aranya-libc", default-features = false }
 buggy = { version = "0.1.0", default-features = false }
 
-elain = "0.3"
 cfg-if = { workspace = true, default-features = false }
 const_format = { version = "0.2.31", default-features = false, features = ["assertcp"] }
+elain = "0.3"
 thiserror = { workspace = true }
 tracing = { workspace = true, default-features = false }
 

--- a/crates/aranya-capi-core/Cargo.toml
+++ b/crates/aranya-capi-core/Cargo.toml
@@ -35,6 +35,7 @@ aranya-capi-macro = { version = "0.2.2", path = "../aranya-capi-macro", default-
 aranya-libc = { version = "0.2.0", path = "../aranya-libc", default-features = false }
 buggy = { version = "0.1.0", default-features = false }
 
+elain = "0.3"
 cfg-if = { workspace = true, default-features = false }
 const_format = { version = "0.2.31", default-features = false, features = ["assertcp"] }
 thiserror = { workspace = true }

--- a/crates/aranya-capi-core/src/lib.rs
+++ b/crates/aranya-capi-core/src/lib.rs
@@ -5,6 +5,7 @@ mod error;
 #[doc(hidden)]
 pub mod internal;
 mod macros;
+pub mod opaque;
 pub mod safe;
 mod traits;
 pub mod types;

--- a/crates/aranya-capi-core/src/opaque.rs
+++ b/crates/aranya-capi-core/src/opaque.rs
@@ -1,0 +1,70 @@
+use std::{
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut},
+};
+
+#[repr(C)]
+pub struct Opaque<const SIZE: usize, const ALIGN: usize, T>(OpaqueRepr<SIZE, ALIGN, T>)
+where
+    elain::Align<ALIGN>: elain::Alignment;
+
+impl<const SIZE: usize, const ALIGN: usize, T> Deref for Opaque<SIZE, ALIGN, T>
+where
+    elain::Align<ALIGN>: elain::Alignment,
+{
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        const { assert!(SIZE >= size_of::<T>()) };
+        const { assert!(ALIGN >= align_of::<T>()) };
+
+        // SAFETY: `OpaqueRepr` is always the `inner` variant.
+        unsafe { &self.0.inner }
+    }
+}
+
+impl<const SIZE: usize, const ALIGN: usize, T> DerefMut for Opaque<SIZE, ALIGN, T>
+where
+    elain::Align<ALIGN>: elain::Alignment,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        const { assert!(SIZE >= size_of::<T>()) };
+        const { assert!(ALIGN >= align_of::<T>()) };
+
+        // SAFETY: `OpaqueRepr` is always the `inner` variant.
+        unsafe { &mut self.0.inner }
+    }
+}
+
+#[repr(C)]
+union OpaqueRepr<const SIZE: usize, const ALIGN: usize, T>
+where
+    elain::Align<ALIGN>: elain::Alignment,
+{
+    inner: ManuallyDrop<T>,
+    __backing_for_size_align_only: Backing<SIZE, ALIGN>,
+}
+
+impl<const SIZE: usize, const ALIGN: usize, T> Drop for OpaqueRepr<SIZE, ALIGN, T>
+where
+    elain::Align<ALIGN>: elain::Alignment,
+{
+    fn drop(&mut self) {
+        // SAFETY: `OpaqueRepr` is always the `inner` variant.
+        // Forwarding the drop impl is safe.
+        unsafe {
+            ManuallyDrop::drop(&mut self.inner);
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct Backing<const SIZE: usize, const ALIGN: usize>
+where
+    elain::Align<ALIGN>: elain::Alignment,
+{
+    size: [u8; SIZE],
+    align: elain::Align<ALIGN>,
+    // `Backing` should never be constructed.
+    never: core::convert::Infallible,
+}

--- a/crates/aranya-capi-core/src/opaque.rs
+++ b/crates/aranya-capi-core/src/opaque.rs
@@ -1,12 +1,104 @@
-use std::{
-    mem::ManuallyDrop,
+use core::{
+    mem::MaybeUninit,
     ops::{Deref, DerefMut},
 };
 
+use crate::{
+    safe::{Safe, Typed},
+    Builder, InitDefault,
+};
+
+mod imp {
+    use core::mem::ManuallyDrop;
+
+    #[repr(C)]
+    pub(super) union OpaqueRepr<const SIZE: usize, const ALIGN: usize, T>
+    where
+        elain::Align<ALIGN>: elain::Alignment,
+    {
+        // Invariant: always the `inner` variant.
+        // Invariant: only dropped in the drop impl.
+        inner: ManuallyDrop<T>,
+        __backing_for_size_align_only: Backing<SIZE, ALIGN>,
+    }
+
+    impl<const SIZE: usize, const ALIGN: usize, T> OpaqueRepr<SIZE, ALIGN, T>
+    where
+        elain::Align<ALIGN>: elain::Alignment,
+    {
+        pub fn into_inner(mut self) -> T {
+            // SAFETY: always `inner`` variant
+            let inner = unsafe { &mut self.inner };
+            // SAFETY: consuming self
+            unsafe { ManuallyDrop::take(inner) }
+        }
+
+        pub fn as_ref(&self) -> &T {
+            // SAFETY: always the `inner` variant.
+            unsafe { &self.inner }
+        }
+
+        pub fn as_mut(&mut self) -> &mut T {
+            // SAFETY: always the `inner` variant.
+            unsafe { &mut self.inner }
+        }
+    }
+
+    impl<const SIZE: usize, const ALIGN: usize, T> Drop for OpaqueRepr<SIZE, ALIGN, T>
+    where
+        elain::Align<ALIGN>: elain::Alignment,
+    {
+        fn drop(&mut self) {
+            // SAFETY: always the `inner` variant.
+            // Forwarding the drop impl is safe.
+            unsafe {
+                ManuallyDrop::drop(&mut self.inner);
+            }
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    struct Backing<const SIZE: usize, const ALIGN: usize>
+    where
+        elain::Align<ALIGN>: elain::Alignment,
+    {
+        size: [u8; SIZE],
+        align: elain::Align<ALIGN>,
+        // `Backing` should never be constructed.
+        never: core::convert::Infallible,
+    }
+}
+
+/// Opaque is a wrapper which ensures a minimum size and alignment.
+///
+/// This is used by the `opaque` macro so the rust and C types will have the same size.
+///
+/// It is expected that `SIZE >= size_of::<T>()` and `ALIGN >= align_of::<T>()`. However, if
+/// that is not true, all the operations below are still safe since the repr always contains a `T`.
 #[repr(C)]
-pub struct Opaque<const SIZE: usize, const ALIGN: usize, T>(OpaqueRepr<SIZE, ALIGN, T>)
+pub struct Opaque<const SIZE: usize, const ALIGN: usize, T>(imp::OpaqueRepr<SIZE, ALIGN, T>)
 where
     elain::Align<ALIGN>: elain::Alignment;
+
+impl<const SIZE: usize, const ALIGN: usize, T> Opaque<SIZE, ALIGN, T>
+where
+    elain::Align<ALIGN>: elain::Alignment,
+{
+    fn into_inner(self) -> T {
+        self.0.into_inner()
+    }
+}
+
+impl<const SIZE: usize, const ALIGN: usize, T> Opaque<SIZE, ALIGN, Safe<T>>
+where
+    T: Typed,
+    elain::Align<ALIGN>: elain::Alignment,
+{
+    pub fn init(out: &mut MaybeUninit<Self>, v: T) {
+        Safe::init(downcast_maybe_uninit(out), v);
+    }
+}
 
 impl<const SIZE: usize, const ALIGN: usize, T> Deref for Opaque<SIZE, ALIGN, T>
 where
@@ -14,11 +106,7 @@ where
 {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        const { assert!(SIZE >= size_of::<T>()) };
-        const { assert!(ALIGN >= align_of::<T>()) };
-
-        // SAFETY: `OpaqueRepr` is always the `inner` variant.
-        unsafe { &self.0.inner }
+        self.0.as_ref()
     }
 }
 
@@ -27,44 +115,43 @@ where
     elain::Align<ALIGN>: elain::Alignment,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        const { assert!(SIZE >= size_of::<T>()) };
-        const { assert!(ALIGN >= align_of::<T>()) };
-
-        // SAFETY: `OpaqueRepr` is always the `inner` variant.
-        unsafe { &mut self.0.inner }
+        self.0.as_mut()
     }
 }
 
-#[repr(C)]
-union OpaqueRepr<const SIZE: usize, const ALIGN: usize, T>
+impl<const SIZE: usize, const ALIGN: usize, T> Builder for Opaque<SIZE, ALIGN, T>
 where
+    T: Builder,
     elain::Align<ALIGN>: elain::Alignment,
 {
-    inner: ManuallyDrop<T>,
-    __backing_for_size_align_only: Backing<SIZE, ALIGN>,
-}
+    type Output = T::Output;
+    type Error = T::Error;
 
-impl<const SIZE: usize, const ALIGN: usize, T> Drop for OpaqueRepr<SIZE, ALIGN, T>
-where
-    elain::Align<ALIGN>: elain::Alignment,
-{
-    fn drop(&mut self) {
-        // SAFETY: `OpaqueRepr` is always the `inner` variant.
-        // Forwarding the drop impl is safe.
-        unsafe {
-            ManuallyDrop::drop(&mut self.inner);
-        }
+    unsafe fn build(self, out: &mut MaybeUninit<Self::Output>) -> Result<(), Self::Error> {
+        let inner = self.into_inner();
+        // SAFETY: just forwarding requirements.
+        unsafe { inner.build(out) }
     }
 }
 
-#[repr(C)]
-#[derive(Copy, Clone)]
-struct Backing<const SIZE: usize, const ALIGN: usize>
+impl<const SIZE: usize, const ALIGN: usize, T> InitDefault for Opaque<SIZE, ALIGN, T>
+where
+    T: InitDefault,
+    elain::Align<ALIGN>: elain::Alignment,
+{
+    fn init_default(out: &mut MaybeUninit<Self>) {
+        T::init_default(downcast_maybe_uninit(out));
+    }
+}
+
+fn downcast_maybe_uninit<const SIZE: usize, const ALIGN: usize, T>(
+    out: &mut MaybeUninit<Opaque<SIZE, ALIGN, T>>,
+) -> &mut MaybeUninit<T>
 where
     elain::Align<ALIGN>: elain::Alignment,
 {
-    size: [u8; SIZE],
-    align: elain::Align<ALIGN>,
-    // `Backing` should never be constructed.
-    never: core::convert::Infallible,
+    // SAFETY: `*Opaque<_, _, T>` is a valid `*T`
+    unsafe {
+        core::mem::transmute::<&mut MaybeUninit<Opaque<SIZE, ALIGN, T>>, &mut MaybeUninit<T>>(out)
+    }
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,6 +1,11 @@
 
 # cargo-vet audits file
 
+[[audits.elain]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+
 [[audits.rcgen]]
 who = "Jonathan Dygert <jdygert@spideroak.com>"
 criteria = "safe-to-run"


### PR DESCRIPTION
The opaque macro now serves two functions. It first wraps the original type in the `Opaque` wrapper. Then it applies the `[u8; SIZE]` representation to the generated renamed type that cbindgen sees.

Closes #227.