### PR TITLE
capi-core: fix `Opaque` use-after-free

### DIFF
--- a/crates/aranya-capi-core/src/opaque.rs
+++ b/crates/aranya-capi-core/src/opaque.rs
@@ -29,8 +29,10 @@ mod imp {
         pub fn into_inner(mut self) -> T {
             // SAFETY: always `inner`` variant
             let inner = unsafe { &mut self.inner };
-            // SAFETY: consuming self
-            unsafe { ManuallyDrop::take(inner) }
+            // SAFETY: we consume and forget `self`
+            let val = unsafe { ManuallyDrop::take(inner) };
+            core::mem::forget(self);
+            val
         }
 
         pub fn as_ref(&self) -> &T {
@@ -85,7 +87,7 @@ impl<const SIZE: usize, const ALIGN: usize, T> Opaque<SIZE, ALIGN, T>
 where
     elain::Align<ALIGN>: elain::Alignment,
 {
-    fn into_inner(self) -> T {
+    pub fn into_inner(self) -> T {
         self.0.into_inner()
     }
 }


### PR DESCRIPTION
Also make `into_inner` `pub`.