### PR TITLE
Close #193: Allow a struct to be cast to another struct with the same schema

### DIFF
--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -345,6 +345,8 @@ pub enum Expression {
     Block(Vec<AstNode<Statement>>, Box<Expression>),
     /// A substruct expression
     Substruct(Box<Expression>, Identifier),
+    /// As expression (struct isomorphic conversion, e.g. Foo as Bar)
+    StructAs(Box<Expression>, Identifier),
     /// Match expression
     Match(Box<MatchExpression>),
 }

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -345,8 +345,8 @@ pub enum Expression {
     Block(Vec<AstNode<Statement>>, Box<Expression>),
     /// A substruct expression
     Substruct(Box<Expression>, Identifier),
-    /// As expression (struct isomorphic conversion, e.g. Foo as Bar)
-    StructAs(Box<Expression>, Identifier),
+    /// Type cast expression
+    Cast(Box<Expression>, Identifier),
     /// Match expression
     Match(Box<MatchExpression>),
 }

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -987,6 +987,8 @@ impl<'a> CompileState<'a> {
                                 rhs_ident.clone(),
                             )));
                         }
+
+                        self.append_instruction(Instruction::Cast(rhs_ident.clone()));
                     }
                     Typeish::Indeterminate => {}
                     Typeish::Type(_) => {
@@ -995,16 +997,6 @@ impl<'a> CompileState<'a> {
                         )));
                     }
                 }
-
-                // Go back to the StructNew(LHS-ident) instruction, and replace it with StructNew(RHS-ident).
-                // The field order may be different, but the VM sets them by name, so the order doesn't matter.
-                let i = self
-                    .m
-                    .progmem
-                    .iter()
-                    .position(|i| matches!(i, &Instruction::StructNew(_)))
-                    .expect("should have found a StructNew instruction");
-                self.m.progmem[i] = Instruction::StructNew(rhs_ident.clone());
 
                 Typeish::Type(VType::Struct(rhs_ident.clone()))
             }

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -989,8 +989,6 @@ impl<'a> CompileState<'a> {
                                 rhs_ident.clone(),
                             )));
                         }
-
-                        self.append_instruction(Instruction::Cast(rhs_ident.clone()));
                     }
                     Typeish::Indeterminate => {}
                     Typeish::Type(_) => {
@@ -999,6 +997,8 @@ impl<'a> CompileState<'a> {
                         )));
                     }
                 }
+
+                self.append_instruction(Instruction::Cast(rhs_ident.clone()));
 
                 Typeish::Type(VType::Struct(rhs_ident.clone()))
             }

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -963,8 +963,8 @@ impl<'a> CompileState<'a> {
                 })?;
 
                 let lhs_type = self.compile_expression(lhs)?;
-                match lhs_type {
-                    Typeish::Definitely(NullableVType::Type(VType::Struct(lhs_struct_name))) => {
+                _ = lhs_type.try_map(|t| match t {
+                    NullableVType::Type(VType::Struct(lhs_struct_name)) => {
                         let lhs_fields =
                             self.m.struct_defs.get(&lhs_struct_name).ok_or_else(|| {
                                 self.err(CompileErrorType::NotDefined(format!(
@@ -981,14 +981,14 @@ impl<'a> CompileState<'a> {
                                 rhs_ident.clone(),
                             )));
                         }
+                        Ok(NullableVType::Type(VType::Struct(rhs_ident.clone())))
                     }
-                    Typeish::Definitely(_) => {
+                    _ => {
                         return Err(self.err(CompileErrorType::InvalidType(
                             "Expression to the left of `as` is not a struct".to_string(),
                         )));
                     }
-                    Typeish::Indeterminate | Typeish::Probably(_) => {}
-                }
+                })?;
 
                 self.append_instruction(Instruction::Cast(rhs_ident.clone()));
 

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -964,7 +964,7 @@ impl<'a> CompileState<'a> {
 
                 let lhs_type = self.compile_expression(lhs)?;
                 match lhs_type {
-                    Typeish::Type(VType::Struct(lhs_struct_name)) => {
+                    Typeish::Definitely(NullableVType::Type(VType::Struct(lhs_struct_name))) => {
                         let lhs_fields =
                             self.m.struct_defs.get(&lhs_struct_name).ok_or_else(|| {
                                 self.err(CompileErrorType::NotDefined(format!(
@@ -982,17 +982,17 @@ impl<'a> CompileState<'a> {
                             )));
                         }
                     }
-                    Typeish::Indeterminate => {}
-                    Typeish::Type(_) => {
+                    Typeish::Definitely(_) => {
                         return Err(self.err(CompileErrorType::InvalidType(
                             "Expression to the left of `as` is not a struct".to_string(),
                         )));
                     }
+                    Typeish::Indeterminate | Typeish::Probably(_) => {}
                 }
 
                 self.append_instruction(Instruction::Cast(rhs_ident.clone()));
 
-                Typeish::Type(VType::Struct(rhs_ident.clone()))
+                Typeish::Definitely(NullableVType::Type(VType::Struct(rhs_ident.clone())))
             }
             Expression::Add(a, b) | Expression::Subtract(a, b) => {
                 let left_type = self.compile_expression(a)?;

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -955,7 +955,7 @@ impl<'a> CompileState<'a> {
                 result_type
             }
             Expression::Cast(lhs, rhs_ident) => {
-                // NOTE this is implemented for structs
+                // NOTE this is implemented only for structs
 
                 // make sure other struct is defined
                 let rhs_fields = self.m.struct_defs.get(rhs_ident).cloned().ok_or_else(|| {
@@ -971,14 +971,6 @@ impl<'a> CompileState<'a> {
                                     "struct {lhs_struct_name}"
                                 )))
                             })?;
-
-                        // Don't allow converting to same type
-                        if &lhs_struct_name == rhs_ident {
-                            return Err(self.err(CompileErrorType::InvalidCast(
-                                lhs_struct_name,
-                                rhs_ident.clone(),
-                            )));
-                        }
 
                         // Check that both structs have the same field names and types (though not necessarily in the same order)
                         if lhs_fields.len() != rhs_fields.len()

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -983,11 +983,9 @@ impl<'a> CompileState<'a> {
                         }
                         Ok(NullableVType::Type(VType::Struct(rhs_ident.clone())))
                     }
-                    _ => {
-                        return Err(self.err(CompileErrorType::InvalidType(
-                            "Expression to the left of `as` is not a struct".to_string(),
-                        )));
-                    }
+                    _ => Err(self.err(CompileErrorType::InvalidType(
+                        "Expression to the left of `as` is not a struct".to_string(),
+                    ))),
                 })?;
 
                 self.append_instruction(Instruction::Cast(rhs_ident.clone()));

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -990,7 +990,7 @@ impl<'a> CompileState<'a> {
 
                 self.append_instruction(Instruction::Cast(rhs_ident.clone()));
 
-                Typeish::Definitely(NullableVType::Type(VType::Struct(rhs_ident.clone())))
+                Typeish::known(VType::Struct(rhs_ident.clone()))
             }
             Expression::Add(a, b) | Expression::Subtract(a, b) => {
                 let left_type = self.compile_expression(a)?;

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -957,10 +957,7 @@ impl<'a> CompileState<'a> {
             Expression::StructAs(lhs, rhs_ident) => {
                 // make sure other struct is defined
                 let rhs_fields = self.m.struct_defs.get(rhs_ident).cloned().ok_or_else(|| {
-                    self.err(CompileErrorType::NotDefined(format!(
-                        "Struct `{}` not defined",
-                        rhs_ident
-                    )))
+                    self.err(CompileErrorType::NotDefined(format!("struct {rhs_ident}")))
                 })?;
 
                 let lhs_type = self.compile_expression(lhs)?;
@@ -969,10 +966,17 @@ impl<'a> CompileState<'a> {
                         let lhs_fields =
                             self.m.struct_defs.get(&lhs_struct_name).ok_or_else(|| {
                                 self.err(CompileErrorType::NotDefined(format!(
-                                    "Struct `{}` not defined",
-                                    lhs_struct_name
+                                    "struct {lhs_struct_name}"
                                 )))
                             })?;
+
+                        // Don't allow converting to same type
+                        if &lhs_struct_name == rhs_ident {
+                            return Err(self.err(CompileErrorType::InvalidCast(
+                                lhs_struct_name,
+                                rhs_ident.clone(),
+                            )));
+                        }
 
                         // Check that both structs have the same field names and types (though not necessarily in the same order)
                         if lhs_fields.len() != rhs_fields.len()

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -954,7 +954,9 @@ impl<'a> CompileState<'a> {
 
                 result_type
             }
-            Expression::StructAs(lhs, rhs_ident) => {
+            Expression::Cast(lhs, rhs_ident) => {
+                // NOTE this is implemented for structs
+
                 // make sure other struct is defined
                 let rhs_fields = self.m.struct_defs.get(rhs_ident).cloned().ok_or_else(|| {
                     self.err(CompileErrorType::NotDefined(format!("struct {rhs_ident}")))

--- a/crates/aranya-policy-compiler/src/compile/error.rs
+++ b/crates/aranya-policy-compiler/src/compile/error.rs
@@ -61,6 +61,9 @@ pub enum CompileErrorType {
     /// Todo found
     #[error("todo found")]
     TodoFound,
+    /// Invalid cast - LHS cannot be converted to RHS
+    #[error("invalid cast: `{0}` cannot be converted to `{1}`")]
+    InvalidCast(Identifier, Identifier),
     /// An implementation bug
     #[error("bug: {0}")]
     Bug(#[from] Bug),

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -2469,8 +2469,8 @@ fn test_struct_conversion() {
                     a int,
                     b string,
                 }
-                seal { return None }
-                open { return None }
+                seal { return todo() }
+                open { return todo() }
             }
             action convert() {
                 let bar = Foo { a: 1, b: "test" } as Bar

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -2395,16 +2395,6 @@ fn test_struct_conversion_errors() {
             CompileErrorType::NotDefined("struct Bar".to_string()),
         ),
         (
-            "LHS is same as RHS",
-            r#"
-            struct Foo { a int, b string }
-            function convert() struct Foo {
-                return Foo { a: 1, b: "test" } as Foo
-            }
-            "#,
-            CompileErrorType::InvalidCast(ident!("Foo"), ident!("Foo")),
-        ),
-        (
             "types don't match",
             r#"
             struct Foo { a int, b string }
@@ -2416,7 +2406,7 @@ fn test_struct_conversion_errors() {
             CompileErrorType::InvalidCast(ident!("Foo"), ident!("Bar")),
         ),
         (
-            "names don't match",
+            "field names don't match",
             r#"
             struct Foo { a int, b string }
             struct Bar { a bool, s string }
@@ -2487,6 +2477,15 @@ fn test_struct_conversion() {
                 publish bar
             }
         "#,
+        ),
+        (
+            "cast to self - noop",
+            r#"
+            struct Foo { a int, b string }
+            function convert() struct Foo {
+                return Foo { a: 1, b: "test" } as Foo
+            }
+            "#,
         ),
     ];
 

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -2437,17 +2437,6 @@ fn test_struct_conversion_errors() {
             "#,
             CompileErrorType::InvalidCast(ident!("Foo"), ident!("Bar")),
         ),
-        (
-            "different number of fields",
-            r#"
-            struct Foo { a int, b string }
-            struct Bar { a int, b string, c bool }
-            function convert() struct Bar {
-                return Foo { a: 1, b: "test" } as Bar
-            }
-            "#,
-            CompileErrorType::InvalidCast(ident!("Foo"), ident!("Bar")),
-        ),
     ];
 
     for (msg, text, expected) in cases {

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -2380,6 +2380,28 @@ fn test_substruct_errors() {
         assert_eq!(err.to_string(), c.e);
     }
 }
+
+#[test]
+fn test_struct_conversion() {
+    let text = r#"
+        struct Foo {
+            a int,
+            b string,
+        }
+
+        struct Bar {
+            b string,
+            a int,
+        }
+
+        function convert() struct Bar {
+            return Foo { a: 1, b: "test" } as Bar
+        }
+    "#;
+
+    compile_pass(text);
+}
+
 #[test]
 fn if_expression_block() {
     let text = r#"

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -2402,7 +2402,7 @@ fn test_struct_conversion_errors() {
                 return Foo { a: 1, b: "test" } as Foo
             }
             "#,
-            CompileErrorType::InvalidCast("Foo".to_string(), "Foo".to_string()),
+            CompileErrorType::InvalidCast(ident!("Foo"), ident!("Foo")),
         ),
         (
             "types don't match",
@@ -2413,7 +2413,7 @@ fn test_struct_conversion_errors() {
                 return Foo { a: 1, b: "test" } as Bar
             }
             "#,
-            CompileErrorType::InvalidCast("Foo".to_string(), "Bar".to_string()),
+            CompileErrorType::InvalidCast(ident!("Foo"), ident!("Bar")),
         ),
         (
             "names don't match",
@@ -2424,7 +2424,7 @@ fn test_struct_conversion_errors() {
                 return Foo { a: 1, b: "test" } as Bar
             }
             "#,
-            CompileErrorType::InvalidCast("Foo".to_string(), "Bar".to_string()),
+            CompileErrorType::InvalidCast(ident!("Foo"), ident!("Bar")),
         ),
         (
             "different number of fields",
@@ -2435,7 +2435,7 @@ fn test_struct_conversion_errors() {
                 return Foo { a: 1, b: "test" } as Bar
             }
             "#,
-            CompileErrorType::InvalidCast("Foo".to_string(), "Bar".to_string()),
+            CompileErrorType::InvalidCast(ident!("Foo"), ident!("Bar")),
         ),
         (
             "different number of fields",
@@ -2446,7 +2446,7 @@ fn test_struct_conversion_errors() {
                 return Foo { a: 1, b: "test" } as Bar
             }
             "#,
-            CompileErrorType::InvalidCast("Foo".to_string(), "Bar".to_string()),
+            CompileErrorType::InvalidCast(ident!("Foo"), ident!("Bar")),
         ),
     ];
 

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -1687,7 +1687,7 @@ pub fn parse_ffi_structs_enums(data: &str) -> Result<FfiTypes, ParseError> {
 /// | Priority | Op |
 /// |----------|----|
 /// | 1        | `.` |
-/// | 2        | `substruct`, `cast` (infix) |
+/// | 2        | `substruct`, `as` (infix) |
 /// | 3        | `-` (prefix), `!`, `unwrap`, `check_unwrap` |
 /// | 4        | `%` |
 /// | 5        | `+`, `-` (infix) |

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -585,8 +585,8 @@ impl ChunkParser<'_> {
                         Some(op.as_span()),
                     )),
                 },
-                Rule::struct_as => match rhs? {
-                        Expression::Identifier(s) => Ok(Expression::StructAs(Box::new(lhs?), s)),
+                Rule::cast => match rhs? {
+                        Expression::Identifier(s) => Ok(Expression::Cast(Box::new(lhs?), s)),
                         e => Err(ParseError::new(
                             ParseErrorKind::InvalidSubstruct,
                             format!("Expression `{:?}` to the right of the as operator must be an identifier", e),
@@ -1708,7 +1708,7 @@ pub fn get_pratt_parser() -> PrattParser<Rule> {
             | Op::prefix(Rule::unwrap)
             | Op::prefix(Rule::check_unwrap))
         .op(Op::infix(Rule::substruct, Assoc::Left))
-        .op(Op::infix(Rule::struct_as, Assoc::Left))
+        .op(Op::infix(Rule::cast, Assoc::Left))
         .op(Op::infix(Rule::dot, Assoc::Left))
 }
 

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -1687,12 +1687,13 @@ pub fn parse_ffi_structs_enums(data: &str) -> Result<FfiTypes, ParseError> {
 /// | Priority | Op |
 /// |----------|----|
 /// | 1        | `.` |
-/// | 2        | `-` (prefix), `!`, `unwrap`, `check_unwrap` |
-/// | 3        | `%` |
-/// | 4        | `+`, `-` (infix) |
-/// | 5        | `>`, `<`, `>=`, `<=`, `is` |
-/// | 6        | `==`, `!=` |
-/// | 7        | `&&`, \|\| (\| conflicts with markdown tables :[) |
+/// | 2        | `substruct`, `cast` (infix) |
+/// | 3        | `-` (prefix), `!`, `unwrap`, `check_unwrap` |
+/// | 4        | `%` |
+/// | 5        | `+`, `-` (infix) |
+/// | 6        | `>`, `<`, `>=`, `<=`, `is` |
+/// | 7        | `==`, `!=` |
+/// | 8        | `&&`, \|\| (\| conflicts with markdown tables :[) |
 pub fn get_pratt_parser() -> PrattParser<Rule> {
     PrattParser::new()
         .op(Op::infix(Rule::and, Assoc::Left) | Op::infix(Rule::or, Assoc::Left))

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -586,12 +586,12 @@ impl ChunkParser<'_> {
                     )),
                 },
                 Rule::cast => match rhs? {
-                        Expression::Identifier(s) => Ok(Expression::Cast(Box::new(lhs?), s)),
-                        e => Err(ParseError::new(
-                            ParseErrorKind::InvalidSubstruct,
-                            format!("Expression `{:?}` to the right of the as operator must be an identifier", e),
-                            Some(op.as_span()),
-                        )),
+                    Expression::Identifier(s) => Ok(Expression::Cast(Box::new(lhs?), s)),
+                    e => Err(ParseError::new(
+                        ParseErrorKind::InvalidSubstruct,
+                        format!("Expression `{:?}` to the right of the as operator must be an identifier", e),
+                        Some(op.as_span()),
+                    )),
                 },
                 _ => Err(ParseError::new(
                     ParseErrorKind::Expression,
@@ -1707,8 +1707,7 @@ pub fn get_pratt_parser() -> PrattParser<Rule> {
             | Op::prefix(Rule::not)
             | Op::prefix(Rule::unwrap)
             | Op::prefix(Rule::check_unwrap))
-        .op(Op::infix(Rule::substruct, Assoc::Left))
-        .op(Op::infix(Rule::cast, Assoc::Left))
+        .op(Op::infix(Rule::substruct, Assoc::Left) | Op::infix(Rule::cast, Assoc::Left))
         .op(Op::infix(Rule::dot, Assoc::Left))
 }
 

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -584,7 +584,15 @@ impl ChunkParser<'_> {
                         format!("Expression `{:?}` to the right of the substruct operator must be an identifier", e),
                         Some(op.as_span()),
                     )),
-                }
+                },
+                Rule::struct_as => match rhs? {
+                        Expression::Identifier(s) => Ok(Expression::StructAs(Box::new(lhs?), s)),
+                        e => Err(ParseError::new(
+                            ParseErrorKind::InvalidSubstruct,
+                            format!("Expression `{:?}` to the right of the as operator must be an identifier", e),
+                            Some(op.as_span()),
+                        )),
+                },
                 _ => Err(ParseError::new(
                     ParseErrorKind::Expression,
                     format!("bad infix: {:?}", op.as_rule()),
@@ -1700,6 +1708,7 @@ pub fn get_pratt_parser() -> PrattParser<Rule> {
             | Op::prefix(Rule::unwrap)
             | Op::prefix(Rule::check_unwrap))
         .op(Op::infix(Rule::substruct, Assoc::Left))
+        .op(Op::infix(Rule::struct_as, Assoc::Left))
         .op(Op::infix(Rule::dot, Assoc::Left))
 }
 

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -219,8 +219,8 @@ and = { "&&" }
 or = { "||" }
 dot = { "." }
 substruct = { "substruct" }
-struct_as = { "as" }
-infix_op = _{ add | subtract | and | or | dot | equal | not_equal | greater_than_or_equal | less_than_or_equal | greater_than | less_than | substruct | struct_as }
+cast = { "as" }
+infix_op = _{ add | subtract | and | or | dot | equal | not_equal | greater_than_or_equal | less_than_or_equal | greater_than | less_than | substruct | cast }
 
 // ## Prefix operators
 neg = { "-" }

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -219,7 +219,8 @@ and = { "&&" }
 or = { "||" }
 dot = { "." }
 substruct = { "substruct" }
-infix_op = _{ add | subtract | and | or | dot | equal | not_equal | greater_than_or_equal | less_than_or_equal | greater_than | less_than | substruct }
+struct_as = { "as" }
+infix_op = _{ add | subtract | and | or | dot | equal | not_equal | greater_than_or_equal | less_than_or_equal | greater_than | less_than | substruct | struct_as }
 
 // ## Prefix operators
 neg = { "-" }

--- a/crates/aranya-policy-lang/test-policy.md
+++ b/crates/aranya-policy-lang/test-policy.md
@@ -2,22 +2,17 @@
 policy-version: 2
 ---
 ```policy
-command Result {
-    fields {
-        x int
-    }
+struct Foo {
+    a int,
+    b string,
 }
 
-action foo() {
-    let x = 6
+struct Bar {
+    b string,
+    a int,
+}
 
-    match x {
-        5 => {
-            publish Result { x: x }
-        }
-        6 => {
-            publish Result { x: x }
-        }
-    }
+function convert() struct Bar {
+    return Foo { a: 1, b: "test" } as Bar
 }
 ```

--- a/crates/aranya-policy-module/src/instructions.rs
+++ b/crates/aranya-policy-module/src/instructions.rs
@@ -139,6 +139,8 @@ pub enum Instruction {
     MStructSet(NonZeroUsize),
     /// Get multiple members from the struct
     MStructGet(NonZeroUsize),
+    /// Cast previous stack value to given type
+    Cast(Identifier),
     // context-specific
     /// Publish a struct as a command
     Publish,
@@ -210,6 +212,7 @@ impl Display for Instruction {
             Instruction::Serialize => write!(f, "serialize"),
             Instruction::Deserialize => write!(f, "deserialize"),
             Instruction::Meta(m) => write!(f, "meta: {m}"),
+            Instruction::Cast(identifier) => write!(f, "cast {identifier}"),
         }
     }
 }

--- a/crates/aranya-policy-vm/doc/machine-model.md
+++ b/crates/aranya-policy-vm/doc/machine-model.md
@@ -32,6 +32,7 @@ All instructions can be prefixed with a label, but labels can only be jumped to 
 |`x`, `y`  |numbers|
 |`a`, `b`  |bools|
 |`s`       |a string|
+|`n`       |identifier|
 |`t`       |a struct|
 |`v`, `w`  |any value|
 |`f`       |a fact|
@@ -69,7 +70,7 @@ All instructions can be prefixed with a label, but labels can only be jumped to 
 |`gt`           | `( a b -- a&gt;b )`  | true if `a` is greater than `b`, else false
 |`lt`           | `( a b -- a&lt;b )`  | true if `a` is less than `b`, else false
 |`eq`           | `( a b -- a=b )`     | true if `a` is equal to `b`, else false
-|`as`           | `foo as Bar`         | replaces the foo value at the top of the stack with a new instance of Bar |
+|`as(n)`        | `( t -- t' )`        | replace a struct value with an equivalent struct of the given type
 
 ## facts
 ||||

--- a/crates/aranya-policy-vm/doc/machine-model.md
+++ b/crates/aranya-policy-vm/doc/machine-model.md
@@ -69,6 +69,7 @@ All instructions can be prefixed with a label, but labels can only be jumped to 
 |`gt`           | `( a b -- a&gt;b )`  | true if `a` is greater than `b`, else false
 |`lt`           | `( a b -- a&lt;b )`  | true if `a` is less than `b`, else false
 |`eq`           | `( a b -- a=b )`     | true if `a` is equal to `b`, else false
+|`as`           | `foo as Bar`         | replaces the foo value at the top of the stack with a new instance of Bar |
 
 ## facts
 ||||

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -952,36 +952,12 @@ where
                 match value {
                     Value::Struct(s) => {
                         // make sure identifier is a valid struct name
-                        let rhs_struct =
-                            self.machine.struct_defs.get(&identifier).ok_or_else(|| {
-                                self.err(MachineErrorType::NotDefined(alloc::format!(
-                                    "struct `{}`",
-                                    identifier
-                                )))
-                            })?;
-
-                        // Check that all required fields exist and have matching types
-                        for field in rhs_struct {
-                            let field_name = &field.identifier;
-                            let field_type = &field.field_type;
-
-                            // Check if the source struct has this field
-                            let value = s.fields.get(field_name).ok_or_else(|| {
-                                self.err(MachineErrorType::Unknown(alloc::format!(
-                                    "cannot cast to `struct {}`: missing field `{}`",
-                                    identifier,
-                                    field_name
-                                )))
-                            })?;
-
-                            // Check if the type matches
-                            if !value.fits_type(field_type) {
-                                return Err(self.err(MachineErrorType::Unknown(alloc::format!(
-                                    "cannot cast to `struct {}`: field `{}` has wrong type (expected `{}`, found `{}`)",
-                                    identifier, field_name, field_type, value.type_name()
-                                ))));
-                            }
-                        }
+                        self.machine.struct_defs.get(&identifier).ok_or_else(|| {
+                            self.err(MachineErrorType::NotDefined(alloc::format!(
+                                "struct `{}`",
+                                identifier
+                            )))
+                        })?;
 
                         // replace value on stack with clone, under new name
                         let mut s = s;

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -959,7 +959,7 @@ where
                                 "Cast RHS",
                             )));
                         }
-                        // Cast to Struct
+                        // replace value on stack with clone, under new name
                         let mut s = s.clone();
                         s.name = identifier.clone();
                         self.ipush(Value::Struct(s))?;

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -7,7 +7,6 @@ use alloc::{
     vec,
     vec::Vec,
 };
-use aranya_crypto::Id;
 use core::{
     cell::RefCell,
     fmt::{self, Display},
@@ -955,10 +954,10 @@ where
                         // make sure identifier is a valid struct name
                         let rhs_struct =
                             self.machine.struct_defs.get(&identifier).ok_or_else(|| {
-                                return self.err(MachineErrorType::NotDefined(alloc::format!(
+                                self.err(MachineErrorType::NotDefined(alloc::format!(
                                     "struct `{}`",
-                                    identifier.to_string()
-                                )));
+                                    identifier
+                                )))
                             })?;
 
                         // Check that all required fields exist and have matching types

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -952,12 +952,36 @@ where
                 match value {
                     Value::Struct(s) => {
                         // make sure identifier is a valid struct name
-                        self.machine.struct_defs.get(&identifier).ok_or_else(|| {
-                            self.err(MachineErrorType::NotDefined(alloc::format!(
-                                "struct `{}`",
-                                identifier
-                            )))
-                        })?;
+                        let rhs_struct =
+                            self.machine.struct_defs.get(&identifier).ok_or_else(|| {
+                                self.err(MachineErrorType::NotDefined(alloc::format!(
+                                    "struct `{}`",
+                                    identifier
+                                )))
+                            })?;
+
+                        // Check that all required fields exist and have matching types
+                        for field in rhs_struct {
+                            let field_name = &field.identifier;
+                            let field_type = &field.field_type;
+
+                            // Check if the source struct has this field
+                            let value = s.fields.get(field_name).ok_or_else(|| {
+                                self.err(MachineErrorType::Unknown(alloc::format!(
+                                    "cannot cast to `struct {}`: missing field `{}`",
+                                    identifier,
+                                    field_name
+                                )))
+                            })?;
+
+                            // Check if the type matches
+                            if !value.fits_type(field_type) {
+                                return Err(self.err(MachineErrorType::Unknown(alloc::format!(
+                                    "cannot cast to `struct {}`: field `{}` has wrong type (expected `{}`, found `{}`)",
+                                    identifier, field_name, field_type, value.type_name()
+                                ))));
+                            }
+                        }
 
                         // replace value on stack with clone, under new name
                         let mut s = s;

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -947,6 +947,32 @@ where
                 self.ipush(s)?;
             }
             Instruction::Meta(_m) => {}
+            Instruction::Cast(identifier) => {
+                let value = self.ipop_value()?;
+                match value {
+                    Value::Struct(s) => {
+                        // make sure identifier is a valid struct name
+                        if !self.machine.struct_defs.contains_key(&identifier) {
+                            return Err(self.err(MachineErrorType::invalid_type(
+                                "Struct",
+                                identifier.to_string(),
+                                "Cast RHS",
+                            )));
+                        }
+                        // Cast to Struct
+                        let mut s = s.clone();
+                        s.name = identifier.clone();
+                        self.ipush(Value::Struct(s))?;
+                    }
+                    _ => {
+                        return Err(self.err(MachineErrorType::invalid_type(
+                            "Struct",
+                            value.type_name(),
+                            "Cast LHS",
+                        )));
+                    }
+                }
+            }
         }
 
         self.pc = self.pc.checked_add(1).assume("self.pc + 1 must not wrap")?;

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -2439,6 +2439,7 @@ fn test_struct_conversion() -> anyhow::Result<()> {
             publish foo as Bar // var reference
             publish Foo { y: "b", x: 1 } as Bar // struct literal
             publish new_foo(5, "def") as Bar // function return value
+            publish Bar { x: 100, y: "xyz" } as Bar
         }
         "#;
 
@@ -2476,6 +2477,16 @@ fn test_struct_conversion() -> anyhow::Result<()> {
             vec![
                 KVPair::new(ident!("x"), Value::Int(5)),
                 KVPair::new(ident!("y"), Value::String(text!("def"))),
+            ]
+        )
+    );
+    assert_eq!(
+        io.borrow().publish_stack[3],
+        (
+            ident!("Bar"),
+            vec![
+                KVPair::new(ident!("x"), Value::Int(100)),
+                KVPair::new(ident!("y"), Value::String(text!("xyz"))),
             ]
         )
     );

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -2429,8 +2429,9 @@ fn test_struct_conversion() -> anyhow::Result<()> {
             open { return None }
         }
         action test() {
-            let bar = Foo { x: 42, y: "abc" } as Bar
-            publish bar
+            let foo = Foo { x: 42, y: "abc" }
+            publish foo as Bar
+            publish Foo { x: 1, y: "b" } as Bar
         }
     "#;
 
@@ -2448,6 +2449,16 @@ fn test_struct_conversion() -> anyhow::Result<()> {
             vec![
                 KVPair::new(ident!("x"), Value::Int(42)),
                 KVPair::new(ident!("y"), Value::String(text!("abc"))),
+            ]
+        )
+    );
+    assert_eq!(
+        io.borrow().publish_stack[1],
+        (
+            ident!("Foo"), // TODO is this right?
+            vec![
+                KVPair::new(ident!("x"), Value::Int(1)),
+                KVPair::new(ident!("y"), Value::String(text!("b"))),
             ]
         )
     );

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -2449,46 +2449,40 @@ fn test_struct_conversion() -> anyhow::Result<()> {
     let io = RefCell::new(TestIO::new());
     let ctx = dummy_ctx_action(ident!("test"));
     let mut rs = machine.create_run_state(&io, ctx);
-    let _ = call_action(&mut rs, &io, ident!("test"), iter::empty::<Value>())?;
+    let mut published = Vec::new();
+    let _ = call_action(
+        &mut rs,
+        &mut published,
+        ident!("test"),
+        iter::empty::<Value>(),
+    )?;
     assert_eq!(
-        io.borrow().publish_stack[0],
-        (
-            ident!("Bar"),
-            vec![
-                KVPair::new(ident!("x"), Value::Int(42)),
-                KVPair::new(ident!("y"), Value::String(text!("abc"))),
-            ]
-        )
+        published[0],
+        vm_struct!(Bar {
+            x: Value::Int(42),
+            y: Value::String(text!("abc")),
+        })
     );
     assert_eq!(
-        io.borrow().publish_stack[1],
-        (
-            ident!("Bar"),
-            vec![
-                KVPair::new(ident!("x"), Value::Int(1)),
-                KVPair::new(ident!("y"), Value::String(text!("b"))),
-            ]
-        )
+        published[1],
+        vm_struct!(Bar {
+            x: Value::Int(1),
+            y: Value::String(text!("b")),
+        })
     );
     assert_eq!(
-        io.borrow().publish_stack[2],
-        (
-            ident!("Bar"),
-            vec![
-                KVPair::new(ident!("x"), Value::Int(5)),
-                KVPair::new(ident!("y"), Value::String(text!("def"))),
-            ]
-        )
+        published[2],
+        vm_struct!(Bar {
+            x: Value::Int(5),
+            y: Value::String(text!("def")),
+        })
     );
     assert_eq!(
-        io.borrow().publish_stack[3],
-        (
-            ident!("Bar"),
-            vec![
-                KVPair::new(ident!("x"), Value::Int(100)),
-                KVPair::new(ident!("y"), Value::String(text!("xyz"))),
-            ]
-        )
+        published[3],
+        vm_struct!(Bar {
+            x: Value::Int(100),
+            y: Value::String(text!("xyz")),
+        })
     );
     Ok(())
 }

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -2438,16 +2438,16 @@ fn test_struct_conversion() -> anyhow::Result<()> {
     let module = Compiler::new(&policy).compile()?;
     let machine = Machine::from_module(module)?;
     let io = RefCell::new(TestIO::new());
-    let ctx = dummy_ctx_action("test");
+    let ctx = dummy_ctx_action(ident!("test"));
     let mut rs = machine.create_run_state(&io, ctx);
-    let _ = call_action(&mut rs, &io, "test", iter::empty::<Value>())?;
+    let _ = call_action(&mut rs, &io, ident!("test"), iter::empty::<Value>())?;
     assert_eq!(
         io.borrow().publish_stack[0],
         (
-            "Bar".to_string(),
+            ident!("Bar"),
             vec![
-                KVPair::new("x", Value::Int(42)),
-                KVPair::new("y", Value::String("abc".to_string())),
+                KVPair::new(ident!("x"), Value::Int(42)),
+                KVPair::new(ident!("y"), Value::String(text!("abc"))),
             ]
         )
     );

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -2426,8 +2426,8 @@ fn test_struct_conversion() -> anyhow::Result<()> {
 
         command Bar {
             fields { x int, y string }
-            seal { return None }
-            open { return None }
+            seal { return todo() }
+            open { return todo() }
         }
         
         function new_foo(x int, y string) struct Foo {


### PR DESCRIPTION
E.g.
```
struct Foo { x int, y string }

command Bar {
  fields { y string, x int }
}

action a() {
    publish Foo { x: 1, y:"abc" } as Bar
}
```