### PR TITLE
all: use derive-where for better derive bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "cfg-if",
  "ciborium",
  "ciborium-io",
+ "derive-where",
  "postcard",
  "proptest",
  "proptest-derive",
@@ -302,6 +303,7 @@ dependencies = [
  "cfg-if",
  "const_format",
  "criterion",
+ "derive-where",
  "errno",
  "heapless 0.8.0",
  "hex",
@@ -351,6 +353,7 @@ dependencies = [
  "aranya-policy-lang",
  "aranya-policy-vm",
  "aranya-runtime",
+ "derive-where",
  "postcard",
  "serde",
  "tempfile",
@@ -1174,6 +1177,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ byteorder = { version = "1", default-features = false }
 bytes = { version = "1.9.0" }
 cfg-if = { version = "1", default-features = false }
 const_format = { version = "0.2", default-features = false }
-derive-where = { version = "1" }
+derive-where = { version = "1", default-features = false }
 errno = { version = "0.3", default-features = false }
 heapless = { version = "0.8", default-features = false }
 libc = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ byteorder = { version = "1", default-features = false }
 bytes = { version = "1.9.0" }
 cfg-if = { version = "1", default-features = false }
 const_format = { version = "0.2", default-features = false }
+derive-where = { version = "1" }
 errno = { version = "0.3", default-features = false }
 heapless = { version = "0.8", default-features = false }
 libc = { version = "0.2", default-features = false }

--- a/crates/aranya-crypto/Cargo.toml
+++ b/crates/aranya-crypto/Cargo.toml
@@ -157,6 +157,7 @@ byteorder = { workspace = true, default-features = false, optional = true }
 cfg-if = { workspace = true, default-features = false, optional = true }
 ciborium = { version = "0.2", default-features = false, optional = true }
 ciborium-io = { version = "0.2", default-features = false, optional = true }
+derive-where = { workspace = true, features = ["serde"] }
 proptest = { workspace = true, default-features = false, features = ["alloc"], optional = true }
 proptest-derive = { workspace = true, optional = true }
 rustix = { version = "0.38", default-features = false, features = ["fs"], optional = true }

--- a/crates/aranya-crypto/Cargo.toml
+++ b/crates/aranya-crypto/Cargo.toml
@@ -157,7 +157,7 @@ byteorder = { workspace = true, default-features = false, optional = true }
 cfg-if = { workspace = true, default-features = false, optional = true }
 ciborium = { version = "0.2", default-features = false, optional = true }
 ciborium-io = { version = "0.2", default-features = false, optional = true }
-derive-where = { workspace = true, features = ["serde"] }
+derive-where = { workspace = true, default-features = false, features = ["serde"] }
 proptest = { workspace = true, default-features = false, features = ["alloc"], optional = true }
 proptest-derive = { workspace = true, optional = true }
 rustix = { version = "0.38", default-features = false, features = ["fs"], optional = true }

--- a/crates/aranya-crypto/src/afc/bidi.rs
+++ b/crates/aranya-crypto/src/afc/bidi.rs
@@ -1,7 +1,7 @@
 use core::cell::OnceCell;
 
 use buggy::BugExt;
-use serde::{Deserialize, Serialize};
+use derive_where::derive_where;
 use spideroak_crypto::{
     csprng::Random,
     hash::{Digest, Hash},
@@ -235,7 +235,7 @@ unwrapped! {
 /// A bidirectional channel peer's encapsulated secret.
 ///
 /// This should be freely shared with the channel peer.
-#[derive(Serialize, Deserialize)]
+#[derive_where(Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct BidiPeerEncap<CS: CipherSuite> {
     encap: Encap<CS>,

--- a/crates/aranya-crypto/src/afc/shared.rs
+++ b/crates/aranya-crypto/src/afc/shared.rs
@@ -1,3 +1,4 @@
+use derive_where::derive_where;
 use spideroak_crypto::{
     csprng::{Csprng, Random},
     import::{ExportError, Import, ImportError},
@@ -11,6 +12,7 @@ use spideroak_crypto::{
 use crate::ciphersuite::CipherSuite;
 
 /// The root key material for a channel.
+#[derive_where(Clone)]
 pub(crate) struct RootChannelKey<CS: CipherSuite>(<CS::Kem as Kem>::DecapKey);
 
 impl<CS: CipherSuite> RootChannelKey<CS> {
@@ -24,12 +26,6 @@ impl<CS: CipherSuite> RootChannelKey<CS> {
 
     pub(super) fn into_inner(self) -> <CS::Kem as Kem>::DecapKey {
         self.0
-    }
-}
-
-impl<CS: CipherSuite> Clone for RootChannelKey<CS> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
     }
 }
 

--- a/crates/aranya-crypto/src/afc/uni.rs
+++ b/crates/aranya-crypto/src/afc/uni.rs
@@ -1,7 +1,7 @@
 use core::cell::OnceCell;
 
 use buggy::BugExt;
-use serde::{Deserialize, Serialize};
+use derive_where::derive_where;
 use spideroak_crypto::{
     csprng::Random,
     hash::{Digest, Hash},
@@ -206,7 +206,7 @@ unwrapped! {
 /// A unirectional channel peer's encapsulated secret.
 ///
 /// This should be freely shared with the channel peer.
-#[derive(Serialize, Deserialize)]
+#[derive_where(Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct UniPeerEncap<CS: CipherSuite> {
     encap: Encap<CS>,

--- a/crates/aranya-crypto/src/aqc/bidi.rs
+++ b/crates/aranya-crypto/src/aqc/bidi.rs
@@ -1,5 +1,6 @@
 use core::{cell::OnceCell, fmt};
 
+use derive_where::derive_where;
 use serde::{Deserialize, Serialize};
 use spideroak_crypto::{
     csprng::Random,
@@ -195,7 +196,7 @@ unwrapped! {
 /// A bidirectional channel peer's encapsulated secret.
 ///
 /// This should be freely shared with the channel peer.
-#[derive(Serialize, Deserialize)]
+#[derive_where(Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct BidiPeerEncap<CS: CipherSuite> {
     encap: Encap<CS>,

--- a/crates/aranya-crypto/src/aqc/bidi.rs
+++ b/crates/aranya-crypto/src/aqc/bidi.rs
@@ -300,8 +300,10 @@ impl<CS: CipherSuite> BidiSecrets<CS> {
 
 /// The shared bidirectional channel secret used by both the
 /// channel author and channel peer to derive individual PSKs.
+#[derive_where(Debug)]
 pub struct BidiSecret<CS: CipherSuite> {
     id: BidiChannelId,
+    #[derive_where(skip(Debug))]
     ctx: SendOrRecvCtx<CS>,
 }
 
@@ -403,14 +405,6 @@ impl<CS: CipherSuite> BidiSecret<CS> {
     }
 }
 
-impl<CS: CipherSuite> fmt::Debug for BidiSecret<CS> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BidiSecret")
-            .field("id", &self.id)
-            .finish_non_exhaustive()
-    }
-}
-
 /// The context used when generating a [`BidiPsk`].
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Immutable, IntoBytes, KnownLayout)]
@@ -421,8 +415,10 @@ struct PskCtx {
 }
 
 /// A PSK for a bidirectional channel.
+#[derive_where(Debug)]
 pub struct BidiPsk<CS> {
     id: BidiPskId,
+    #[derive_where(skip(Debug))]
     psk: RawPsk<CS>,
 }
 
@@ -445,15 +441,6 @@ impl<CS: CipherSuite> BidiPsk<CS> {
     /// [RFC 8446]: https://datatracker.ietf.org/doc/html/rfc8446#autoid-37
     pub fn raw_secret_bytes(&self) -> &[u8] {
         self.psk.raw_secret_bytes()
-    }
-}
-
-impl<CS: CipherSuite> fmt::Debug for BidiPsk<CS> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Avoid leaking `psk`.
-        f.debug_struct("BidiPsk")
-            .field("id", &self.id)
-            .finish_non_exhaustive()
     }
 }
 

--- a/crates/aranya-crypto/src/aqc/shared.rs
+++ b/crates/aranya-crypto/src/aqc/shared.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use serde::{Deserialize, Serialize};
+use derive_where::derive_where;
 use spideroak_crypto::{
     csprng::{Csprng, Random},
     hpke::{RecvCtx, SendCtx},
@@ -17,6 +17,7 @@ use spideroak_crypto::{
 use crate::ciphersuite::CipherSuite;
 
 /// The root key material for a channel.
+#[derive_where(Clone)]
 pub(crate) struct RootChannelKey<CS: CipherSuite>(<CS::Kem as Kem>::DecapKey);
 
 impl<CS: CipherSuite> RootChannelKey<CS> {
@@ -30,12 +31,6 @@ impl<CS: CipherSuite> RootChannelKey<CS> {
 
     pub(super) fn into_inner(self) -> <CS::Kem as Kem>::DecapKey {
         self.0
-    }
-}
-
-impl<CS: CipherSuite> Clone for RootChannelKey<CS> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
     }
 }
 
@@ -70,7 +65,7 @@ impl<'a, CS: CipherSuite> Import<&'a [u8]> for RootChannelKey<CS> {
 }
 
 /// A raw PSK.
-#[derive(Serialize, Deserialize)]
+#[derive_where(Clone, Serialize, Deserialize)]
 pub(super) struct RawPsk<CS> {
     // TODO(eric): support different sizes?
     psk: [u8; 32],
@@ -82,16 +77,6 @@ impl<CS: CipherSuite> RawPsk<CS> {
     #[inline]
     pub(super) const fn raw_secret_bytes(&self) -> &[u8] {
         &self.psk
-    }
-}
-
-impl<CS: CipherSuite> Clone for RawPsk<CS> {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self {
-            psk: self.psk,
-            _marker: PhantomData,
-        }
     }
 }
 

--- a/crates/aranya-crypto/src/aqc/uni.rs
+++ b/crates/aranya-crypto/src/aqc/uni.rs
@@ -1,5 +1,6 @@
 use core::{cell::OnceCell, fmt};
 
+use derive_where::derive_where;
 use serde::{Deserialize, Serialize};
 use spideroak_crypto::{
     csprng::Random,
@@ -107,7 +108,7 @@ use crate::{
 /// assert!(bool::from(device1_psk.raw_secret_bytes().ct_eq(device2_psk.raw_secret_bytes())));
 /// # }
 /// ```
-#[derive(Debug)]
+#[derive_where(Debug)]
 pub struct UniChannel<'a, CS: CipherSuite> {
     /// The size in bytes of the PSK.
     ///
@@ -178,7 +179,7 @@ unwrapped! {
 /// A unirectional channel peer's encapsulated secret.
 ///
 /// This should be freely shared with the channel peer.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive_where(Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct UniPeerEncap<CS: CipherSuite> {
     encap: Encap<CS>,

--- a/crates/aranya-crypto/src/aqc/uni.rs
+++ b/crates/aranya-crypto/src/aqc/uni.rs
@@ -277,8 +277,10 @@ impl<CS: CipherSuite> UniSecrets<CS> {
 
 /// The shared unidirectional channel secret used by both the
 /// channel author and channel peer to derive individual PSKs.
+#[derive_where(Debug)]
 pub struct UniSecret<CS: CipherSuite> {
     id: UniChannelId,
+    #[derive_where(skip(Debug))]
     ctx: SendOrRecvCtx<CS>,
 }
 
@@ -386,14 +388,6 @@ impl<CS: CipherSuite> UniSecret<CS> {
             suite,
         };
         Ok(self.ctx.export(context.as_bytes())?)
-    }
-}
-
-impl<CS: CipherSuite> fmt::Debug for UniSecret<CS> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("UniSecret")
-            .field("id", &self.id)
-            .finish_non_exhaustive()
     }
 }
 

--- a/crates/aranya-crypto/src/aranya.rs
+++ b/crates/aranya-crypto/src/aranya.rs
@@ -4,6 +4,7 @@
 
 use core::{borrow::Borrow, cell::OnceCell, fmt, marker::PhantomData, result::Result};
 
+use derive_where::derive_where;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use spideroak_crypto::{
     aead::Tag,
@@ -26,6 +27,7 @@ use crate::{
 };
 
 /// A signature created by a signing key.
+#[derive_where(Clone, Debug)]
 pub struct Signature<CS: CipherSuite>(pub(crate) <CS::Signer as Signer>::Signature);
 
 impl<CS: CipherSuite> Signature<CS> {
@@ -46,18 +48,6 @@ impl<CS: CipherSuite> Signature<CS> {
     pub fn from_bytes(data: &[u8]) -> Result<Self, ImportError> {
         let sig = <CS::Signer as Signer>::Signature::import(data)?;
         Ok(Self(sig))
-    }
-}
-
-impl<CS: CipherSuite> fmt::Debug for Signature<CS> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Signature").field(&self.0).finish()
-    }
-}
-
-impl<CS: CipherSuite> Clone for Signature<CS> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
     }
 }
 

--- a/crates/aranya-crypto/src/ciphersuite/ext.rs
+++ b/crates/aranya-crypto/src/ciphersuite/ext.rs
@@ -6,6 +6,7 @@ use core::{
     slice,
 };
 
+use derive_where::derive_where;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use sha3_utils::{encode_string, EncodedString};
 use spideroak_crypto::{
@@ -138,8 +139,7 @@ pub(crate) type Digest<CS> = hash::Digest<<<CS as CipherSuite>::Hash as hash::Ha
 pub(crate) type Prk<CS> = kdf::Prk<<<CS as CipherSuite>::Kdf as kdf::Kdf>::PrkSize>;
 
 /// The OIDs used by a [`CipherSuite`].
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(bound = "CS: CipherSuite")]
+#[derive_where(Copy, Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Oids<CS: CipherSuite + ?Sized> {
     aead: AeadOid<CS>,
     hash: HashOid<CS>,
@@ -198,7 +198,7 @@ where
 /// [`EncodedString`]s into their parts.
 ///
 /// [TupleHash]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf
-#[derive(Copy, Clone, Debug)]
+#[derive_where(Copy, Clone, Debug)]
 struct EncodedOids<CS: ?Sized>(PhantomData<CS>);
 
 impl<CS: CipherSuite + ?Sized> EncodedOids<CS> {
@@ -249,7 +249,7 @@ where
 /// OID.
 macro_rules! oid_repr {
     ($($name:ident => $ty:ident),* $(,)?) => {$(
-        #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+        #[derive_where(Copy, Clone, Debug, Eq, PartialEq)]
         struct $name<CS: ?Sized>(PhantomData<CS>);
 
         impl<CS: CipherSuite + ?Sized> Identified for $name<CS> {

--- a/crates/aranya-crypto/src/groupkey.rs
+++ b/crates/aranya-crypto/src/groupkey.rs
@@ -3,7 +3,7 @@
 use core::{cell::OnceCell, marker::PhantomData, result::Result};
 
 use buggy::Bug;
-use serde::{Deserialize, Serialize};
+use derive_where::derive_where;
 use spideroak_crypto::{
     aead::{Aead, BufferTooSmallError, KeyData, OpenError, SealError, Tag},
     csprng::{Csprng, Random},
@@ -299,18 +299,8 @@ custom_id! {
 }
 
 /// An encrypted [`GroupKey`].
-#[derive(Debug, Serialize, Deserialize)]
+#[derive_where(Clone, Debug, Serialize, Deserialize)]
 pub struct EncryptedGroupKey<CS: CipherSuite> {
     pub(crate) ciphertext: GenericArray<u8, U64>,
     pub(crate) tag: Tag<CS::Aead>,
-}
-
-impl<CS: CipherSuite> Clone for EncryptedGroupKey<CS> {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self {
-            ciphertext: self.ciphertext,
-            tag: self.tag.clone(),
-        }
-    }
 }

--- a/crates/aranya-crypto/src/test_util/mod.rs
+++ b/crates/aranya-crypto/src/test_util/mod.rs
@@ -14,12 +14,10 @@
 pub mod ciphersuite;
 pub mod engine;
 
-use core::{
-    fmt::{self, Debug},
-    marker::PhantomData,
-};
+use core::marker::PhantomData;
 
 pub use ciphersuite::test_ciphersuite;
+use derive_where::derive_where;
 pub use engine::test_engine;
 pub use spideroak_crypto::test_util::{
     aead::{self, test_aead},
@@ -239,6 +237,7 @@ impl<T: Signer + ?Sized> Identified for SignerWithDefaults<T> {
 }
 
 /// A [`SigningKey`] that uses the default trait methods.
+#[derive_where(Clone)]
 pub struct SigningKeyWithDefaults<T: Signer + ?Sized>(T::SigningKey);
 
 impl<T: Signer + ?Sized> SigningKey<SignerWithDefaults<T>> for SigningKeyWithDefaults<T> {
@@ -277,15 +276,10 @@ impl<'a, T: Signer + ?Sized> Import<&'a [u8]> for SigningKeyWithDefaults<T> {
     }
 }
 
-impl<T: Signer + ?Sized> Clone for SigningKeyWithDefaults<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
 impl<T: Signer + ?Sized> ZeroizeOnDrop for SigningKeyWithDefaults<T> {}
 
 /// A [`VerifyingKey`] that uses the default trait methods.
+#[derive_where(Clone, Debug, PartialEq, Eq)]
 pub struct VerifyingKeyWithDefaults<T: Signer + ?Sized>(T::VerifyingKey);
 
 impl<T: Signer + ?Sized> VerifyingKey<SignerWithDefaults<T>> for VerifyingKeyWithDefaults<T> {
@@ -308,26 +302,8 @@ impl<'a, T: Signer + ?Sized> Import<&'a [u8]> for VerifyingKeyWithDefaults<T> {
     }
 }
 
-impl<T: Signer + ?Sized> Clone for VerifyingKeyWithDefaults<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-impl<T: Signer + ?Sized> Debug for VerifyingKeyWithDefaults<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Debug::fmt(&self.0, f)
-    }
-}
-
-impl<T: Signer + ?Sized> Eq for VerifyingKeyWithDefaults<T> {}
-impl<T: Signer + ?Sized> PartialEq for VerifyingKeyWithDefaults<T> {
-    fn eq(&self, other: &Self) -> bool {
-        PartialEq::eq(&self.0, &other.0)
-    }
-}
-
 /// `Signer::Signature` that uses the default trait methods.
+#[derive_where(Clone, Debug)]
 pub struct SignatureWithDefaults<T: Signer + ?Sized>(T::Signature);
 
 impl<T: Signer + ?Sized> Signature<SignerWithDefaults<T>> for SignatureWithDefaults<T> {
@@ -335,18 +311,6 @@ impl<T: Signer + ?Sized> Signature<SignerWithDefaults<T>> for SignatureWithDefau
 
     fn export(&self) -> Self::Data {
         self.0.export()
-    }
-}
-
-impl<T: Signer + ?Sized> Clone for SignatureWithDefaults<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-impl<T: Signer + ?Sized> Debug for SignatureWithDefaults<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Debug::fmt(&self.0, f)
     }
 }
 

--- a/crates/aranya-crypto/src/tls/psk.rs
+++ b/crates/aranya-crypto/src/tls/psk.rs
@@ -170,8 +170,9 @@ impl<CS: CipherSuite> ConstantTimeEq for PskSeed<CS> {
 /// PSKs.
 ///
 /// [RFC 8446]: https://datatracker.ietf.org/doc/html/rfc8446#autoid-37
-#[derive_where(Clone)]
+#[derive_where(Clone, Debug)]
 pub struct Psk<CS> {
+    #[derive_where(skip(Debug))]
     secret: [u8; 32],
     id: PskId,
     _marker: PhantomData<CS>,
@@ -196,15 +197,6 @@ impl<CS: CipherSuite> Psk<CS> {
     /// [RFC 8446]: https://datatracker.ietf.org/doc/html/rfc8446#autoid-37
     pub fn raw_secret_bytes(&self) -> &[u8] {
         &self.secret
-    }
-}
-
-impl<CS> fmt::Debug for Psk<CS> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Avoid leaking `secret`.
-        f.debug_struct("Psk")
-            .field("id", &self.id)
-            .finish_non_exhaustive()
     }
 }
 

--- a/crates/aranya-crypto/src/tls/psk.rs
+++ b/crates/aranya-crypto/src/tls/psk.rs
@@ -1,6 +1,7 @@
 use core::{cell::OnceCell, fmt, marker::PhantomData};
 
 use buggy::{Bug, BugExt};
+use derive_where::derive_where;
 use serde::{Deserialize, Serialize};
 use zerocopy::{ByteEq, Immutable, IntoBytes, KnownLayout, Unaligned};
 
@@ -33,6 +34,7 @@ custom_id! {
 }
 
 /// A cryptographic seed used to derive multiple [`Psk`]s.
+#[derive_where(Clone)]
 pub struct PskSeed<CS: CipherSuite> {
     prk: Prk<CS>,
     // The ID is computed with `labeled_expand(...)`, which can
@@ -120,17 +122,6 @@ impl<CS: CipherSuite> PskSeed<CS> {
     }
 }
 
-impl<CS: CipherSuite> Clone for PskSeed<CS> {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self {
-            prk: self.prk.clone(),
-            id: self.id.clone(),
-            _marker: PhantomData,
-        }
-    }
-}
-
 impl<CS: CipherSuite> fmt::Debug for PskSeed<CS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Avoid leaking `seed`.
@@ -179,6 +170,7 @@ impl<CS: CipherSuite> ConstantTimeEq for PskSeed<CS> {
 /// PSKs.
 ///
 /// [RFC 8446]: https://datatracker.ietf.org/doc/html/rfc8446#autoid-37
+#[derive_where(Clone)]
 pub struct Psk<CS> {
     secret: [u8; 32],
     id: PskId,
@@ -204,17 +196,6 @@ impl<CS: CipherSuite> Psk<CS> {
     /// [RFC 8446]: https://datatracker.ietf.org/doc/html/rfc8446#autoid-37
     pub fn raw_secret_bytes(&self) -> &[u8] {
         &self.secret
-    }
-}
-
-impl<CS> Clone for Psk<CS> {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self {
-            id: self.id,
-            secret: self.secret,
-            _marker: PhantomData,
-        }
     }
 }
 

--- a/crates/aranya-fast-channels/Cargo.toml
+++ b/crates/aranya-fast-channels/Cargo.toml
@@ -92,6 +92,7 @@ buggy = { version = "0.1.0", default-features = false }
 byteorder = { version = "1", default-features = false }
 cfg-if = { workspace = true }
 const_format = { version = "0.2.31", features = ["assertcp"] }
+derive-where = { workspace = true }
 errno = { workspace = true, default-features = false }
 heapless = { workspace = true, default-features = false }
 # Only enabled by the `testing` feature which already enables

--- a/crates/aranya-fast-channels/src/memory.rs
+++ b/crates/aranya-fast-channels/src/memory.rs
@@ -12,6 +12,7 @@ use aranya_crypto::{
     CipherSuite,
 };
 use buggy::{Bug, BugExt};
+use derive_where::derive_where;
 
 use crate::{
     error::Error,
@@ -21,25 +22,10 @@ use crate::{
 
 /// An im-memory implementation of [`AfcState`] and
 /// [`AranyaState`].
+#[derive_where(Clone, Default)]
 pub struct State<CS: CipherSuite> {
     #[allow(clippy::type_complexity)]
     chans: Arc<StdMutex<BTreeMap<ChannelId, Directed<SealKey<CS>, OpenKey<CS>>>>>,
-}
-
-impl<CS: CipherSuite> Clone for State<CS> {
-    fn clone(&self) -> Self {
-        State {
-            chans: self.chans.clone(),
-        }
-    }
-}
-
-impl<CS: CipherSuite> Default for State<CS> {
-    fn default() -> Self {
-        Self {
-            chans: Arc::default(),
-        }
-    }
 }
 
 impl<CS: CipherSuite> State<CS> {

--- a/crates/aranya-fast-channels/src/shm/align.rs
+++ b/crates/aranya-fast-channels/src/shm/align.rs
@@ -5,6 +5,8 @@ use core::{
     ptr::NonNull,
 };
 
+use derive_where::derive_where;
+
 use super::shared::assert_ffi_safe;
 
 /// Reports whether `v` is aligned to `align`.
@@ -54,18 +56,10 @@ impl<T> Deref for CacheAligned<T> {
 
 /// A non-null pointer aligned to `T`.
 #[repr(transparent)]
-#[derive(Debug)]
+#[derive_where(Copy, Clone, Debug)]
 pub(super) struct Aligned<T: Sized> {
     ptr: NonNull<T>,
 }
-
-impl<T: Sized> Clone for Aligned<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T: Sized> Copy for Aligned<T> {}
 
 impl<T: Sized> Aligned<T> {
     /// Creates an [`Aligned`] from a pointer with the

--- a/crates/aranya-fast-channels/src/shm/posix.rs
+++ b/crates/aranya-fast-channels/src/shm/posix.rs
@@ -9,6 +9,7 @@ use core::{
 
 use buggy::BugExt;
 use cfg_if::cfg_if;
+use derive_where::derive_where;
 use libc::{
     off_t, MAP_FAILED, O_CREAT, O_EXCL, O_RDONLY, O_RDWR, PROT_READ, PROT_WRITE, S_IRUSR, S_IWUSR,
 };
@@ -63,7 +64,7 @@ where
 }
 
 /// Memory mapped shared memory.
-#[derive(Debug)]
+#[derive_where(Debug)]
 pub(super) struct Mapping<T> {
     /// The usable section of the mapping.
     ptr: Aligned<T>,

--- a/crates/aranya-fast-channels/src/shm/sdlib.rs
+++ b/crates/aranya-fast-channels/src/shm/sdlib.rs
@@ -7,6 +7,7 @@ use core::{
 };
 
 use buggy::BugExt;
+use derive_where::derive_where;
 use libc::off_t;
 
 use super::{

--- a/crates/aranya-fast-channels/src/shm/sdlib.rs
+++ b/crates/aranya-fast-channels/src/shm/sdlib.rs
@@ -94,7 +94,7 @@ fn unmap(id: c_int) -> Result<(), Errno> {
 }
 
 /// Shared data mapping.
-#[derive(Debug)]
+#[derive_where(Debug)]
 pub(super) struct Mapping<T> {
     /// The usable section of the mapping.
     ptr: Aligned<T>,

--- a/crates/aranya-fast-channels/src/shm/shared.rs
+++ b/crates/aranya-fast-channels/src/shm/shared.rs
@@ -14,6 +14,7 @@ use aranya_crypto::{
 };
 use buggy::{Bug, BugExt};
 use cfg_if::cfg_if;
+use derive_where::derive_where;
 
 use super::{
     align::{is_aligned_to, layout_repeat, CacheAligned},
@@ -343,6 +344,7 @@ impl PartialEq<Op> for ChanDirection {
 ///
 /// All integers are little endian.
 #[repr(C)]
+#[derive_where(Clone)]
 pub(super) struct ShmChan<CS: CipherSuite> {
     /// Must be [`ShmChan::MAGIC`].
     pub magic: U32,
@@ -496,21 +498,6 @@ impl<CS: CipherSuite> ShmChan<CS> {
     }
 }
 
-impl<CS: CipherSuite> Clone for ShmChan<CS> {
-    fn clone(&self) -> Self {
-        Self {
-            magic: self.magic,
-            node_id: self.node_id,
-            label: self.label,
-            direction: self.direction,
-            seq: self.seq,
-            seal_key: self.seal_key.clone(),
-            open_key: self.open_key.clone(),
-            key_id: self.key_id,
-        }
-    }
-}
-
 impl<CS: CipherSuite> fmt::Debug for ShmChan<CS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ShmChan")
@@ -565,7 +552,7 @@ impl ShmLayout {
     ),
     repr(C, align(32))
 )]
-#[derive(Debug)]
+#[derive_where(Debug)]
 pub(super) struct SharedMem<CS> {
     /// Identifies this memory as a [`SharedMem`].
     ///
@@ -734,7 +721,7 @@ impl<CS: CipherSuite> SharedMem<CS> {
     ),
     repr(C, align(32))
 )]
-#[derive(Debug)]
+#[derive_where(Debug)]
 struct ChanList<CS> {
     /// Identifies this memory as a [`ChanList`].
     ///
@@ -815,7 +802,7 @@ impl<CS: CipherSuite> ChanList<CS> {
 ///
 /// Broken out separately so it can be placed inside a [`Mutex`].
 #[repr(C, align(8))]
-#[derive(Debug)]
+#[derive_where(Debug)]
 pub(super) struct ChanListData<CS> {
     /// The current generation.
     ///

--- a/crates/aranya-fast-channels/src/shm/shared.rs
+++ b/crates/aranya-fast-channels/src/shm/shared.rs
@@ -344,7 +344,7 @@ impl PartialEq<Op> for ChanDirection {
 ///
 /// All integers are little endian.
 #[repr(C)]
-#[derive_where(Clone)]
+#[derive_where(Clone, Debug)]
 pub(super) struct ShmChan<CS: CipherSuite> {
     /// Must be [`ShmChan::MAGIC`].
     pub magic: U32,
@@ -358,8 +358,10 @@ pub(super) struct ShmChan<CS: CipherSuite> {
     /// The current encryption sequence counter.
     pub seq: U64,
     /// The key/nonce used to encrypt data for the channel peer.
+    #[derive_where(skip(Debug))]
     pub seal_key: RawSealKey<CS>,
     /// The key/nonce used to decrypt data from the channel peer.
+    #[derive_where(skip(Debug))]
     pub open_key: RawOpenKey<CS>,
     /// Uniquely identifies `seal_key` and `open_key`.
     pub key_id: KeyId,
@@ -495,19 +497,6 @@ impl<CS: CipherSuite> ShmChan<CS> {
         } else {
             Ok(())
         }
-    }
-}
-
-impl<CS: CipherSuite> fmt::Debug for ShmChan<CS> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ShmChan")
-            .field("magic", &self.magic)
-            .field("node_id", &self.node_id)
-            .field("label", &self.label)
-            .field("direction", &self.direction)
-            .field("seq", &self.seq)
-            .field("key_id", &self.key_id)
-            .finish_non_exhaustive()
     }
 }
 

--- a/crates/aranya-fast-channels/src/state.rs
+++ b/crates/aranya-fast-channels/src/state.rs
@@ -9,6 +9,7 @@ use aranya_crypto::{
     CipherSuite,
 };
 use byteorder::{ByteOrder, LittleEndian};
+use derive_where::derive_where;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
@@ -238,6 +239,7 @@ impl From<u32> for Label {
 
 /// An AFC channel.
 #[derive(Copy, Clone)]
+#[derive_where(Debug)]
 pub struct Channel<S, O> {
     /// Uniquely identifies the channel.
     pub id: ChannelId,
@@ -252,15 +254,6 @@ impl<S, O> Channel<S, O> {
             id: self.id,
             keys: self.keys.as_ref(),
         }
-    }
-}
-
-impl<S, O> Debug for Channel<S, O> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Channel")
-            .field("id", &self.id)
-            .field("keys", &self.keys)
-            .finish()
     }
 }
 
@@ -425,6 +418,7 @@ mod test {
         CipherSuite, Rng,
     };
     use buggy::Bug;
+    use derive_where::derive_where;
 
     use crate::{
         error::Error,
@@ -440,24 +434,9 @@ mod test {
 
     /// An implementation of [`AfcState`] and [`AranyaState`]
     /// that defers to default trait methods.
+    #[derive_where(Clone, Default)]
     pub struct DefaultState<CS: CipherSuite> {
         state: memory::State<CS>,
-    }
-
-    impl<CS: CipherSuite> Clone for DefaultState<CS> {
-        fn clone(&self) -> Self {
-            DefaultState {
-                state: self.state.clone(),
-            }
-        }
-    }
-
-    impl<CS: CipherSuite> Default for DefaultState<CS> {
-        fn default() -> Self {
-            Self {
-                state: memory::State::default(),
-            }
-        }
     }
 
     impl<CS: CipherSuite> DefaultState<CS> {

--- a/crates/aranya-model/Cargo.toml
+++ b/crates/aranya-model/Cargo.toml
@@ -15,6 +15,7 @@ aranya-policy-vm = { path = "../aranya-policy-vm" }
 aranya-runtime = { path = "../aranya-runtime", features = ["testing"] }
 
 anyhow = { workspace = true }
+derive-where = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/aranya-model/src/model.rs
+++ b/crates/aranya-model/src/model.rs
@@ -19,6 +19,7 @@ use aranya_runtime::{
     ClientError, ClientState, CommandId, PeerCache, StorageProvider, SyncError, SyncRequester,
     MAX_SYNC_MESSAGE_SIZE,
 };
+use derive_where::derive_where;
 
 /// Model engine effect.
 ///
@@ -194,7 +195,8 @@ pub trait Model {
 }
 
 /// Holds a collection of effect data.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
+#[derive_where(Default)]
 pub struct VecSink<E> {
     /// Effects from executing a policy action.
     pub(crate) effects: Vec<E>,

--- a/crates/aranya-model/src/tests/keygen.rs
+++ b/crates/aranya-model/src/tests/keygen.rs
@@ -3,6 +3,7 @@ use aranya_crypto::{
     CipherSuite, DeviceId, Engine, IdentityKey, IdentityVerifyingKey, KeyStore, KeyStoreExt,
     SigningKey, SigningKeyId, VerifyingKey,
 };
+use derive_where::derive_where;
 use serde::{Deserialize, Serialize};
 
 /// A key bundle.
@@ -22,7 +23,7 @@ pub struct MinKeyBundle {
 }
 
 /// Public keys from key bundle.
-#[derive(Debug)]
+#[derive_where(Debug)]
 pub struct PublicKeys<CS: CipherSuite> {
     /// Public identity key.
     pub ident_pk: IdentityVerifyingKey<CS>,

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,6 +1,11 @@
 
 # cargo-vet audits file
 
+[[audits.derive-where]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+version = "1.5.0"
+
 [[audits.elain]]
 who = "Jonathan Dygert <jdygert@spideroak.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Removes some unneeded bounds like `where CS: Clone` which the regular derive introduces, and converts some manual impls to derives.