### PR TITLE
crypto: hide DhKemP256HkdfSha256 in private module

### DIFF
--- a/crates/aranya-crypto/src/default.rs
+++ b/crates/aranya-crypto/src/default.rs
@@ -58,8 +58,6 @@ mod __private {
         pub struct DhKemP256HkdfSha256(rust::DhKemP256HkdfSha256) => DHKEM_P256_HKDF_SHA256
     }
 }
-
-// Expose the newtype for crate-local tests, but keep it hidden externally.
 pub(crate) use __private::DhKemP256HkdfSha256;
 
 /// A basic [`Engine`] implementation that wraps keys with its [`Aead`].

--- a/crates/aranya-crypto/src/default.rs
+++ b/crates/aranya-crypto/src/default.rs
@@ -43,8 +43,7 @@ impl CipherSuite for DefaultCipherSuite {
     type Aead = rust::Aes256Gcm;
     type Hash = rust::Sha256;
     type Kdf = rust::HkdfSha512;
-    #[cfg_attr(test, allow(unused_qualifications))]
-    type Kem = __private::DhKemP256HkdfSha256;
+    type Kem = DhKemP256HkdfSha256;
     type Mac = rust::HmacSha512;
     type Signer = ed25519::Ed25519;
 }
@@ -61,7 +60,6 @@ mod __private {
 }
 
 // Expose the newtype for crate-local tests, but keep it hidden externally.
-#[cfg(test)]
 pub(crate) use __private::DhKemP256HkdfSha256;
 
 /// A basic [`Engine`] implementation that wraps keys with its [`Aead`].

--- a/crates/aranya-crypto/src/default.rs
+++ b/crates/aranya-crypto/src/default.rs
@@ -43,7 +43,7 @@ impl CipherSuite for DefaultCipherSuite {
     type Aead = rust::Aes256Gcm;
     type Hash = rust::Sha256;
     type Kdf = rust::HkdfSha512;
-    #[allow(unused_qualifications)]
+    #[cfg_attr(test, allow(unused_qualifications))]
     type Kem = __private::DhKemP256HkdfSha256;
     type Mac = rust::HmacSha512;
     type Signer = ed25519::Ed25519;

--- a/crates/aranya-crypto/src/default.rs
+++ b/crates/aranya-crypto/src/default.rs
@@ -62,7 +62,7 @@ mod __private {
 
 // Expose the newtype for crate-local tests, but keep it hidden externally.
 #[cfg(test)]
-pub use __private::DhKemP256HkdfSha256;
+pub(crate) use __private::DhKemP256HkdfSha256;
 
 /// A basic [`Engine`] implementation that wraps keys with its [`Aead`].
 pub struct DefaultEngine<R: Csprng = Rng, S: CipherSuite = DefaultCipherSuite> {

--- a/crates/aranya-crypto/src/default.rs
+++ b/crates/aranya-crypto/src/default.rs
@@ -43,6 +43,7 @@ impl CipherSuite for DefaultCipherSuite {
     type Aead = rust::Aes256Gcm;
     type Hash = rust::Sha256;
     type Kdf = rust::HkdfSha512;
+    #[allow(unused_qualifications)]
     type Kem = __private::DhKemP256HkdfSha256;
     type Mac = rust::HmacSha512;
     type Signer = ed25519::Ed25519;


### PR DESCRIPTION
Moves DhKemP256HkdfSha256 into a private __private module.
Fixes #293.
