### PR TITLE
policy-compiler: reject duplicate fields in struct literals

### DIFF
--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -759,7 +759,7 @@ impl ChunkParser<'_> {
             let pc = descend(field.clone());
             let identifier = pc.consume_identifier()?;
             let expression = pc.consume_expression(self)?;
-            
+
             if seen_fields.contains(&identifier) {
                 return Err(ParseError::new(
                     ParseErrorKind::DuplicateField,
@@ -797,7 +797,7 @@ impl ChunkParser<'_> {
                     ))
                 }
             };
-            
+
             if seen_fields.contains(&identifier) {
                 return Err(ParseError::new(
                     ParseErrorKind::DuplicateField,

--- a/crates/aranya-policy-lang/src/lang/parse/error.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/error.rs
@@ -41,6 +41,8 @@ pub enum ParseErrorKind {
     FrontMatter,
     /// An identifier was shared with a keyword
     ReservedIdentifier,
+    /// A field name appears more than once in a struct or fact literal
+    DuplicateField,
     /// An implementation bug
     Bug,
     /// Every other possible error.
@@ -87,6 +89,7 @@ impl Display for ParseError {
             ParseErrorKind::Syntax => "Syntax error",
             ParseErrorKind::FrontMatter => "Front matter YAML parse error",
             ParseErrorKind::ReservedIdentifier => "Reserved identifier",
+            ParseErrorKind::DuplicateField => "Duplicate field",
             ParseErrorKind::Bug => "Bug",
             ParseErrorKind::Unknown => "Unknown error",
         };


### PR DESCRIPTION
Fixes #314