### PR TITLE
policy-ifgen: stub ffi for compilation

### DIFF
--- a/crates/aranya-policy-ifgen-build/src/lib.rs
+++ b/crates/aranya-policy-ifgen-build/src/lib.rs
@@ -21,7 +21,10 @@ pub fn generate(input: impl AsRef<Path>, output: impl AsRef<Path>) -> Result<()>
 fn generate_(input: &Path, output: &Path) -> Result<()> {
     let policy_source = fs::read_to_string(input).with_context(|| format!("reading {input:?}"))?;
     let policy_ast = parse_policy_document(&policy_source)?;
-    let target = Compiler::new(&policy_ast).compile_to_target()?;
+    let target = Compiler::new(&policy_ast)
+        .debug(true)
+        .stub_ffi(true)
+        .compile_to_target()?;
     let rust_code = generate_code(&target);
 
     fs::write(output, rust_code).with_context(|| format!("writing to {output:?}"))?;


### PR DESCRIPTION
Needed after #235 to allow using ifgen on policies with FFI.