### PR TITLE
Add `ephemeral` keyword to actions and commands and enforce ephemeral/persistent rules at compile time.

### DIFF
--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -567,6 +567,8 @@ impl<T> StructItem<T> {
 /// A command definition
 #[derive(Debug, Clone, PartialEq)]
 pub struct CommandDefinition {
+    /// Whether the command is ephemeral (not persisted on-graph)
+    pub ephemeral: bool,
     /// Optional attributes
     pub attributes: Vec<(Identifier, Expression)>,
     /// The name of the command

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -72,6 +72,21 @@ impl<T> Deref for AstNode<T> {
     }
 }
 
+/// Persistence mode for commands and actions
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum Persistence {
+    /// Persisted on-graph (default behavior)
+    Persistent,
+    /// Not persisted on-graph (ephemeral)
+    Ephemeral,
+}
+
+impl Default for Persistence {
+    fn default() -> Self {
+        Self::Persistent
+    }
+}
+
 /// The type of a value
 ///
 /// It is not called `Type` because that conflicts with reserved keywords.
@@ -517,8 +532,8 @@ pub struct FactDefinition {
 /// An action definition
 #[derive(Debug, Clone, PartialEq)]
 pub struct ActionDefinition {
-    /// Whether the action is persisted on-graph (ephemeral=false)
-    pub ephemeral: bool,
+    /// The persistence mode of the action
+    pub persistence: Persistence,
     /// The name of the action
     pub identifier: Identifier,
     /// The arguments to the action
@@ -567,8 +582,8 @@ impl<T> StructItem<T> {
 /// A command definition
 #[derive(Debug, Clone, PartialEq)]
 pub struct CommandDefinition {
-    /// Whether the command is ephemeral (not persisted on-graph)
-    pub ephemeral: bool,
+    /// The persistence mode of the command
+    pub persistence: Persistence,
     /// Optional attributes
     pub attributes: Vec<(Identifier, Expression)>,
     /// The name of the command

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -81,6 +81,15 @@ pub enum Persistence {
     Ephemeral,
 }
 
+impl fmt::Display for Persistence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Persistent => write!(f, "persistent"),
+            Self::Ephemeral => write!(f, "ephemeral"),
+        }
+    }
+}
+
 impl Default for Persistence {
     fn default() -> Self {
         Self::Persistent

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -517,6 +517,8 @@ pub struct FactDefinition {
 /// An action definition
 #[derive(Debug, Clone, PartialEq)]
 pub struct ActionDefinition {
+    /// Whether the action is persisted on-graph (ephemeral=false)
+    pub ephemeral: bool,
     /// The name of the action
     pub identifier: Identifier,
     /// The arguments to the action

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1306,11 +1306,10 @@ impl<'a> CompileState<'a> {
                                     .iter()
                                     .find(|c| c.identifier == *ident)
                                     .assume("command must be defined")?;
-                                if action.ephemeral != command.ephemeral {
-                                    let (action_type, command_type) = if action.ephemeral {
-                                        ("ephemeral", "persistent")
-                                    } else {
-                                        ("persistent", "ephemeral")
+                                if action.persistence != command.persistence {
+                                    let (action_type, command_type) = match action.persistence {
+                                        ast::Persistence::Ephemeral => ("ephemeral", "persistent"),
+                                        ast::Persistence::Persistent => ("persistent", "ephemeral"),
                                     };
                                     return Err(CompileErrorType::InvalidType(format!(
                                         "{} action `{}` cannot publish {} command `{}`",

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1300,20 +1300,20 @@ impl<'a> CompileState<'a> {
                                 }
 
                                 //  Persistent actions can publish only persistent commands, and vice versa.
-                                let command = self
+                                let command_persistence = &self
                                     .policy
                                     .commands
                                     .iter()
                                     .find(|c| c.identifier == *ident)
-                                    .assume("command must be defined")?;
-                                if action.persistence != command.persistence {
-                                    let (action_type, command_type) = match action.persistence {
-                                        ast::Persistence::Ephemeral => ("ephemeral", "persistent"),
-                                        ast::Persistence::Persistent => ("persistent", "ephemeral"),
-                                    };
+                                    .assume("command must be defined")?
+                                    .persistence;
+                                if &action.persistence != command_persistence {
                                     return Err(CompileErrorType::InvalidType(format!(
                                         "{} action `{}` cannot publish {} command `{}`",
-                                        action_type, action.identifier, command_type, ident
+                                        action.persistence,
+                                        action.identifier,
+                                        command_persistence,
+                                        ident
                                     )));
                                 }
                                 Ok(nty)

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1311,8 +1311,8 @@ impl<'a> CompileState<'a> {
                                         .assume("command must be defined")?;
                                     if !command.ephemeral {
                                         return Err(CompileErrorType::InvalidType(format!(
-                                            "Ephemeral action cannot publish persistent command `{}`",
-                                            ident
+                                            "Ephemeral action `{}` cannot publish persistent command `{}`",
+                                            action.identifier, ident
                                         )));
                                     }
                                 }

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -2400,7 +2400,7 @@ fn test_action_command_persistence() {
             open { return todo() }
         }
         
-        ephemeral action InvalidAction() {
+        ephemeral action EphemeralAction() {
             publish PersistentCmd {}
         }
     "#;
@@ -2408,7 +2408,8 @@ fn test_action_command_persistence() {
     assert_eq!(
         err,
         CompileErrorType::InvalidType(
-            "Ephemeral action cannot publish persistent command `PersistentCmd`".to_string()
+            "Ephemeral action `EphemeralAction` cannot publish persistent command `PersistentCmd`"
+                .to_string()
         )
     );
 

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -1141,6 +1141,15 @@ impl ChunkParser<'_> {
 
         let locator = self.add_range(&item)?;
         let pc = descend(item);
+        let token = pc.consume()?;
+        let ephemeral = token.as_rule() == Rule::ephemeral_modifier;
+        let token = if ephemeral {
+            pc.consume_of_type(Rule::action_def)?
+        } else {
+            token
+        };
+
+        let pc = descend(token);
         let identifier = pc.consume_identifier()?;
         let token = pc.consume_of_type(Rule::function_arguments)?;
         let mut arguments = vec![];
@@ -1154,6 +1163,7 @@ impl ChunkParser<'_> {
 
         Ok(AstNode::new(
             ast::ActionDefinition {
+                ephemeral,
                 identifier,
                 arguments,
                 statements,

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -1147,7 +1147,11 @@ impl ChunkParser<'_> {
 
         let locator = self.add_range(&item)?;
         let pc = descend(item);
-        let ephemeral = pc.consume_optional(Rule::ephemeral_modifier).is_some();
+        let persistence = pc
+            .consume_optional(Rule::ephemeral_modifier)
+            .map_or(ast::Persistence::Persistent, |_| {
+                ast::Persistence::Ephemeral
+            });
         let identifier = pc.consume_identifier()?;
         let token = pc.consume_of_type(Rule::function_arguments)?;
         let mut arguments = vec![];
@@ -1161,7 +1165,7 @@ impl ChunkParser<'_> {
 
         Ok(AstNode::new(
             ast::ActionDefinition {
-                ephemeral,
+                persistence,
                 identifier,
                 arguments,
                 statements,
@@ -1289,7 +1293,11 @@ impl ChunkParser<'_> {
         let locator = self.add_range(&item)?;
 
         let pc = descend(item);
-        let ephemeral = pc.consume_optional(Rule::ephemeral_modifier).is_some();
+        let persistence = pc
+            .consume_optional(Rule::ephemeral_modifier)
+            .map_or(ast::Persistence::Persistent, |_| {
+                ast::Persistence::Ephemeral
+            });
         let identifier = pc.consume_identifier()?;
 
         let mut attributes = vec![];
@@ -1360,7 +1368,7 @@ impl ChunkParser<'_> {
 
         Ok(AstNode::new(
             ast::CommandDefinition {
-                ephemeral,
+                persistence,
                 attributes,
                 identifier,
                 fields,

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -123,6 +123,12 @@ impl<'a> PairContext<'a> {
             .parse()
             .assume("grammar produces valid identifiers")?)
     }
+
+    fn consume_optional(&self, rule: Rule) -> Option<Pair<'_, Rule>> {
+        self.peek()
+            .filter(|p| p.as_rule() == rule)
+            .inspect(|_| _ = self.next())
+    }
 }
 
 /// Helper function which consumes and returns an iterator over the
@@ -1141,15 +1147,7 @@ impl ChunkParser<'_> {
 
         let locator = self.add_range(&item)?;
         let pc = descend(item);
-        let token = pc.consume()?;
-        let ephemeral = token.as_rule() == Rule::ephemeral_modifier;
-        let token = if ephemeral {
-            pc.consume_of_type(Rule::action_def)?
-        } else {
-            token
-        };
-
-        let pc = descend(token);
+        let ephemeral = pc.consume_optional(Rule::ephemeral_modifier).is_some();
         let identifier = pc.consume_identifier()?;
         let token = pc.consume_of_type(Rule::function_arguments)?;
         let mut arguments = vec![];
@@ -1291,15 +1289,7 @@ impl ChunkParser<'_> {
         let locator = self.add_range(&item)?;
 
         let pc = descend(item);
-        let token = pc.consume()?;
-        let ephemeral = token.as_rule() == Rule::ephemeral_modifier;
-        let token = if ephemeral {
-            pc.consume_of_type(Rule::command_def)?
-        } else {
-            token
-        };
-        let pc = descend(token);
-
+        let ephemeral = pc.consume_optional(Rule::ephemeral_modifier).is_some();
         let identifier = pc.consume_identifier()?;
 
         let mut attributes = vec![];

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -1289,7 +1289,17 @@ impl ChunkParser<'_> {
         assert_eq!(item.as_rule(), Rule::command_definition);
 
         let locator = self.add_range(&item)?;
+
         let pc = descend(item);
+        let token = pc.consume()?;
+        let ephemeral = token.as_rule() == Rule::ephemeral_modifier;
+        let token = if ephemeral {
+            pc.consume_of_type(Rule::command_def)?
+        } else {
+            token
+        };
+        let pc = descend(token);
+
         let identifier = pc.consume_identifier()?;
 
         let mut attributes = vec![];
@@ -1360,6 +1370,7 @@ impl ChunkParser<'_> {
 
         Ok(AstNode::new(
             ast::CommandDefinition {
+                ephemeral,
                 attributes,
                 identifier,
                 fields,

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -331,8 +331,7 @@ immutable_modifier = { "immutable" }
 use_definition = { "use" ~ identifier }
 fact_definition = { immutable_modifier? ~ "fact" ~ fact_signature }
 // [ephemeral] action foo(a int) { ... }
-action_def = { identifier ~ function_arguments ~ statement_block }
-action_definition = { ephemeral_modifier? ~ "action" ~ action_def }
+action_definition = { ephemeral_modifier? ~ "action" ~ identifier ~ function_arguments ~ statement_block }
 // effect Foo { bar id }
 effect_definition = { "effect" ~ identifier ~ effect_struct_def }
 // struct Foo { bar id }
@@ -340,8 +339,7 @@ struct_definition = { "struct" ~ identifier ~ struct_def }
 // enum Result { OK, Err }
 enum_definition = { "enum" ~ identifier ~ "{" ~ identifier ~ ("," ~ identifier)* ~ ","? ~ "}" }
 // command Foo { ... }
-command_def = { identifier ~ "{" ~ command_blocks+ ~ "}" }
-command_definition = { ephemeral_modifier? ~ "command" ~ command_def }
+command_definition = { ephemeral_modifier? ~ "command" ~ identifier ~ "{" ~ command_blocks+ ~ "}" }
 // function foo(a int) int { return a }
 function_decl = { "function" ~ identifier ~ function_arguments ~ vtype }
 function_definition = { function_decl ~ statement_block }

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -325,12 +325,14 @@ open_block = { "open" ~ statement_block }
 command_blocks = _{ attributes_block | fields_block | seal_block | open_block | policy_block | recall_block }
 
 // # Top-level Statements
+ephemeral_modifier = { "ephemeral" }
 // fact Foo[]=>{}
 immutable_modifier = { "immutable" }
 use_definition = { "use" ~ identifier }
 fact_definition = { immutable_modifier? ~ "fact" ~ fact_signature }
-// action foo(a int) { ... }
-action_definition = { "action" ~ identifier ~ function_arguments ~ statement_block }
+// [ephemeral] action foo(a int) { ... }
+action_def = { identifier ~ function_arguments ~ statement_block }
+action_definition = { ephemeral_modifier? ~ "action" ~ action_def }
 // effect Foo { bar id }
 effect_definition = { "effect" ~ identifier ~ effect_struct_def }
 // struct Foo { bar id }

--- a/crates/aranya-policy-lang/src/lang/parse/policy.pest
+++ b/crates/aranya-policy-lang/src/lang/parse/policy.pest
@@ -340,7 +340,8 @@ struct_definition = { "struct" ~ identifier ~ struct_def }
 // enum Result { OK, Err }
 enum_definition = { "enum" ~ identifier ~ "{" ~ identifier ~ ("," ~ identifier)* ~ ","? ~ "}" }
 // command Foo { ... }
-command_definition = { "command" ~ identifier ~ "{" ~ command_blocks+ ~ "}" }
+command_def = { identifier ~ "{" ~ command_blocks+ ~ "}" }
+command_definition = { ephemeral_modifier? ~ "command" ~ command_def }
 // function foo(a int) int { return a }
 function_decl = { "function" ~ identifier ~ function_arguments ~ vtype }
 function_definition = { function_decl ~ statement_block }

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -568,6 +568,7 @@ fn parse_policy_test() -> Result<(), ParseError> {
             create Next[]=>{}
         }
 
+        ephemeral action a() {}
     "#;
 
     let policy = parse_policy_str(policy_str, Version::V2)?;
@@ -598,41 +599,53 @@ fn parse_policy_test() -> Result<(), ParseError> {
     );
     assert_eq!(
         policy.actions,
-        vec![AstNode::new(
-            ast::ActionDefinition {
-                identifier: ident!("add"),
-                arguments: vec![
-                    ast::FieldDefinition {
-                        identifier: ident!("x"),
-                        field_type: ast::VType::Int,
-                    },
-                    ast::FieldDefinition {
-                        identifier: ident!("y"),
-                        field_type: ast::VType::Int,
-                    },
-                ],
-                statements: vec![
-                    AstNode::new(
-                        ast::Statement::Let(ast::LetStatement {
-                            identifier: ident!("obj"),
-                            expression: Expression::NamedStruct(ast::NamedStruct {
-                                identifier: ident!("Add"),
-                                fields: vec![(
-                                    ident!("count"),
-                                    Expression::Identifier(ident!("x")),
-                                )],
+        vec![
+            AstNode::new(
+                ast::ActionDefinition {
+                    ephemeral: false,
+                    identifier: ident!("add"),
+                    arguments: vec![
+                        ast::FieldDefinition {
+                            identifier: ident!("x"),
+                            field_type: ast::VType::Int,
+                        },
+                        ast::FieldDefinition {
+                            identifier: ident!("y"),
+                            field_type: ast::VType::Int,
+                        },
+                    ],
+                    statements: vec![
+                        AstNode::new(
+                            ast::Statement::Let(ast::LetStatement {
+                                identifier: ident!("obj"),
+                                expression: Expression::NamedStruct(ast::NamedStruct {
+                                    identifier: ident!("Add"),
+                                    fields: vec![(
+                                        ident!("count"),
+                                        Expression::Identifier(ident!("x")),
+                                    )],
+                                }),
                             }),
-                        }),
-                        227,
-                    ),
-                    AstNode::new(
-                        ast::Statement::Publish(Expression::Identifier(ident!("obj"))),
-                        295,
-                    ),
-                ],
-            },
-            188,
-        )]
+                            227,
+                        ),
+                        AstNode::new(
+                            ast::Statement::Publish(Expression::Identifier(ident!("obj"))),
+                            295,
+                        ),
+                    ],
+                },
+                188,
+            ),
+            AstNode::new(
+                ast::ActionDefinition {
+                    ephemeral: true,
+                    identifier: ident!("a"),
+                    arguments: vec![],
+                    statements: vec![],
+                },
+                2189,
+            )
+        ]
     );
     assert_eq!(
         policy.effects,
@@ -1567,6 +1580,7 @@ fn parse_global_let_statements() -> Result<(), ParseError> {
         policy.actions,
         vec![AstNode::new(
             ast::ActionDefinition {
+                ephemeral: false,
                 identifier: ident!("foo"),
                 arguments: vec![],
                 statements: vec![
@@ -1709,6 +1723,7 @@ fn test_action_call() -> anyhow::Result<()> {
         policy.actions[1],
         AstNode {
             inner: ast::ActionDefinition {
+                ephemeral: false,
                 identifier: ident!("pong"),
                 arguments: vec![],
                 statements: vec![AstNode {

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -568,6 +568,15 @@ fn parse_policy_test() -> Result<(), ParseError> {
             create Next[]=>{}
         }
 
+        
+        // ephemeral commands and actions
+
+        ephemeral command C {
+            fields {
+                x int
+            }
+        }
+
         ephemeral action a() {}
     "#;
 
@@ -643,7 +652,7 @@ fn parse_policy_test() -> Result<(), ParseError> {
                     arguments: vec![],
                     statements: vec![],
                 },
-                2189,
+                2339,
             )
         ]
     );
@@ -670,336 +679,379 @@ fn parse_policy_test() -> Result<(), ParseError> {
     );
     assert_eq!(
         policy.commands,
-        vec![AstNode::new(
-            ast::CommandDefinition {
-                attributes: vec![],
-                identifier: ident!("Add"),
-                fields: vec![ast::StructItem::Field(ast::FieldDefinition {
-                    identifier: ident!("count"),
-                    field_type: ast::VType::Int,
-                })],
-                seal: vec![],
-                open: vec![],
-                policy: vec![
-                    AstNode::new(
-                        ast::Statement::Let(ast::LetStatement {
-                            identifier: ident!("envelope_id"),
-                            expression: Expression::ForeignFunctionCall(ForeignFunctionCall {
-                                module: ident!("envelope"),
-                                identifier: ident!("command_id"),
-                                arguments: vec![Expression::Identifier(ident!("envelope"))]
-                            },),
-                        }),
-                        519,
-                    ),
-                    AstNode::new(
-                        ast::Statement::Let(ast::LetStatement {
-                            identifier: ident!("author"),
-                            expression: Expression::ForeignFunctionCall(ForeignFunctionCall {
-                                module: ident!("envelope"),
-                                identifier: ident!("author_id"),
-                                arguments: vec![Expression::Identifier(ident!("envelope"))]
-                            },),
-                        }),
-                        584,
-                    ),
-                    AstNode::new(
-                        ast::Statement::Let(ast::LetStatement {
-                            identifier: ident!("new_x"),
-                            expression: Expression::Add(
-                                Box::new(Expression::Identifier(ident!("x"))),
-                                Box::new(Expression::Identifier(ident!("count"))),
-                            ),
-                        }),
-                        643,
-                    ),
-                    AstNode::new(
-                        ast::Statement::Check(ast::CheckStatement {
-                            expression: Expression::InternalFunction(
-                                ast::InternalFunction::Exists(ast::FactLiteral {
-                                    identifier: ident!("TestFact"),
-                                    key_fields: vec![(
-                                        ident!("v"),
-                                        FactField::Expression(Expression::String(text!("test"))),
-                                    )],
-                                    value_fields: Some(vec![]),
-                                }),
-                            ),
-                        }),
-                        681,
-                    ),
-                    AstNode::new(
-                        ast::Statement::Match(ast::MatchStatement {
-                            expression: Expression::Identifier(ident!("x")),
-                            arms: vec![
-                                ast::MatchArm {
-                                    pattern: MatchPattern::Values(vec![Expression::Int(0)]),
-                                    statements: vec![AstNode::new(
-                                        ast::Statement::Check(ast::CheckStatement {
-                                            expression: Expression::FunctionCall(
-                                                ast::FunctionCall {
-                                                    identifier: ident!("positive"),
-                                                    arguments: vec![Expression::Optional(Some(
-                                                        Box::new(Expression::Identifier(ident!(
-                                                            "new_x"
-                                                        ),),)
-                                                    ),)],
-                                                },
-                                            ),
-                                        }),
-                                        795,
-                                    )],
-                                },
-                                ast::MatchArm {
-                                    pattern: MatchPattern::Values(vec!(Expression::Int(1))),
-                                    statements: vec![AstNode::new(
-                                        ast::Statement::Check(ast::CheckStatement {
-                                            expression: Expression::FunctionCall(
-                                                ast::FunctionCall {
-                                                    identifier: ident!("positive"),
-                                                    arguments: vec![Expression::Optional(None,)],
-                                                },
-                                            ),
-                                        }),
-                                        896,
-                                    )],
-                                },
-                                ast::MatchArm {
-                                    pattern: MatchPattern::Default,
-                                    statements: vec![],
-                                },
-                            ],
-                        }),
-                        734,
-                    ),
-                    AstNode::new(
-                        ast::Statement::If(ast::IfStatement {
-                            branches: vec![(
-                                Expression::Equal(
-                                    Box::new(Expression::Identifier(ident!("x"))),
-                                    Box::new(Expression::Int(3)),
-                                ),
-                                vec![AstNode::new(
-                                    ast::Statement::Check(ast::CheckStatement {
-                                        expression: Expression::LessThan(
-                                            Box::new(Expression::Identifier(ident!("new_x"))),
-                                            Box::new(Expression::Int(10)),
-                                        ),
-                                    }),
-                                    1056,
-                                )],
-                            )],
-                            fallback: None
-                        }),
-                        1024
-                    ),
-                    AstNode::new(
-                        ast::Statement::Let(ast::LetStatement {
-                            identifier: ident!("a"),
-                            expression: Expression::ForeignFunctionCall(ForeignFunctionCall {
-                                module: ident!("foo"),
-                                identifier: ident!("ext_func"),
-                                arguments: vec![Expression::Identifier(ident!("x"))],
+        vec![
+            AstNode::new(
+                ast::CommandDefinition {
+                    ephemeral: false,
+                    attributes: vec![],
+                    identifier: ident!("Add"),
+                    fields: vec![ast::StructItem::Field(ast::FieldDefinition {
+                        identifier: ident!("count"),
+                        field_type: ast::VType::Int,
+                    })],
+                    seal: vec![],
+                    open: vec![],
+                    policy: vec![
+                        AstNode::new(
+                            ast::Statement::Let(ast::LetStatement {
+                                identifier: ident!("envelope_id"),
+                                expression: Expression::ForeignFunctionCall(ForeignFunctionCall {
+                                    module: ident!("envelope"),
+                                    identifier: ident!("command_id"),
+                                    arguments: vec![Expression::Identifier(ident!("envelope"))]
+                                },),
                             }),
-                        }),
-                        1108
-                    ),
-                    AstNode::new(
-                        ast::Statement::Finish(vec![
-                            AstNode::new(
-                                ast::Statement::Create(ast::CreateStatement {
-                                    fact: ast::FactLiteral {
-                                        identifier: ident!("F"),
+                            519,
+                        ),
+                        AstNode::new(
+                            ast::Statement::Let(ast::LetStatement {
+                                identifier: ident!("author"),
+                                expression: Expression::ForeignFunctionCall(ForeignFunctionCall {
+                                    module: ident!("envelope"),
+                                    identifier: ident!("author_id"),
+                                    arguments: vec![Expression::Identifier(ident!("envelope"))]
+                                },),
+                            }),
+                            584,
+                        ),
+                        AstNode::new(
+                            ast::Statement::Let(ast::LetStatement {
+                                identifier: ident!("new_x"),
+                                expression: Expression::Add(
+                                    Box::new(Expression::Identifier(ident!("x"))),
+                                    Box::new(Expression::Identifier(ident!("count"))),
+                                ),
+                            }),
+                            643,
+                        ),
+                        AstNode::new(
+                            ast::Statement::Check(ast::CheckStatement {
+                                expression: Expression::InternalFunction(
+                                    ast::InternalFunction::Exists(ast::FactLiteral {
+                                        identifier: ident!("TestFact"),
                                         key_fields: vec![(
                                             ident!("v"),
                                             FactField::Expression(Expression::String(text!(
-                                                "hello"
-                                            )),)
+                                                "test"
+                                            ))),
                                         )],
-                                        value_fields: Some(vec![
-                                            (
+                                        value_fields: Some(vec![]),
+                                    }),
+                                ),
+                            }),
+                            681,
+                        ),
+                        AstNode::new(
+                            ast::Statement::Match(ast::MatchStatement {
+                                expression: Expression::Identifier(ident!("x")),
+                                arms: vec![
+                                    ast::MatchArm {
+                                        pattern: MatchPattern::Values(vec![Expression::Int(0)]),
+                                        statements: vec![AstNode::new(
+                                            ast::Statement::Check(ast::CheckStatement {
+                                                expression: Expression::FunctionCall(
+                                                    ast::FunctionCall {
+                                                        identifier: ident!("positive"),
+                                                        arguments: vec![Expression::Optional(
+                                                            Some(Box::new(Expression::Identifier(
+                                                                ident!("new_x"),
+                                                            ),)),
+                                                        )],
+                                                    },
+                                                ),
+                                            }),
+                                            795,
+                                        )],
+                                    },
+                                    ast::MatchArm {
+                                        pattern: MatchPattern::Values(vec!(Expression::Int(1))),
+                                        statements: vec![AstNode::new(
+                                            ast::Statement::Check(ast::CheckStatement {
+                                                expression: Expression::FunctionCall(
+                                                    ast::FunctionCall {
+                                                        identifier: ident!("positive"),
+                                                        arguments: vec![
+                                                            Expression::Optional(None,)
+                                                        ],
+                                                    },
+                                                ),
+                                            }),
+                                            896,
+                                        )],
+                                    },
+                                    ast::MatchArm {
+                                        pattern: MatchPattern::Default,
+                                        statements: vec![],
+                                    },
+                                ],
+                            }),
+                            734,
+                        ),
+                        AstNode::new(
+                            ast::Statement::If(ast::IfStatement {
+                                branches: vec![(
+                                    Expression::Equal(
+                                        Box::new(Expression::Identifier(ident!("x"))),
+                                        Box::new(Expression::Int(3)),
+                                    ),
+                                    vec![AstNode::new(
+                                        ast::Statement::Check(ast::CheckStatement {
+                                            expression: Expression::LessThan(
+                                                Box::new(Expression::Identifier(ident!("new_x"))),
+                                                Box::new(Expression::Int(10)),
+                                            ),
+                                        }),
+                                        1056,
+                                    )],
+                                )],
+                                fallback: None
+                            }),
+                            1024
+                        ),
+                        AstNode::new(
+                            ast::Statement::Let(ast::LetStatement {
+                                identifier: ident!("a"),
+                                expression: Expression::ForeignFunctionCall(ForeignFunctionCall {
+                                    module: ident!("foo"),
+                                    identifier: ident!("ext_func"),
+                                    arguments: vec![Expression::Identifier(ident!("x"))],
+                                }),
+                            }),
+                            1108
+                        ),
+                        AstNode::new(
+                            ast::Statement::Finish(vec![
+                                AstNode::new(
+                                    ast::Statement::Create(ast::CreateStatement {
+                                        fact: ast::FactLiteral {
+                                            identifier: ident!("F"),
+                                            key_fields: vec![(
+                                                ident!("v"),
+                                                FactField::Expression(Expression::String(text!(
+                                                    "hello"
+                                                )),)
+                                            )],
+                                            value_fields: Some(vec![
+                                                (
+                                                    ident!("x"),
+                                                    FactField::Expression(Expression::Identifier(
+                                                        ident!("x")
+                                                    ),)
+                                                ),
+                                                (
+                                                    ident!("y"),
+                                                    FactField::Expression(Expression::Negative(
+                                                        Box::new(Expression::Identifier(ident!(
+                                                            "x"
+                                                        )),)
+                                                    )),
+                                                ),
+                                            ]),
+                                        },
+                                    }),
+                                    1179
+                                ),
+                                AstNode::new(
+                                    ast::Statement::Update(ast::UpdateStatement {
+                                        fact: ast::FactLiteral {
+                                            identifier: ident!("F"),
+                                            key_fields: vec![],
+                                            value_fields: Some(vec![(
                                                 ident!("x"),
                                                 FactField::Expression(Expression::Identifier(
                                                     ident!("x")
                                                 ),)
-                                            ),
-                                            (
-                                                ident!("y"),
-                                                FactField::Expression(Expression::Negative(
-                                                    Box::new(Expression::Identifier(ident!("x")),)
-                                                )),
-                                            ),
-                                        ]),
-                                    },
-                                }),
-                                1179
-                            ),
-                            AstNode::new(
-                                ast::Statement::Update(ast::UpdateStatement {
-                                    fact: ast::FactLiteral {
-                                        identifier: ident!("F"),
-                                        key_fields: vec![],
-                                        value_fields: Some(vec![(
+                                            )]),
+                                        },
+                                        to: vec![(
                                             ident!("x"),
                                             FactField::Expression(Expression::Identifier(ident!(
-                                                "x"
-                                            )),)
-                                        )]),
-                                    },
-                                    to: vec![(
-                                        ident!("x"),
-                                        FactField::Expression(Expression::Identifier(ident!(
-                                            "new_x"
-                                        )),)
-                                    )],
-                                }),
-                                1235
-                            ),
-                            AstNode::new(
-                                ast::Statement::Delete(ast::DeleteStatement {
-                                    fact: ast::FactLiteral {
-                                        identifier: ident!("F"),
-                                        key_fields: vec![(
-                                            ident!("v"),
-                                            FactField::Expression(Expression::String(text!(
-                                                "hello"
+                                                "new_x"
                                             )),)
                                         )],
-                                        value_fields: None,
-                                    },
-                                }),
-                                1288
-                            ),
-                            AstNode::new(
-                                ast::Statement::Emit(Expression::NamedStruct(ast::NamedStruct {
-                                    identifier: ident!("Added"),
-                                    fields: vec![
-                                        (ident!("x"), Expression::Identifier(ident!("new_x")),),
-                                        (ident!("y"), Expression::Identifier(ident!("count")),),
-                                    ],
-                                },)),
-                                1329
-                            ),
-                        ]),
-                        1150,
-                    ),
-                ],
-                recall: vec![
-                    AstNode::new(
-                        ast::Statement::Let(ast::LetStatement {
-                            identifier: ident!("envelope_id"),
-                            expression: Expression::ForeignFunctionCall(ForeignFunctionCall {
-                                module: ident!("envelope"),
-                                identifier: ident!("command_id"),
-                                arguments: vec![Expression::Identifier(ident!("envelope"))]
-                            },),
-                        }),
-                        1501,
-                    ),
-                    AstNode::new(
-                        ast::Statement::Let(ast::LetStatement {
-                            identifier: ident!("author"),
-                            expression: Expression::ForeignFunctionCall(ForeignFunctionCall {
-                                module: ident!("envelope"),
-                                identifier: ident!("author_id"),
-                                arguments: vec![Expression::Identifier(ident!("envelope"))]
-                            },),
-                        }),
-                        1566,
-                    ),
-                    AstNode::new(
-                        ast::Statement::Let(ast::LetStatement {
-                            identifier: ident!("new_x"),
-                            expression: Expression::Add(
-                                Box::new(Expression::Identifier(ident!("x"))),
-                                Box::new(Expression::Identifier(ident!("count"))),
-                            ),
-                        }),
-                        1625,
-                    ),
-                    AstNode::new(
-                        ast::Statement::Finish(vec![
-                            AstNode::new(
-                                ast::Statement::Create(ast::CreateStatement {
-                                    fact: ast::FactLiteral {
-                                        identifier: ident!("F"),
-                                        key_fields: vec![(
-                                            ident!("v"),
-                                            FactField::Expression(Expression::String(text!(
-                                                "hello"
-                                            ))),
-                                        )],
-                                        value_fields: Some(vec![
-                                            (
+                                    }),
+                                    1235
+                                ),
+                                AstNode::new(
+                                    ast::Statement::Delete(ast::DeleteStatement {
+                                        fact: ast::FactLiteral {
+                                            identifier: ident!("F"),
+                                            key_fields: vec![(
+                                                ident!("v"),
+                                                FactField::Expression(Expression::String(text!(
+                                                    "hello"
+                                                )),)
+                                            )],
+                                            value_fields: None,
+                                        },
+                                    }),
+                                    1288
+                                ),
+                                AstNode::new(
+                                    ast::Statement::Emit(Expression::NamedStruct(
+                                        ast::NamedStruct {
+                                            identifier: ident!("Added"),
+                                            fields: vec![
+                                                (
+                                                    ident!("x"),
+                                                    Expression::Identifier(ident!("new_x")),
+                                                ),
+                                                (
+                                                    ident!("y"),
+                                                    Expression::Identifier(ident!("count")),
+                                                ),
+                                            ],
+                                        },
+                                    )),
+                                    1329
+                                ),
+                            ]),
+                            1150,
+                        ),
+                    ],
+                    recall: vec![
+                        AstNode::new(
+                            ast::Statement::Let(ast::LetStatement {
+                                identifier: ident!("envelope_id"),
+                                expression: Expression::ForeignFunctionCall(ForeignFunctionCall {
+                                    module: ident!("envelope"),
+                                    identifier: ident!("command_id"),
+                                    arguments: vec![Expression::Identifier(ident!("envelope"))]
+                                },),
+                            }),
+                            1501,
+                        ),
+                        AstNode::new(
+                            ast::Statement::Let(ast::LetStatement {
+                                identifier: ident!("author"),
+                                expression: Expression::ForeignFunctionCall(ForeignFunctionCall {
+                                    module: ident!("envelope"),
+                                    identifier: ident!("author_id"),
+                                    arguments: vec![Expression::Identifier(ident!("envelope"))]
+                                },),
+                            }),
+                            1566,
+                        ),
+                        AstNode::new(
+                            ast::Statement::Let(ast::LetStatement {
+                                identifier: ident!("new_x"),
+                                expression: Expression::Add(
+                                    Box::new(Expression::Identifier(ident!("x"))),
+                                    Box::new(Expression::Identifier(ident!("count"))),
+                                ),
+                            }),
+                            1625,
+                        ),
+                        AstNode::new(
+                            ast::Statement::Finish(vec![
+                                AstNode::new(
+                                    ast::Statement::Create(ast::CreateStatement {
+                                        fact: ast::FactLiteral {
+                                            identifier: ident!("F"),
+                                            key_fields: vec![(
+                                                ident!("v"),
+                                                FactField::Expression(Expression::String(text!(
+                                                    "hello"
+                                                ))),
+                                            )],
+                                            value_fields: Some(vec![
+                                                (
+                                                    ident!("x"),
+                                                    FactField::Expression(Expression::Identifier(
+                                                        ident!("x")
+                                                    )),
+                                                ),
+                                                (
+                                                    ident!("y"),
+                                                    FactField::Expression(Expression::Negative(
+                                                        Box::new(Expression::Identifier(ident!(
+                                                            "x"
+                                                        )),)
+                                                    )),
+                                                ),
+                                            ]),
+                                        },
+                                    }),
+                                    1692
+                                ),
+                                AstNode::new(
+                                    ast::Statement::Update(ast::UpdateStatement {
+                                        fact: ast::FactLiteral {
+                                            identifier: ident!("F"),
+                                            key_fields: vec![],
+                                            value_fields: Some(vec![(
                                                 ident!("x"),
                                                 FactField::Expression(Expression::Identifier(
                                                     ident!("x")
-                                                )),
-                                            ),
-                                            (
-                                                ident!("y"),
-                                                FactField::Expression(Expression::Negative(
-                                                    Box::new(Expression::Identifier(ident!("x")),)
-                                                )),
-                                            ),
-                                        ]),
-                                    },
-                                }),
-                                1692
-                            ),
-                            AstNode::new(
-                                ast::Statement::Update(ast::UpdateStatement {
-                                    fact: ast::FactLiteral {
-                                        identifier: ident!("F"),
-                                        key_fields: vec![],
-                                        value_fields: Some(vec![(
+                                                ),)
+                                            )]),
+                                        },
+                                        to: vec![(
                                             ident!("x"),
                                             FactField::Expression(Expression::Identifier(ident!(
-                                                "x"
-                                            )),)
-                                        )]),
-                                    },
-                                    to: vec![(
-                                        ident!("x"),
-                                        FactField::Expression(Expression::Identifier(ident!(
-                                            "new_x"
-                                        )),)
-                                    )],
-                                }),
-                                1748
-                            ),
-                            AstNode::new(
-                                ast::Statement::Delete(ast::DeleteStatement {
-                                    fact: ast::FactLiteral {
-                                        identifier: ident!("F"),
-                                        key_fields: vec![(
-                                            ident!("v"),
-                                            FactField::Expression(Expression::String(text!(
-                                                "hello"
+                                                "new_x"
                                             )),)
                                         )],
-                                        value_fields: None,
-                                    },
-                                }),
-                                1801
-                            ),
-                            AstNode::new(
-                                ast::Statement::Emit(Expression::NamedStruct(ast::NamedStruct {
-                                    identifier: ident!("Added"),
-                                    fields: vec![
-                                        (ident!("x"), Expression::Identifier(ident!("new_x")),),
-                                        (ident!("y"), Expression::Identifier(ident!("count")),),
-                                    ],
-                                },)),
-                                1842
-                            ),
-                        ]),
-                        1663,
-                    ),
-                ],
-            },
-            406,
-        )]
+                                    }),
+                                    1748
+                                ),
+                                AstNode::new(
+                                    ast::Statement::Delete(ast::DeleteStatement {
+                                        fact: ast::FactLiteral {
+                                            identifier: ident!("F"),
+                                            key_fields: vec![(
+                                                ident!("v"),
+                                                FactField::Expression(Expression::String(text!(
+                                                    "hello"
+                                                )),)
+                                            )],
+                                            value_fields: None,
+                                        },
+                                    }),
+                                    1801
+                                ),
+                                AstNode::new(
+                                    ast::Statement::Emit(Expression::NamedStruct(
+                                        ast::NamedStruct {
+                                            identifier: ident!("Added"),
+                                            fields: vec![
+                                                (
+                                                    ident!("x"),
+                                                    Expression::Identifier(ident!("new_x")),
+                                                ),
+                                                (
+                                                    ident!("y"),
+                                                    Expression::Identifier(ident!("count")),
+                                                ),
+                                            ],
+                                        },
+                                    )),
+                                    1842
+                                ),
+                            ]),
+                            1663,
+                        ),
+                    ],
+                },
+                406,
+            ),
+            AstNode::new(
+                ast::CommandDefinition {
+                    ephemeral: true,
+                    attributes: vec![],
+                    identifier: ident!("C"),
+                    fields: vec![ast::StructItem::Field(ast::FieldDefinition {
+                        identifier: ident!("x"),
+                        field_type: ast::VType::Int,
+                    })],
+                    policy: vec![],
+                    seal: vec![],
+                    open: vec![],
+                    recall: vec![],
+                },
+                2241,
+            )
+        ]
     );
     assert_eq!(
         policy.functions,
@@ -1403,6 +1455,7 @@ fn parse_seal_open() {
         policy.commands,
         vec![AstNode::new(
             ast::CommandDefinition {
+                ephemeral: false,
                 attributes: vec![],
                 identifier: ident!("Foo"),
                 fields: vec![],
@@ -1451,6 +1504,7 @@ fn parse_serialize_deserialize() {
         policy.commands,
         vec![AstNode::new(
             ast::CommandDefinition {
+                ephemeral: false,
                 attributes: vec![],
                 identifier: ident!("Foo"),
                 fields: vec![],

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -611,7 +611,7 @@ fn parse_policy_test() -> Result<(), ParseError> {
         vec![
             AstNode::new(
                 ast::ActionDefinition {
-                    ephemeral: false,
+                    persistence: ast::Persistence::Persistent,
                     identifier: ident!("add"),
                     arguments: vec![
                         ast::FieldDefinition {
@@ -647,7 +647,7 @@ fn parse_policy_test() -> Result<(), ParseError> {
             ),
             AstNode::new(
                 ast::ActionDefinition {
-                    ephemeral: true,
+                    persistence: ast::Persistence::Ephemeral,
                     identifier: ident!("a"),
                     arguments: vec![],
                     statements: vec![],
@@ -682,7 +682,7 @@ fn parse_policy_test() -> Result<(), ParseError> {
         vec![
             AstNode::new(
                 ast::CommandDefinition {
-                    ephemeral: false,
+                    persistence: ast::Persistence::Persistent,
                     attributes: vec![],
                     identifier: ident!("Add"),
                     fields: vec![ast::StructItem::Field(ast::FieldDefinition {
@@ -1037,7 +1037,7 @@ fn parse_policy_test() -> Result<(), ParseError> {
             ),
             AstNode::new(
                 ast::CommandDefinition {
-                    ephemeral: true,
+                    persistence: ast::Persistence::Ephemeral,
                     attributes: vec![],
                     identifier: ident!("C"),
                     fields: vec![ast::StructItem::Field(ast::FieldDefinition {
@@ -1455,7 +1455,7 @@ fn parse_seal_open() {
         policy.commands,
         vec![AstNode::new(
             ast::CommandDefinition {
-                ephemeral: false,
+                persistence: ast::Persistence::Persistent,
                 attributes: vec![],
                 identifier: ident!("Foo"),
                 fields: vec![],
@@ -1504,7 +1504,7 @@ fn parse_serialize_deserialize() {
         policy.commands,
         vec![AstNode::new(
             ast::CommandDefinition {
-                ephemeral: false,
+                persistence: ast::Persistence::Persistent,
                 attributes: vec![],
                 identifier: ident!("Foo"),
                 fields: vec![],
@@ -1634,7 +1634,7 @@ fn parse_global_let_statements() -> Result<(), ParseError> {
         policy.actions,
         vec![AstNode::new(
             ast::ActionDefinition {
-                ephemeral: false,
+                persistence: ast::Persistence::Persistent,
                 identifier: ident!("foo"),
                 arguments: vec![],
                 statements: vec![
@@ -1777,7 +1777,7 @@ fn test_action_call() -> anyhow::Result<()> {
         policy.actions[1],
         AstNode {
             inner: ast::ActionDefinition {
-                ephemeral: false,
+                persistence: ast::Persistence::Persistent,
                 identifier: ident!("pong"),
                 arguments: vec![],
                 statements: vec![AstNode {


### PR DESCRIPTION
Closes #106: Commands (and actions) now have a `persistence` field which specifies whether the command will be stored on-graph. This is specified via an optional `ephemeral` keyword, and the compiler asserts that persistent actions can only publish persistent commands, and ephemeral actions only ephemeral commands. E.g.

```
ephemeral command Foo { ... }
command Bar { ... }
ephemeral action foo() {
    publish Foo { ... }
    publish Bar { ... } // error: ephemeral action `foo` cannot publish persistent command `Bar`
}
```

