### PR TITLE
Fix #332: Show corect line number for errors in policy chunks.

### DIFF
--- a/crates/aranya-policy-lang/src/bin/parser-explorer/main.rs
+++ b/crates/aranya-policy-lang/src/bin/parser-explorer/main.rs
@@ -71,8 +71,7 @@ fn parse_thing(s: &str, args: &Args) -> anyhow::Result<String> {
             let token = pairs.next().context("No tokens")?;
 
             let pratt = get_pratt_parser();
-            let start = Point::new(0, 0, 0);
-            let mut p = ChunkParser::new(&start, &pratt);
+            let mut p = ChunkParser::new(0, &pratt);
             let ast = p.parse_expression(token)?;
 
             Ok(format!("{:#?}", ast))

--- a/crates/aranya-policy-lang/src/bin/parser-explorer/main.rs
+++ b/crates/aranya-policy-lang/src/bin/parser-explorer/main.rs
@@ -9,7 +9,6 @@ use aranya_policy_lang::lang::{
     ChunkParser, PolicyParser, Rule, Version, extract_policy, get_pratt_parser, parse_policy_str,
 };
 use clap::{Parser, ValueEnum};
-use markdown::unist::Point;
 use pest::Parser as PestParser;
 
 #[derive(Parser, Debug)]

--- a/crates/aranya-policy-lang/src/bin/parser-explorer/main.rs
+++ b/crates/aranya-policy-lang/src/bin/parser-explorer/main.rs
@@ -9,6 +9,7 @@ use aranya_policy_lang::lang::{
     ChunkParser, PolicyParser, Rule, Version, extract_policy, get_pratt_parser, parse_policy_str,
 };
 use clap::{Parser, ValueEnum};
+use markdown::unist::Point;
 use pest::Parser as PestParser;
 
 #[derive(Parser, Debug)]
@@ -70,7 +71,8 @@ fn parse_thing(s: &str, args: &Args) -> anyhow::Result<String> {
             let token = pairs.next().context("No tokens")?;
 
             let pratt = get_pratt_parser();
-            let mut p = ChunkParser::new(0, &pratt);
+            let start = Point::new(0, 0, 0);
+            let mut p = ChunkParser::new(&start, &pratt);
             let ast = p.parse_expression(token)?;
 
             Ok(format!("{:#?}", ast))

--- a/crates/aranya-policy-lang/src/lang/parse/error.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/error.rs
@@ -2,6 +2,7 @@ use std::fmt::Display;
 
 use aranya_policy_ast::Version;
 use buggy::Bug;
+use markdown::unist::Point;
 use pest::{
     Span,
     error::{Error as PestError, LineColLocation},
@@ -66,13 +67,13 @@ impl ParseError {
     }
 
     /// Return a new error with a location starting from the given line.
-    pub fn adjust_line_number(&self, start_line: usize) -> ParseError {
+    pub fn adjust_line_number(&self, start: &Point) -> ParseError {
         ParseError {
             kind: self.kind.clone(),
             message: self.message.clone(),
             location: self
                 .location
-                .map(|(line, col)| (line.saturating_add(start_line), col)),
+                .map(|(line, col)| (line.saturating_add(start.line), col)),
         }
     }
 }

--- a/crates/aranya-policy-lang/src/lang/parse/error.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/error.rs
@@ -114,15 +114,15 @@ impl Display for ParseError {
 
 impl From<PestError<Rule>> for ParseError {
     fn from(e: PestError<Rule>) -> Self {
-        let (line, column) = match e.line_col {
+        let p = match e.line_col {
             LineColLocation::Pos(p) => p,
             LineColLocation::Span(p, _) => p,
         };
-        let message = match e.path() {
-            Some(path) => format!("in {} line {} column {}: {}", path, line, column, e),
-            None => format!("line {} column {}: {}", line, column, e),
-        };
-        ParseError::new(ParseErrorKind::Syntax, message, None)
+        ParseError {
+            kind: ParseErrorKind::Syntax,
+            message: e.to_string(),
+            location: Some(p),
+        }
     }
 }
 

--- a/crates/aranya-policy-lang/src/lang/parse/error.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/error.rs
@@ -48,6 +48,32 @@ pub enum ParseErrorKind {
     Unknown,
 }
 
+impl Display for ParseErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseErrorKind::InvalidType => write!(f, "Invalid type"),
+            ParseErrorKind::InvalidStatement => write!(f, "Invalid statement"),
+            ParseErrorKind::InvalidNumber => write!(f, "Invalid number"),
+            ParseErrorKind::InvalidString => write!(f, "Invalid string"),
+            ParseErrorKind::InvalidFunctionCall => write!(f, "Invalid function call"),
+            ParseErrorKind::InvalidMember => write!(f, "Invalid member"),
+            ParseErrorKind::InvalidSubstruct => write!(f, "Invalid substruct operation"),
+            ParseErrorKind::InvalidVersion { found, required } => {
+                write!(
+                    f,
+                    "Invalid policy version {found}, supported version is {required}"
+                )
+            }
+            ParseErrorKind::Expression => write!(f, "Invalid expression"),
+            ParseErrorKind::Syntax => write!(f, "Syntax error"),
+            ParseErrorKind::FrontMatter => write!(f, "Front matter YAML parse error"),
+            ParseErrorKind::ReservedIdentifier => write!(f, "Reserved identifier"),
+            ParseErrorKind::Bug => write!(f, "Bug"),
+            ParseErrorKind::Unknown => write!(f, "Unknown error"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ParseError {
     pub kind: ParseErrorKind,
@@ -77,29 +103,12 @@ impl ParseError {
 
 impl Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let location = match self.location {
-            Some((line, column)) => format!("line {line} column {column}: "),
-            None => String::new(),
-        };
-        let prefix = match &self.kind {
-            ParseErrorKind::InvalidType => "Invalid type",
-            ParseErrorKind::InvalidStatement => "Invalid statement",
-            ParseErrorKind::InvalidNumber => "Invalid number",
-            ParseErrorKind::InvalidString => "Invalid string",
-            ParseErrorKind::InvalidFunctionCall => "Invalid function call",
-            ParseErrorKind::InvalidMember => "Invalid member",
-            ParseErrorKind::InvalidVersion { found, required } => {
-                &{ format!("Invalid policy version {found}, supported version is {required}") }
-            }
-            ParseErrorKind::InvalidSubstruct => "Invalid substruct operation",
-            ParseErrorKind::Expression => "Invalid expression",
-            ParseErrorKind::Syntax => "Syntax error",
-            ParseErrorKind::FrontMatter => "Front matter YAML parse error",
-            ParseErrorKind::ReservedIdentifier => "Reserved identifier",
-            ParseErrorKind::Bug => "Bug",
-            ParseErrorKind::Unknown => "Unknown error",
-        };
-        write!(f, "{prefix}: {location}{}", self.message)
+        write!(f, "{}: ", self.kind)?;
+        if let Some((line, column)) = self.location {
+            write!(f, "line {line} column {column}: ")?;
+        }
+        write!(f, "{}", self.message)?;
+        Ok(())
     }
 }
 

--- a/crates/aranya-policy-lang/src/lang/parse/error.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/error.rs
@@ -67,14 +67,11 @@ impl ParseError {
     }
 
     /// Return a new error with a location starting from the given line.
-    pub fn adjust_line_number(&self, start: &Point) -> ParseError {
-        ParseError {
-            kind: self.kind.clone(),
-            message: self.message.clone(),
-            location: self
-                .location
-                .map(|(line, col)| (line.saturating_add(start.line), col)),
+    pub fn adjust_line_number(mut self, start: &Point) -> ParseError {
+        if let Some((line, _)) = &mut self.location {
+            *line = line.saturating_add(start.line);
         }
+        self
     }
 }
 

--- a/crates/aranya-policy-lang/src/lang/parse/error.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/error.rs
@@ -2,7 +2,6 @@ use std::fmt::Display;
 
 use aranya_policy_ast::Version;
 use buggy::Bug;
-use markdown::unist::Point;
 use pest::{
     Span,
     error::{Error as PestError, LineColLocation},
@@ -93,9 +92,9 @@ impl ParseError {
     }
 
     /// Return a new error with a location starting from the given line.
-    pub fn adjust_line_number(mut self, start: &Point) -> ParseError {
+    pub fn adjust_line_number(mut self, start_line: usize) -> ParseError {
         if let Some((line, _)) = &mut self.location {
-            *line = line.saturating_add(start.line);
+            *line = line.saturating_add(start_line);
         }
         self
     }

--- a/crates/aranya-policy-lang/src/lang/parse/markdown.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/markdown.rs
@@ -88,7 +88,7 @@ pub fn parse_policy_document(data: &str) -> Result<ast::Policy, ParseError> {
     let (chunks, version) = extract_policy(data)?;
     if chunks.is_empty() {
         return Err(ParseError::new(
-            ParseErrorKind::FrontMatter,
+            ParseErrorKind::Unknown,
             String::from("No policy code found in Markdown document"),
             None,
         ));

--- a/crates/aranya-policy-lang/src/lang/parse/markdown.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/markdown.rs
@@ -3,6 +3,7 @@ use markdown::{
     ParseOptions,
     mdast::{Node, Yaml},
     to_mdast,
+    unist::Point,
 };
 use serde::Deserialize;
 
@@ -36,7 +37,7 @@ fn parse_front_matter(yaml: &Yaml) -> Result<Version, ParseError> {
 #[derive(Debug)]
 pub struct PolicyChunk {
     pub text: String,
-    pub start_line: usize,
+    pub start: Point,
 }
 
 fn extract_policy_from_markdown(node: &Node) -> Result<(Vec<PolicyChunk>, Version), ParseError> {
@@ -63,10 +64,9 @@ fn extract_policy_from_markdown(node: &Node) -> Result<(Vec<PolicyChunk>, Versio
                 if let Some(lang) = &c.lang {
                     if lang == "policy" {
                         let position = c.position.as_ref().expect("no code block position");
-                        let start_line = position.start.line;
                         chunks.push(PolicyChunk {
                             text: c.value.clone(),
-                            start_line,
+                            start: position.start.clone(),
                         });
                     }
                 }
@@ -95,7 +95,7 @@ pub fn parse_policy_document(data: &str) -> Result<ast::Policy, ParseError> {
     }
     let mut policy = ast::Policy::new(version, data);
     for c in chunks {
-        parse_policy_chunk(&c.text, &mut policy, c.start_line)?;
+        parse_policy_chunk(&c.text, &mut policy, &c.start)?;
     }
     Ok(policy)
 }

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -4,7 +4,6 @@ use std::{fs::OpenOptions, io::Read};
 
 use aranya_policy_ast::{ident, text};
 use ast::{Expression, FactField, ForeignFunctionCall, MatchPattern};
-use markdown::unist::Point;
 use pest::{Parser, error::Error as PestError, iterators::Pair};
 
 use super::{

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -243,8 +243,7 @@ fn parse_expression_errors() -> Result<(), ParseError> {
             description: String::from("Integer overflow"),
             input: r#"18446744073709551617"#.to_string(),
             error_message: String::from(
-                "Invalid number: line 1 column 1: 18446744073709551617: \
-                number too large to fit in target type",
+                "Invalid number: line 1 column 1: number too large to fit in target type",
             ),
             rule: Rule::expression,
         },
@@ -255,24 +254,21 @@ fn parse_expression_errors() -> Result<(), ParseError> {
             )"#
             .to_string(),
             error_message: String::from(
-                "Invalid number: line 2 column 17: 18446744073709551617: \
-                number too large to fit in target type",
+                "Invalid number: line 2 column 17: number too large to fit in target type",
             ),
             rule: Rule::expression,
         },
         ErrorInput {
             description: String::from("Invalid string escape"),
             input: r#""\\""#.to_string(),
-            error_message: String::from(
-                "Invalid string: line 1 column 1: \"\\\\\": invalid escape: \\",
-            ),
+            error_message: String::from("Invalid string: line 1 column 1: invalid escape: \\"),
             rule: Rule::expression,
         },
         ErrorInput {
             description: String::from("Expect Invalid substruct operation"),
             input: r#"x substruct 4"#.to_string(),
             error_message: String::from(
-                "Invalid substruct operation: line 1 column 3: substruct: Expression `Int(4)` to the right of the substruct operator must be an identifier",
+                "Invalid substruct operation: line 1 column 3: Expression `Int(4)` to the right of the substruct operator must be an identifier",
             ),
             rule: Rule::expression,
         },
@@ -1936,4 +1932,18 @@ fn test_invalid_text() {
         let err = parse_policy_str(src, Version::V2).unwrap_err();
         assert_eq!(err.kind, ParseErrorKind::InvalidString, "{src:?}");
     }
+}
+
+#[test]
+fn test_error_line_number_in_chunks() {
+    let policy = r#"---
+policy-version: 2
+---
+
+```policy
+    let int = 0
+```
+"#;
+    let err = parse_policy_document(policy).unwrap_err();
+    assert_eq!(err.to_string(), "Reserved identifier: line 6 column 9: int");
 }

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -190,8 +190,7 @@ fn parse_expression_pratt() -> Result<(), ParseError> {
         .trim(),
     )?;
     let pratt = get_pratt_parser();
-    let start = Point::new(0, 0, 0);
-    let mut p = ChunkParser::new(&start, &pratt);
+    let mut p = ChunkParser::new(0, &pratt);
     let expr = pairs.next().unwrap();
     let expr_parsed = p.parse_expression(expr)?;
     assert_eq!(
@@ -276,8 +275,7 @@ fn parse_expression_errors() -> Result<(), ParseError> {
         },
     ];
     let pratt = get_pratt_parser();
-    let start = Point::new(0, 0, 0);
-    let mut p = ChunkParser::new(&start, &pratt);
+    let mut p = ChunkParser::new(0, &pratt);
     for case in cases {
         let mut pairs = PolicyParser::parse(case.rule, &case.input)?;
         let expr = pairs.next().unwrap();

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -1964,6 +1964,27 @@ Next chunk:
         "#,
             "Invalid string: line 11 column 13: invalid escape: \\",
         ),
+        (
+            r#"---
+policy-version: 2
+---
+
+```policy
+    let x = 0
+```
+Next chunk:
+```policy
+    let x = 0
+    let = 2
+```
+        "#,
+            r#"Syntax error: line 11 column 9:   --> 11:9
+   |
+11 |     let = 2
+   |         ^---
+   |
+   = expected identifier"#,
+        ),
     ];
 
     for (policy, expected) in cases {


### PR DESCRIPTION
Error line numbers now account for starting lines of policy chunks. E.g.

```
---
policy-version: 2
---

'''policy
    let int = 0
'''

Reserved identifier: line 6 column 9: int
```