### PR TITLE
logging: change error! to debug! in convert_err

### DIFF
--- a/crates/aranya-capi-core/src/internal/error.rs
+++ b/crates/aranya-capi-core/src/internal/error.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use tracing::error;
+use tracing::debug;
 
 use crate::{
     as_mut,
@@ -15,7 +15,7 @@ where
     E1: fmt::Display,
     E2: ErrorCode + for<'a> From<&'a E1>,
 {
-    error!(%err);
+    debug!(%err);
     err.into()
 }
 
@@ -30,7 +30,7 @@ where
     E2: ExtendedError,
     E3: ErrorCode + for<'a> From<&'a E1>,
 {
-    error!(%err);
+    debug!(%err);
 
     let res = (&err).into();
     if let Ok(ext_err) = as_mut!(ext_err) {


### PR DESCRIPTION
Using error! here adds a lot of chaff to the logs when using the C API, especially when using the polling-based methods like try_receive_channel (the WoudBlock response logs). This reduces the output when using levels above debug.