### PR TITLE
vm: remove unused method `MachineIo::publish`

### DIFF
--- a/crates/aranya-policy-vm-explorer/src/main.rs
+++ b/crates/aranya-policy-vm-explorer/src/main.rs
@@ -114,7 +114,6 @@ fn subset_key_match(a: &[FactKey], b: &[FactKey]) -> bool {
 
 struct MachExpIO {
     facts: HashMap<(Identifier, FactKeyList), FactValueList>,
-    commands: Vec<(Identifier, Vec<KVPair>)>,
     effects: Vec<(Identifier, Vec<KVPair>)>,
 }
 
@@ -122,7 +121,6 @@ impl MachExpIO {
     fn new() -> Self {
         MachExpIO {
             facts: HashMap::new(),
-            commands: vec![],
             effects: vec![],
         }
     }
@@ -195,11 +193,6 @@ where
             // TODO(jdygert): Worth removing clone?
             iter: self.facts.clone().into_iter(),
         })
-    }
-
-    fn publish(&mut self, name: Identifier, fields: impl IntoIterator<Item = KVPair>) {
-        let fields = fields.into_iter().collect();
-        self.commands.push((name, fields))
     }
 
     fn effect(
@@ -319,7 +312,10 @@ fn main() -> anyhow::Result<()> {
                 }
             }
 
-            drop(rs);
+            println!("Stack:");
+            for value in rs.stack.into_vec() {
+                println!("  {value}");
+            }
 
             println!("Facts:");
             for ((name, k), v) in &io.borrow().facts {
@@ -333,16 +329,9 @@ fn main() -> anyhow::Result<()> {
                 }
                 println!("}}");
             }
+
             println!("Effects:");
             for (name, fields) in &io.borrow().effects {
-                println!("  {} {{", name);
-                for f in fields {
-                    println!("    {}", f);
-                }
-                println!("  }}");
-            }
-            println!("Published Commands:");
-            for (name, fields) in &io.borrow().commands {
                 println!("  {} {{", name);
                 for f in fields {
                     println!("    {}", f);

--- a/crates/aranya-policy-vm/src/io.rs
+++ b/crates/aranya-policy-vm/src/io.rs
@@ -68,9 +68,6 @@ where
         key: impl IntoIterator<Item = FactKey>,
     ) -> Result<Self::QueryIterator, MachineIOError>;
 
-    /// Publish a command
-    fn publish(&mut self, name: Identifier, fields: impl IntoIterator<Item = KVPair>);
-
     /// Create an effect
     fn effect(
         &mut self,

--- a/crates/aranya-policy-vm/src/tests/io.rs
+++ b/crates/aranya-policy-vm/src/tests/io.rs
@@ -16,7 +16,6 @@ use crate::{
 
 pub struct TestIO {
     pub facts: BTreeMap<(Identifier, FactKeyList), FactValueList>,
-    pub publish_stack: Vec<(Identifier, Vec<KVPair>)>,
     pub effect_stack: Vec<(Identifier, Vec<KVPair>)>,
     pub engine: RefCell<DefaultEngine<Rng, DefaultCipherSuite>>,
     pub print_ffi: PrintFfi,
@@ -27,7 +26,6 @@ impl fmt::Debug for TestIO {
         let module_names = ["print"];
         f.debug_struct("TestIO")
             .field("facts", &self.facts)
-            .field("publish_stack", &self.publish_stack)
             .field("effect_stack", &self.effect_stack)
             .field("modules", &module_names)
             .finish()
@@ -39,7 +37,6 @@ impl TestIO {
         let (engine, _) = DefaultEngine::from_entropy(Rng);
         TestIO {
             facts: BTreeMap::new(),
-            publish_stack: vec![],
             effect_stack: vec![],
             engine: RefCell::new(engine),
             print_ffi: PrintFfi {},
@@ -108,13 +105,6 @@ where
             .map(|((_, k), v)| Ok::<(FactKeyList, FactValueList), MachineIOError>((k, v)));
 
         Ok(Box::new(iter))
-    }
-
-    fn publish(&mut self, name: Identifier, fields: impl IntoIterator<Item = KVPair>) {
-        let mut fields: Vec<_> = fields.into_iter().collect();
-        fields.sort_by(|a, b| a.key().cmp(b.key()));
-        println!("publish {} {{{:?}}}", name, fields);
-        self.publish_stack.push((name, fields));
     }
 
     fn effect(

--- a/crates/aranya-policy-vm/tests/bits/testio.rs
+++ b/crates/aranya-policy-vm/tests/bits/testio.rs
@@ -20,7 +20,6 @@ use super::printffi::*;
 
 pub struct TestIO {
     pub facts: BTreeMap<(Identifier, FactKeyList), FactValueList>,
-    pub publish_stack: Vec<(Identifier, Vec<KVPair>)>,
     pub effect_stack: Vec<(Identifier, Vec<KVPair>)>,
     pub engine: RefCell<DefaultEngine<Rng, DefaultCipherSuite>>,
     pub print_ffi: PrintFfi,
@@ -31,7 +30,6 @@ impl fmt::Debug for TestIO {
         let module_names = ["print"];
         f.debug_struct("TestIO")
             .field("facts", &self.facts)
-            .field("publish_stack", &self.publish_stack)
             .field("effect_stack", &self.effect_stack)
             .field("modules", &module_names)
             .finish()
@@ -43,7 +41,6 @@ impl TestIO {
         let (engine, _) = DefaultEngine::from_entropy(Rng);
         TestIO {
             facts: BTreeMap::new(),
-            publish_stack: vec![],
             effect_stack: vec![],
             engine: RefCell::new(engine),
             print_ffi: PrintFfi {},
@@ -115,13 +112,6 @@ where
             .map(|((_, k), v)| Ok::<(FactKeyList, FactValueList), MachineIOError>((k, v)));
 
         Ok(Box::new(iter))
-    }
-
-    fn publish(&mut self, name: Identifier, fields: impl IntoIterator<Item = KVPair>) {
-        let mut fields: Vec<_> = fields.into_iter().collect();
-        fields.sort_by(|a, b| a.key().cmp(b.key()));
-        println!("publish {} {{{:?}}}", name, fields);
-        self.publish_stack.push((name, fields));
     }
 
     fn effect(

--- a/crates/aranya-runtime/src/vm_policy/io.rs
+++ b/crates/aranya-runtime/src/vm_policy/io.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use alloc::{borrow::ToOwned, boxed::Box, vec, vec::Vec};
+use alloc::{borrow::ToOwned, boxed::Box, vec::Vec};
 use core::{
     cell::RefCell,
     ops::{Deref, DerefMut},
@@ -51,12 +51,9 @@ where
 pub struct VmPolicyIO<'o, P, S, E, FFI> {
     facts: &'o RefCell<&'o mut P>,
     sink: &'o RefCell<&'o mut S>,
-    publish_stack: Vec<(Identifier, Vec<KVPair>)>,
     engine: &'o Mutex<E>,
     ffis: &'o [FFI],
 }
-
-pub type FfiList<'a, E> = &'a mut [&'a mut dyn FfiCallable<E>];
 
 impl<'o, P, S, E, FFI> VmPolicyIO<'o, P, S, E, FFI> {
     /// Creates a new `VmPolicyIO` for a [`crate::storage::FactPerspective`] and a
@@ -70,15 +67,9 @@ impl<'o, P, S, E, FFI> VmPolicyIO<'o, P, S, E, FFI> {
         VmPolicyIO {
             facts,
             sink,
-            publish_stack: vec![],
             engine,
             ffis,
         }
-    }
-
-    /// Consumes the `VmPolicyIO` object and produces the publish stack.
-    pub fn into_publish_stack(self) -> Vec<(Identifier, Vec<KVPair>)> {
-        self.publish_stack
     }
 }
 
@@ -136,11 +127,6 @@ where
                 MachineIOError::Internal
             })?;
         Ok(VmFactCursor { iter })
-    }
-
-    fn publish(&mut self, name: Identifier, fields: impl IntoIterator<Item = KVPair>) {
-        let fields: Vec<_> = fields.into_iter().collect();
-        self.publish_stack.push((name, fields));
     }
 
     fn effect(


### PR DESCRIPTION
After #15, `publish` was only used by tests, since commands are now yielded instead.