### PR TITLE
runtime: check persistence when calling actions

### DIFF
--- a/crates/aranya-model/src/tests/basic-policy.md
+++ b/crates/aranya-model/src/tests/basic-policy.md
@@ -228,9 +228,7 @@ ephemeral action get_stuff() {
 }
 
 // `GetStuff` is a command that queries the contents of the `Stuff` fact and
-// returns it in a `StuffHappened` effect. As pointed out elsewhere, there is
-// absolutely nothing stopping us from using this command in an on-graph or
-// ephemeral context. We chose to use it strictly in the ephemeral context.
+// returns it in a `StuffHappened` effect.
 ephemeral command GetStuff {
     fields {
         key_a int,

--- a/crates/aranya-model/src/tests/basic-policy.md
+++ b/crates/aranya-model/src/tests/basic-policy.md
@@ -14,10 +14,6 @@ not added to the graph of commands and do not persist any changes to the factDB.
 Hence, they are also not delivered through syncs and should be transmitted via
 some other mechanism.
 
-It should be noted that there is no syntactic difference between on-graph and
-ephemeral commands currently. They could in theory be used interchangeably,
-however they are almost always created with a particular flavor in mind.
-
 ```policy
 use envelope
 

--- a/crates/aranya-model/src/tests/ffi-policy.md
+++ b/crates/aranya-model/src/tests/ffi-policy.md
@@ -15,10 +15,6 @@ This policy also supplies sample ephemeral commands, `CreateGreeting` and
 commands and do not persist any changes to the factDB. Hence, they are also not
 delivered through syncs and should be transmitted via some other mechanism.
 
-It should be noted that there is no syntactic difference between on-graph and
-ephemeral commands currently. They could in theory be used interchangeably,
-however they are almost always created with a particular flavor in mind.
-
 ```policy
 use idam
 use perspective

--- a/crates/aranya-model/src/tests/ffi-policy.md
+++ b/crates/aranya-model/src/tests/ffi-policy.md
@@ -339,7 +339,7 @@ command Decrement {
 
 // The `create_greeting` action calls the command `CreateGreeting`. Passing in
 // the hardcoded greeting key and the message value.
-action create_greeting(v string) {
+ephemeral action create_greeting(v string) {
     publish CreateGreeting {
         key: "greeting",
         value: v,
@@ -348,7 +348,7 @@ action create_greeting(v string) {
 
 // `CreateGreeting` is an ephemeral command that creates a fact that lives for
 // the lifetime of the session it was called in.
-command CreateGreeting {
+ephemeral command CreateGreeting {
     fields {
         key string,
         value string,
@@ -369,7 +369,7 @@ command CreateGreeting {
 
 // The `verify_hello` action calls the command `VerifyGreeting` that will verify
 // the Message fact contains "hello".
-action verify_hello() {
+ephemeral action verify_hello() {
     publish VerifyGreeting {
         key: "greeting",
         value: "hello",
@@ -380,7 +380,7 @@ action verify_hello() {
 // compares the contents with the value passed in. It is meant to be used in
 // conjunction with `CreateGreeting`, where CreateGreeting writes to the factDB
 // and VerifyGreeting checks it's contents.
-command VerifyGreeting {
+ephemeral command VerifyGreeting {
     fields {
         key string,
         value string,

--- a/crates/aranya-model/src/tests/mod.rs
+++ b/crates/aranya-model/src/tests/mod.rs
@@ -1190,7 +1190,10 @@ fn can_perform_action_after_receive_on_session() -> anyhow::Result<()> {
     let (cmds, effects) = test_model.session_actions(
         Device::A,
         Graph::X,
-        [vm_action!(create_action(5)), vm_action!(increment(3))],
+        [
+            vm_action!(create_action_ephemeral(5)),
+            vm_action!(increment_ephemeral(3)),
+        ],
     )?;
 
     assert_eq!(
@@ -1206,7 +1209,7 @@ fn can_perform_action_after_receive_on_session() -> anyhow::Result<()> {
     for cmd in cmds {
         session.receive(&cmd)?;
     }
-    session.action(vm_action!(increment(7)))?;
+    session.action(vm_action!(increment_ephemeral(7)))?;
 
     let (cmds, effects) = session.observe();
     assert_eq!(
@@ -1221,7 +1224,7 @@ fn can_perform_action_after_receive_on_session() -> anyhow::Result<()> {
     // Receive commands from client B on a new session,
     // and then perform an action afterward.
     let mut session = test_model.session(Device::A, Graph::X)?;
-    session.action(vm_action!(create_action(2)))?;
+    session.action(vm_action!(create_action_ephemeral(2)))?;
     for cmd in cmds {
         session.receive(&cmd)?;
     }
@@ -1448,10 +1451,10 @@ fn test_storage_fact_creturns_correct_index() {
     for _ in 0..5 {
         for _ in 0..5 {
             test_model
-                .action(Device::A, Graph::X, vm_action!(get_stuff()))
+                .action(Device::A, Graph::X, vm_action!(get_stuff_on_graph()))
                 .unwrap();
             test_model
-                .action(Device::B, Graph::X, vm_action!(get_stuff()))
+                .action(Device::B, Graph::X, vm_action!(get_stuff_on_graph()))
                 .unwrap();
         }
         test_model.sync(Graph::X, Device::A, Device::B).unwrap();

--- a/crates/aranya-runtime/src/client.rs
+++ b/crates/aranya-runtime/src/client.rs
@@ -91,7 +91,12 @@ where
         let mut perspective = self.provider.new_perspective(policy_id);
         sink.begin();
         policy
-            .call_action(action, &mut perspective, sink)
+            .call_action(
+                action,
+                &mut perspective,
+                sink,
+                crate::Persistence::Persistent,
+            )
             .inspect_err(|_| sink.rollback())?;
         sink.commit();
 
@@ -176,7 +181,12 @@ where
         // Must checkpoint once we add action transactions.
 
         sink.begin();
-        match policy.call_action(action, &mut perspective, sink) {
+        match policy.call_action(
+            action,
+            &mut perspective,
+            sink,
+            crate::Persistence::Persistent,
+        ) {
             Ok(_) => {
                 let segment = storage.write(perspective)?;
                 storage.commit(segment)?;

--- a/crates/aranya-runtime/src/client/transaction.rs
+++ b/crates/aranya-runtime/src/client/transaction.rs
@@ -5,9 +5,9 @@ use buggy::{BugExt, bug};
 
 use super::braiding;
 use crate::{
-    Address, ClientError, CmdId, Command, CommandRecall, Engine, EngineError, GraphId, Location,
-    MAX_COMMAND_LENGTH, MergeIds, Persistence, Perspective, Policy, PolicyId, Prior, Revertable,
-    Segment, Sink, Storage, StorageError, StorageProvider,
+    Address, ClientError, CmdId, Command, Engine, EngineError, GraphId, Location,
+    MAX_COMMAND_LENGTH, MergeIds, Perspective, Policy, PolicyId, Prior, Revertable, Segment, Sink,
+    Storage, StorageError, StorageProvider, engine::CommandPlacement,
 };
 
 /// Transaction used to receive many commands at once.
@@ -226,8 +226,7 @@ impl<SP: StorageProvider, E: Engine> Transaction<SP, E> {
             command,
             perspective,
             sink,
-            Persistence::Persistent,
-            CommandRecall::None,
+            CommandPlacement::OnGraphAtOrigin,
         ) {
             perspective.revert(checkpoint)?;
             sink.rollback();
@@ -361,8 +360,7 @@ impl<SP: StorageProvider, E: Engine> Transaction<SP, E> {
             command,
             &mut perspective,
             sink,
-            Persistence::Persistent,
-            CommandRecall::None,
+            CommandPlacement::OnGraphAtOrigin,
         ) {
             sink.rollback();
             // We don't need to revert perspective since we just drop it.
@@ -406,8 +404,7 @@ fn make_braid_segment<S: Storage, E: Engine>(
             &command,
             &mut braid_perspective,
             sink,
-            Persistence::Persistent,
-            CommandRecall::OnCheck,
+            CommandPlacement::OnGraphInBraid,
         );
 
         // If the command failed in an uncontrolled way, rollback
@@ -460,7 +457,8 @@ mod test {
 
     use super::*;
     use crate::{
-        ClientState, Keys, MergeIds, Persistence, Priority,
+        ClientState, Keys, MergeIds, Priority,
+        engine::{ActionPlacement, CommandPlacement},
         memory::MemStorageProvider,
         testing::{hash_for_testing_only, short_b58},
     };
@@ -508,8 +506,7 @@ mod test {
             command: &impl Command,
             facts: &mut impl crate::FactPerspective,
             _sink: &mut impl Sink<Self::Effect>,
-            _persistence: Persistence,
-            _recall: CommandRecall,
+            _placement: CommandPlacement,
         ) -> Result<(), EngineError> {
             assert!(
                 !matches!(command.parent(), Prior::Merge { .. }),
@@ -539,7 +536,7 @@ mod test {
             _action: Self::Action<'_>,
             _facts: &mut impl Perspective,
             _sink: &mut impl Sink<Self::Effect>,
-            _persistence: Persistence,
+            _placement: ActionPlacement,
         ) -> Result<(), EngineError> {
             unimplemented!()
         }

--- a/crates/aranya-runtime/src/engine.rs
+++ b/crates/aranya-runtime/src/engine.rs
@@ -3,6 +3,8 @@
 //! An [`Engine`] stores policies for an application. A [`Policy`] is required
 //! to process [`Command`]s and defines how the runtime's graph is constructed.
 
+use core::fmt;
+
 use buggy::Bug;
 use serde::{Deserialize, Serialize};
 
@@ -145,6 +147,7 @@ pub trait Policy {
         command: &impl Command,
         facts: &mut impl FactPerspective,
         sink: &mut impl Sink<Self::Effect>,
+        persistence: Persistence,
         recall: CommandRecall,
     ) -> Result<(), EngineError>;
 
@@ -156,6 +159,7 @@ pub trait Policy {
         action: Self::Action<'_>,
         facts: &mut impl Perspective,
         sink: &mut impl Sink<Self::Effect>,
+        persistence: Persistence,
     ) -> Result<(), EngineError>;
 
     /// Produces a merge message serialized to target. The `struct` representing the
@@ -165,4 +169,19 @@ pub trait Policy {
         target: &'a mut [u8],
         ids: MergeIds,
     ) -> Result<Self::Command<'a>, EngineError>;
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum Persistence {
+    Persistent,
+    Ephemeral,
+}
+
+impl fmt::Display for Persistence {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Persistent => "persistent",
+            Self::Ephemeral => "ephemeral",
+        })
+    }
 }

--- a/crates/aranya-runtime/src/testing/protocol.rs
+++ b/crates/aranya-runtime/src/testing/protocol.rs
@@ -8,8 +8,8 @@ use tracing::{error, trace};
 
 use crate::{
     Address, CmdId, Command, CommandRecall, Engine, EngineError, FactPerspective, Keys,
-    MAX_COMMAND_LENGTH, MergeIds, Perspective, Policy, PolicyId, Prior, Priority, Sink, alloc,
-    testing::hash_for_testing_only,
+    MAX_COMMAND_LENGTH, MergeIds, Persistence, Perspective, Policy, PolicyId, Prior, Priority,
+    Sink, alloc, testing::hash_for_testing_only,
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -276,6 +276,7 @@ impl Policy for TestPolicy {
         command: &impl Command,
         facts: &mut impl FactPerspective,
         sink: &mut impl Sink<Self::Effect>,
+        _persistence: Persistence,
         _recall: CommandRecall,
     ) -> Result<(), EngineError> {
         let policy_command: WireProtocol = postcard::from_bytes(command.bytes())
@@ -302,6 +303,7 @@ impl Policy for TestPolicy {
         action: Self::Action<'_>,
         facts: &mut impl Perspective,
         sink: &mut impl Sink<Self::Effect>,
+        _persistence: Persistence,
     ) -> Result<(), EngineError> {
         let parent = match facts.head_address()? {
             Prior::None => Address {

--- a/crates/aranya-runtime/src/testing/protocol.rs
+++ b/crates/aranya-runtime/src/testing/protocol.rs
@@ -7,9 +7,9 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, trace};
 
 use crate::{
-    Address, CmdId, Command, CommandRecall, Engine, EngineError, FactPerspective, Keys,
-    MAX_COMMAND_LENGTH, MergeIds, Persistence, Perspective, Policy, PolicyId, Prior, Priority,
-    Sink, alloc, testing::hash_for_testing_only,
+    Address, CmdId, Command, Engine, EngineError, FactPerspective, Keys, MAX_COMMAND_LENGTH,
+    MergeIds, Perspective, Policy, PolicyId, Prior, Priority, Sink, alloc,
+    testing::hash_for_testing_only,
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -276,8 +276,7 @@ impl Policy for TestPolicy {
         command: &impl Command,
         facts: &mut impl FactPerspective,
         sink: &mut impl Sink<Self::Effect>,
-        _persistence: Persistence,
-        _recall: CommandRecall,
+        _placement: crate::engine::CommandPlacement,
     ) -> Result<(), EngineError> {
         let policy_command: WireProtocol = postcard::from_bytes(command.bytes())
             .inspect_err(|err| error!(?err))
@@ -303,7 +302,7 @@ impl Policy for TestPolicy {
         action: Self::Action<'_>,
         facts: &mut impl Perspective,
         sink: &mut impl Sink<Self::Effect>,
-        _persistence: Persistence,
+        _placement: crate::engine::ActionPlacement,
     ) -> Result<(), EngineError> {
         let parent = match facts.head_address()? {
             Prior::None => Address {


### PR DESCRIPTION
Ensures that persistent actions are used on-graph and ephemeral actions are used off-graph.

I changed the API to use `ActionPlacement` and `CommandPlacement` instead of `Persistence` and `OnRecall`. I think it's more clear this way to describe how the methods are being called and have the implementations determine the correct behavior from that.