### PR TITLE
policy-lang: reduce public API

### DIFF
--- a/crates/aranya-policy-lang/src/lang.rs
+++ b/crates/aranya-policy-lang/src/lang.rs
@@ -2,7 +2,6 @@ mod parse;
 
 pub use aranya_policy_ast::Version;
 pub use parse::{
-    ChunkParser, FfiTypes, ParseError, ParseErrorKind, PolicyParser, Rule, extract_policy,
-    get_pratt_parser, parse_ffi_decl, parse_ffi_structs_enums, parse_policy_chunk,
-    parse_policy_document, parse_policy_str,
+    FfiTypes, ParseError, ParseErrorKind, parse_expression, parse_ffi_decl,
+    parse_ffi_structs_enums, parse_policy_document, parse_policy_str,
 };

--- a/crates/aranya-policy-lang/src/lang/parse/markdown.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/markdown.rs
@@ -7,7 +7,7 @@ use markdown::{
 };
 use serde::Deserialize;
 
-use crate::lang::{ParseError, ParseErrorKind, Version, parse_policy_chunk};
+use super::{ParseError, ParseErrorKind, Version, parse_policy_chunk};
 
 #[derive(Deserialize)]
 struct FrontMatter {
@@ -124,7 +124,7 @@ pub fn parse_policy_document(data: &str) -> Result<ast::Policy, ParseError> {
 
 /// Extract the policy chunks from a Markdown policy document. Returns the chunks plus the
 /// policy version.
-pub fn extract_policy(data: &str) -> Result<(Vec<PolicyChunk>, Version), ParseError> {
+fn extract_policy(data: &str) -> Result<(Vec<PolicyChunk>, Version), ParseError> {
     let mut parseoptions = ParseOptions::gfm();
     parseoptions.constructs.frontmatter = true;
     let tree = to_mdast(data, &parseoptions)

--- a/crates/aranya-policy-lang/src/lang/parse/tests.rs
+++ b/crates/aranya-policy-lang/src/lang/parse/tests.rs
@@ -7,10 +7,9 @@ use ast::Expression;
 use pest::{Parser, error::Error as PestError, iterators::Pair};
 
 use super::{
-    ParseError, PolicyParser, Rule, Version, ast, get_pratt_parser, parse_policy_document,
-    parse_policy_str,
+    ChunkParser, ParseError, ParseErrorKind, PolicyParser, Rule, Version, ast, get_pratt_parser,
+    parse_policy_document, parse_policy_str,
 };
-use crate::lang::{ChunkParser, ParseErrorKind};
 
 trait SpannedAt {
     type Type;


### PR DESCRIPTION
Hides `ChunkParser`, `PolicyParser`, `Rule`, `extract_policy`, `get_parser`, `parse_policy_chunk`.

Adds `parse_expression`.