### PR TITLE
policy-module: add `NamedMap` and def types for action and command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,8 @@ version = "0.12.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-ast",
+ "fnv",
+ "indexmap",
  "proptest",
  "proptest-derive",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ criterion = { version = "0.6" }
 derive-where = { version = "1", default-features = false }
 errno = { version = "0.3", default-features = false }
 heapless = { version = "0.8", default-features = false }
+fnv = { version = "1", default-features = false }
+indexmap = { version = "2.9", default-features = false }
 libc = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
 postcard = { version = "1", default-features = false }

--- a/crates/aranya-afc-util/Cargo.toml
+++ b/crates/aranya-afc-util/Cargo.toml
@@ -49,7 +49,7 @@ aranya-crypto = { version = "0.9.0", path = "../aranya-crypto", default-features
 aranya-fast-channels = { version = "0.11.0", path = "../aranya-fast-channels", default-features = false, features = ["alloc"] }
 aranya-policy-vm = { version = "0.12.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 buggy = { version = "0.1.0", default-features = false }
-indexmap = { version = "2.1", default-features = false, optional = true }
+indexmap = { workspace = true, default-features = false, optional = true }
 postcard = { workspace = true, default-features = false, features = ["heapless"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }
 siphasher = { version = "1", default-features = false, optional = true }

--- a/crates/aranya-policy-compiler/Cargo.toml
+++ b/crates/aranya-policy-compiler/Cargo.toml
@@ -22,7 +22,7 @@ buggy = { version = "0.1.0", features = ["std"] }
 
 ciborium = { version = "0.2" }
 clap = { version = "4.4", features = ["derive"] }
-indexmap = { version = "2.9.0", default-features = false, features = ["serde"] }
+indexmap = { workspace = true, default-features = false, features = ["serde"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -18,8 +18,8 @@ use aranya_policy_ast::{
     StructItem, TypeKind, VType, ident,
 };
 use aranya_policy_module::{
-    CodeMap, ExitReason, Instruction, Label, LabelType, Meta, Module, Struct, Target, Value,
-    ffi::ModuleSchema,
+    ActionDef, Attribute, CodeMap, CommandDef, ExitReason, Field, Instruction, Label, LabelType,
+    Meta, Module, Param, Struct, Target, Value, ffi::ModuleSchema, named::NamedMap,
 };
 pub use ast::Policy as AstPolicy;
 use buggy::{Bug, BugExt, bug};
@@ -1546,7 +1546,7 @@ impl<'a> CompileState<'a> {
                                 kind: TypeKind::Struct(ref ident),
                                 ..
                             }) => {
-                                if !self.m.command_defs.contains_key(ident.as_str()) {
+                                if !self.m.command_defs.contains(ident.as_str()) {
                                     return Err(CompileErrorType::InvalidType(format!(
                                         "Struct `{ident}` is not a Command struct",
                                     )));
@@ -2062,13 +2062,20 @@ impl<'a> CompileState<'a> {
         )?;
         self.map_range(action_node.span)?;
 
-        // check for duplicate args
-        if let Some(identifier) = find_duplicate(&action_node.arguments, |a| &a.identifier.name) {
-            return Err(CompileError::from_locator(
-                CompileErrorType::AlreadyDefined(identifier.to_string()),
-                action_node.span.start(),
-                self.m.codemap.as_ref(),
-            ));
+        let mut params = NamedMap::new();
+        for param in &action_node.arguments {
+            params
+                .insert(Param {
+                    name: param.identifier.clone(),
+                    ty: param.field_type.clone(),
+                })
+                .map_err(|_| {
+                    CompileError::from_locator(
+                        CompileErrorType::AlreadyDefined(param.identifier.to_string()),
+                        action_node.span.start(),
+                        self.m.codemap.as_ref(),
+                    )
+                })?;
         }
 
         for arg in action_node.arguments.iter().rev() {
@@ -2079,20 +2086,19 @@ impl<'a> CompileState<'a> {
         self.append_instruction(Instruction::Return);
         self.identifier_types.exit_function();
 
-        match self
-            .m
+        self.m
             .action_defs
-            .entry(action_node.identifier.name.clone())
-        {
-            Entry::Vacant(e) => {
-                e.insert(action_node.arguments.clone());
-            }
-            Entry::Occupied(_) => {
-                return Err(self.err(CompileErrorType::AlreadyDefined(
+            .insert(ActionDef {
+                name: action_node.identifier.clone(),
+                persistence: action_node.persistence.clone(),
+                params,
+            })
+            .map_err(|_| {
+                self.err(CompileErrorType::AlreadyDefined(
                     action_node.identifier.to_string(),
-                )));
-            }
-        }
+                ))
+            })?;
+
         Ok(())
     }
 
@@ -2383,36 +2389,25 @@ impl<'a> CompileState<'a> {
         self.compile_command_open(command, command.span.start())?;
 
         // attributes
-        let mut attr_values = BTreeMap::new();
+        let mut attributes = NamedMap::new();
         for (name, value_expr) in &command.attributes {
-            match attr_values.entry(name.name.clone()) {
-                Entry::Vacant(e) => {
-                    let value = self.expression_value(value_expr)?;
-                    e.insert(value);
-                }
-                Entry::Occupied(_) => {
-                    return Err(self.err(CompileErrorType::AlreadyDefined(name.to_string())));
-                }
-            }
-        }
-        if !attr_values.is_empty() {
-            self.m
-                .command_attributes
-                .insert(command.identifier.name.clone(), attr_values);
+            let value = self.expression_value(value_expr)?;
+            attributes
+                .insert(Attribute {
+                    name: name.clone(),
+                    value,
+                })
+                .map_err(|_| self.err(CompileErrorType::AlreadyDefined(name.to_string())))?;
         }
 
         // fields
-        if self.m.command_defs.contains_key(&command.identifier.name) {
-            return Err(self.err(CompileErrorType::AlreadyDefined(
-                command.identifier.to_string(),
-            )));
-        }
+        let mut fields = NamedMap::new();
+
         let has_struct_refs = command
             .fields
             .iter()
             .any(|item| matches!(item, StructItem::StructRef(_)));
 
-        let mut map = BTreeMap::new();
         for si in &command.fields {
             match si {
                 StructItem::Field(f) => {
@@ -2425,7 +2420,12 @@ impl<'a> CompileState<'a> {
                     } else {
                         f.field_type.clone()
                     };
-                    map.insert(f.identifier.name.clone(), field_type);
+                    fields
+                        .insert(Field {
+                            name: f.identifier.clone(),
+                            ty: field_type,
+                        })
+                        .assume("duplicates are prevented by compile_struct")?;
                 }
                 StructItem::StructRef(ref_name) => {
                     let struct_def = self.m.struct_defs.get(&ref_name.name).ok_or_else(|| {
@@ -2437,14 +2437,30 @@ impl<'a> CompileState<'a> {
                             kind: fd.field_type.kind.clone(),
                             span: Span::default(),
                         };
-                        map.insert(fd.identifier.name.clone(), field_type);
+                        fields
+                            .insert(Field {
+                                name: fd.identifier.clone(),
+                                ty: field_type,
+                            })
+                            .assume("duplicates are prevented by compile_struct")?;
                     }
                 }
             }
         }
+
         self.m
             .command_defs
-            .insert(command.identifier.name.clone(), map);
+            .insert(CommandDef {
+                name: command.identifier.clone(),
+                persistence: command.persistence.clone(),
+                attributes,
+                fields,
+            })
+            .map_err(|_| {
+                self.err(CompileErrorType::AlreadyDefined(
+                    command.identifier.to_string(),
+                ))
+            })?;
 
         Ok(())
     }

--- a/crates/aranya-policy-compiler/src/compile/target.rs
+++ b/crates/aranya-policy-compiler/src/compile/target.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use aranya_policy_ast::{self as ast, Identifier};
-use aranya_policy_module::{CodeMap, Instruction, Label, Module, ModuleData, ModuleV0, Value};
+use aranya_policy_module::{
+    ActionDef, CodeMap, CommandDef, Instruction, Label, Module, ModuleData, ModuleV0, Value,
+    named::NamedMap,
+};
 use ast::FactDefinition;
 use indexmap::IndexMap;
 
@@ -19,9 +22,9 @@ pub struct CompileTarget {
     /// Mapping of Label names to addresses
     pub labels: BTreeMap<Label, usize>,
     /// Action definitions
-    pub action_defs: BTreeMap<Identifier, Vec<ast::FieldDefinition>>,
+    pub action_defs: NamedMap<ActionDef>,
     /// Command definitions (`fields`)
-    pub command_defs: BTreeMap<Identifier, BTreeMap<Identifier, ast::VType>>,
+    pub command_defs: NamedMap<CommandDef>,
     /// Effect identifiers. The effect definitions can be found in `struct_defs`.
     pub effects: BTreeSet<Identifier>,
     /// Fact schemas
@@ -30,8 +33,6 @@ pub struct CompileTarget {
     pub struct_defs: BTreeMap<Identifier, Vec<ast::FieldDefinition>>,
     /// Enum definitions
     pub enum_defs: BTreeMap<Identifier, IndexMap<Identifier, i64>>,
-    /// Command attributes
-    pub command_attributes: BTreeMap<Identifier, BTreeMap<Identifier, Value>>,
     /// Mapping between program instructions and original code
     pub codemap: Option<CodeMap>,
     /// Globally scoped variables
@@ -44,13 +45,12 @@ impl CompileTarget {
         CompileTarget {
             progmem: vec![],
             labels: BTreeMap::new(),
-            action_defs: BTreeMap::new(),
-            command_defs: BTreeMap::new(),
+            action_defs: NamedMap::new(),
+            command_defs: NamedMap::new(),
             effects: BTreeSet::new(),
             fact_defs: BTreeMap::new(),
             struct_defs: BTreeMap::new(),
             enum_defs: BTreeMap::new(),
-            command_attributes: BTreeMap::new(),
             codemap: Some(codemap),
             globals: BTreeMap::new(),
         }
@@ -74,7 +74,6 @@ impl CompileTarget {
                 fact_defs: self.fact_defs,
                 struct_defs: self.struct_defs,
                 enum_defs,
-                command_attributes: self.command_attributes,
                 codemap: self.codemap,
                 globals: self.globals,
             }),

--- a/crates/aranya-policy-compiler/src/tests.rs
+++ b/crates/aranya-policy-compiler/src/tests.rs
@@ -302,22 +302,23 @@ fn test_command_attributes() {
     let m = compile_pass(text);
     match m.data {
         ModuleData::V0(m) => {
-            let attrs = m
-                .command_attributes
+            let attrs = &m
+                .command_defs
                 .get("A")
-                .expect("should find command attribute map");
+                .expect("should find command attribute map")
+                .attributes;
             assert_eq!(attrs.len(), 3);
             assert_eq!(
-                attrs.get("i").expect("should find 1st value"),
-                &Value::Int(5)
+                attrs.get("i").expect("should find 1st value").value,
+                Value::Int(5)
             );
             assert_eq!(
-                attrs.get("s").expect("should find 2nd value"),
-                &Value::String(text!("abc"))
+                attrs.get("s").expect("should find 2nd value").value,
+                Value::String(text!("abc"))
             );
             assert_eq!(
-                attrs.get("priority").expect("should find 3nd value"),
-                &Value::Enum(ident!("Priority"), 1)
+                attrs.get("priority").expect("should find 3nd value").value,
+                Value::Enum(ident!("Priority"), 1)
             );
         }
     }
@@ -384,7 +385,7 @@ fn test_command_with_struct_field_insertion() -> anyhow::Result<()> {
     let module = Compiler::new(&policy).compile()?;
     let ModuleData::V0(module) = module.data;
 
-    let want = BTreeMap::from([
+    let want = [
         (
             ident!("a"),
             VType {
@@ -406,9 +407,14 @@ fn test_command_with_struct_field_insertion() -> anyhow::Result<()> {
                 span: ast::Span::empty(),
             },
         ),
-    ]);
+    ];
     let got = module.command_defs.get("Foo").unwrap();
-    assert_eq!(got, &want);
+    assert!(
+        got.fields
+            .iter()
+            .map(|f| (&f.name.name, &f.ty))
+            .eq(want.iter().map(|(k, v)| (k, v)))
+    );
 
     Ok(())
 }
@@ -2234,12 +2240,14 @@ fn test_struct_composition_global_let_and_command_attributes() {
 
     assert_eq!(*mod_data.globals.get("foo2").unwrap(), expected);
     assert_eq!(
-        *mod_data
-            .command_attributes
+        mod_data
+            .command_defs
             .get("Bar")
             .unwrap()
+            .attributes
             .get("foo_attr")
-            .unwrap(),
+            .unwrap()
+            .value,
         expected
     );
 }

--- a/crates/aranya-policy-ifgen-build/src/imp.rs
+++ b/crates/aranya-policy-ifgen-build/src/imp.rs
@@ -76,12 +76,12 @@ pub fn generate_code(target: &CompileTarget) -> String {
     };
 
     let actions = {
-        let sigs = target.action_defs.iter().map(|(id, args)| {
-            let ident = mk_ident(id);
-            let argnames = args.iter().map(|arg| mk_ident(&arg.identifier.name));
-            let argtypes = args.iter().map(|arg| vtype_to_rtype(&arg.field_type));
+        let sigs = target.action_defs.iter().map(|def| {
+            let ident = mk_ident(def.name.as_str());
+            let param_names = def.params.iter().map(|param| mk_ident(param.name.as_str()));
+            let param_types = def.params.iter().map(|param| vtype_to_rtype(&param.ty));
             quote! {
-                fn #ident(&mut self, #(#argnames: #argtypes),*) -> Result<(), ClientError>;
+                fn #ident(&mut self, #(#param_names: #param_types),*) -> Result<(), ClientError>;
             }
         });
         quote! {
@@ -178,9 +178,9 @@ fn collect_reachable_types(target: &CompileTarget) -> HashSet<&str> {
 
     let mut found = HashSet::new();
 
-    for args in target.action_defs.values() {
-        for arg in args {
-            visit(&struct_defs, &mut found, &arg.field_type);
+    for def in target.action_defs.iter() {
+        for param in def.params.iter() {
+            visit(&struct_defs, &mut found, &param.ty);
         }
     }
 

--- a/crates/aranya-policy-ifgen/tests/data/tictactoe.rs
+++ b/crates/aranya-policy-ifgen/tests/data/tictactoe.rs
@@ -54,6 +54,6 @@ pub struct GameUpdate {
 /// Implements all supported policy actions.
 #[actions]
 pub trait ActorExt {
-    fn MakeMove(&mut self, gameID: Id, x: i64, y: i64) -> Result<(), ClientError>;
     fn StartGame(&mut self, players: Players) -> Result<(), ClientError>;
+    fn MakeMove(&mut self, gameID: Id, x: i64, y: i64) -> Result<(), ClientError>;
 }

--- a/crates/aranya-policy-module/Cargo.toml
+++ b/crates/aranya-policy-module/Cargo.toml
@@ -12,6 +12,8 @@ rust-version.workspace = true
 aranya-crypto = { version = "0.9.0", path = "../aranya-crypto", default-features = false }
 aranya-policy-ast = { version = "0.7.0", path = "../aranya-policy-ast" }
 
+indexmap = { workspace = true, default-features = false, features = ["serde"] }
+fnv = { workspace = true, default-features = false }
 proptest = { workspace = true, default-features = false, features = ["std"], optional = true }
 proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, default-features = false, features = ["derive"] }

--- a/crates/aranya-policy-module/Cargo.toml
+++ b/crates/aranya-policy-module/Cargo.toml
@@ -12,8 +12,8 @@ rust-version.workspace = true
 aranya-crypto = { version = "0.9.0", path = "../aranya-crypto", default-features = false }
 aranya-policy-ast = { version = "0.7.0", path = "../aranya-policy-ast" }
 
-indexmap = { workspace = true, default-features = false, features = ["serde"] }
 fnv = { workspace = true, default-features = false }
+indexmap = { workspace = true, default-features = false, features = ["serde"] }
 proptest = { workspace = true, default-features = false, features = ["std"], optional = true }
 proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, default-features = false, features = ["derive"] }

--- a/crates/aranya-policy-module/src/lib.rs
+++ b/crates/aranya-policy-module/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ffi;
 mod instructions;
 mod label;
 mod module;
+pub mod named;
 
 pub use aranya_policy_ast as ast;
 pub use codemap::*;

--- a/crates/aranya-policy-module/src/module.rs
+++ b/crates/aranya-policy-module/src/module.rs
@@ -1,15 +1,16 @@
 //! Serializable [`Machine`][super::machine::Machine] state.
 
+#![expect(missing_docs, reason = "TODO(jdygert): add docs")]
+
 extern crate alloc;
 
 use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
 use core::fmt::{self, Display};
 
 use aranya_policy_ast::{self as ast, Identifier};
-use ast::FactDefinition;
 use serde::{Deserialize, Serialize};
 
-use crate::{CodeMap, Instruction, Label, Value};
+use crate::{CodeMap, Instruction, Label, Value, named, named::NamedMap};
 
 /// Identifies a [`Module`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -73,19 +74,55 @@ pub struct ModuleV0 {
     /// Labels
     pub labels: BTreeMap<Label, usize>,
     /// Action definitions
-    pub action_defs: BTreeMap<Identifier, Vec<ast::FieldDefinition>>,
+    pub action_defs: NamedMap<ActionDef>,
     /// Command definitions
-    pub command_defs: BTreeMap<Identifier, BTreeMap<Identifier, ast::VType>>,
+    pub command_defs: NamedMap<CommandDef>,
     /// Fact definitions
-    pub fact_defs: BTreeMap<Identifier, FactDefinition>,
+    pub fact_defs: BTreeMap<Identifier, ast::FactDefinition>,
     /// Struct definitions
     pub struct_defs: BTreeMap<Identifier, Vec<ast::FieldDefinition>>,
     /// Enum definitions
     pub enum_defs: BTreeMap<Identifier, BTreeMap<Identifier, i64>>,
-    /// Command attributes
-    pub command_attributes: BTreeMap<Identifier, BTreeMap<Identifier, Value>>,
     /// Code map
     pub codemap: Option<CodeMap>,
     /// Global static data
     pub globals: BTreeMap<Identifier, Value>,
 }
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ActionDef {
+    pub name: ast::Ident,
+    pub persistence: ast::Persistence,
+    pub params: NamedMap<Param>,
+}
+named!(ActionDef);
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Param {
+    pub name: ast::Ident,
+    pub ty: ast::VType,
+}
+named!(Param);
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CommandDef {
+    pub name: ast::Ident,
+    pub persistence: ast::Persistence,
+    pub attributes: NamedMap<Attribute>,
+    pub fields: NamedMap<Field>,
+}
+named!(CommandDef);
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Attribute {
+    pub name: ast::Ident,
+    pub value: Value,
+}
+named!(Attribute);
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Field {
+    pub name: ast::Ident,
+    pub ty: ast::VType,
+}
+named!(Field);

--- a/crates/aranya-policy-module/src/module.rs
+++ b/crates/aranya-policy-module/src/module.rs
@@ -1,7 +1,5 @@
 //! Serializable [`Machine`][super::machine::Machine] state.
 
-#![expect(missing_docs, reason = "TODO(jdygert): add docs")]
-
 extern crate alloc;
 
 use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
@@ -10,7 +8,10 @@ use core::fmt::{self, Display};
 use aranya_policy_ast::{self as ast, Identifier};
 use serde::{Deserialize, Serialize};
 
-use crate::{CodeMap, Instruction, Label, Value, named, named::NamedMap};
+use crate::{
+    CodeMap, Instruction, Label, Value,
+    named::{NamedMap, named},
+};
 
 /// Identifies a [`Module`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -89,40 +90,58 @@ pub struct ModuleV0 {
     pub globals: BTreeMap<Identifier, Value>,
 }
 
+/// An action definition.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ActionDef {
+    /// The name of the action.
     pub name: ast::Ident,
+    /// The persistence of the action.
     pub persistence: ast::Persistence,
+    /// The parameters of the action.
     pub params: NamedMap<Param>,
 }
 named!(ActionDef);
 
+/// An action or function parameter.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Param {
+    /// The name of the parameter.
     pub name: ast::Ident,
+    /// The type of the parameter.
     pub ty: ast::VType,
 }
 named!(Param);
 
+/// A command definition.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CommandDef {
+    /// The name of the command.
     pub name: ast::Ident,
+    /// The persistence of the command.
     pub persistence: ast::Persistence,
+    /// The attributes of the command.
     pub attributes: NamedMap<Attribute>,
+    /// The fields of the command.
     pub fields: NamedMap<Field>,
 }
 named!(CommandDef);
 
+/// A command attribute.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Attribute {
+    /// The name of the attribute.
     pub name: ast::Ident,
+    /// The value of the attribute.
     pub value: Value,
 }
 named!(Attribute);
 
+/// A struct or command field.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Field {
+    /// The name of the field
     pub name: ast::Ident,
+    /// The type of the field
     pub ty: ast::VType,
 }
 named!(Field);

--- a/crates/aranya-policy-module/src/named.rs
+++ b/crates/aranya-policy-module/src/named.rs
@@ -31,32 +31,32 @@ pub trait Named {
     deserialize = "V: serde::de::DeserializeOwned + Named"
 ))]
 pub struct NamedMap<V> {
-    map: indexmap::IndexSet<ByName<V>, fnv::FnvBuildHasher>,
+    set: indexmap::IndexSet<ByName<V>, fnv::FnvBuildHasher>,
 }
 
 impl<V> NamedMap<V> {
     /// Create an empty map.
     pub const fn new() -> Self {
         Self {
-            map: indexmap::IndexSet::with_hasher(core::hash::BuildHasherDefault::new()),
+            set: indexmap::IndexSet::with_hasher(core::hash::BuildHasherDefault::new()),
         }
     }
 
     /// Return the number of items in the map.
     pub fn len(&self) -> usize {
-        self.map.len()
+        self.set.len()
     }
 
     /// Returns true if the map is empty.
     pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
+        self.set.is_empty()
     }
 
     /// Returns an iterator over the items of the map.
     ///
     /// The items are guaranteed to be in insertion order.
     pub fn iter(&self) -> impl Iterator<Item = &V> {
-        self.map.iter().map(|x| &x.0)
+        self.set.iter().map(|x| &x.0)
     }
 }
 
@@ -70,7 +70,7 @@ impl<V: Named> NamedMap<V> {
     ///
     /// Returns an error if an entry with the same name already exists.
     pub fn insert(&mut self, val: V) -> Result<(), AlreadyExists> {
-        if self.map.insert(ByName(val)) {
+        if self.set.insert(ByName(val)) {
             Ok(())
         } else {
             Err(AlreadyExists)
@@ -79,12 +79,12 @@ impl<V: Named> NamedMap<V> {
 
     /// Look up an entry for the given name.
     pub fn get(&self, name: impl AsRef<str>) -> Option<&V> {
-        self.map.get(name.as_ref()).map(|x| &x.0)
+        self.set.get(name.as_ref()).map(|x| &x.0)
     }
 
     /// Returns true if the map contains an entry for the given name.
     pub fn contains(&self, name: impl AsRef<str>) -> bool {
-        self.map.contains(name.as_ref())
+        self.set.contains(name.as_ref())
     }
 }
 
@@ -98,9 +98,9 @@ impl<V: Named + PartialEq> PartialEq for NamedMap<V> {
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len()
             && self
-                .map
+                .set
                 .iter()
-                .all(|x| other.map.get(x.0.name().as_str()).is_some_and(|y| x == y))
+                .all(|x| other.set.get(x.0.name().as_str()).is_some_and(|y| x == y))
     }
 }
 impl<V: Named + Eq> Eq for NamedMap<V> {}

--- a/crates/aranya-policy-module/src/named.rs
+++ b/crates/aranya-policy-module/src/named.rs
@@ -1,0 +1,110 @@
+#![expect(missing_docs, reason = "TODO(jdygert): Document")]
+
+use aranya_policy_ast::Identifier;
+
+#[macro_export]
+macro_rules! named {
+    ($ty:ty) => {
+        impl $crate::named::Named for $ty {
+            fn name(&self) -> &Identifier {
+                &self.name
+            }
+        }
+    };
+}
+
+pub trait Named {
+    fn name(&self) -> &Identifier;
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+#[serde(bound(
+    serialize = "V: serde::Serialize + Named",
+    deserialize = "V: serde::de::DeserializeOwned + Named"
+))]
+pub struct NamedMap<V> {
+    map: indexmap::IndexSet<ByName<V>, fnv::FnvBuildHasher>,
+}
+
+impl<V> NamedMap<V> {
+    pub const fn new() -> Self {
+        Self {
+            map: indexmap::IndexSet::with_hasher(core::hash::BuildHasherDefault::new()),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &V> {
+        self.map.iter().map(|x| &x.0)
+    }
+}
+
+#[derive(Copy, Clone, Debug, thiserror::Error)]
+#[error("An entry with that name already exists")]
+pub struct AlreadyExists;
+
+impl<V: Named> NamedMap<V> {
+    pub fn insert(&mut self, val: V) -> Result<(), AlreadyExists> {
+        if self.map.insert(ByName(val)) {
+            Ok(())
+        } else {
+            Err(AlreadyExists)
+        }
+    }
+
+    pub fn get(&self, name: impl AsRef<str>) -> Option<&V> {
+        self.map.get(name.as_ref()).map(|x| &x.0)
+    }
+
+    pub fn contains(&self, name: impl AsRef<str>) -> bool {
+        self.map.contains(name.as_ref())
+    }
+}
+
+impl<V> Default for NamedMap<V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V: Named + PartialEq> PartialEq for NamedMap<V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len()
+            && self
+                .map
+                .iter()
+                .all(|x| other.map.get(x.0.name().as_str()).is_some_and(|y| x == y))
+    }
+}
+impl<V: Named + Eq> Eq for NamedMap<V> {}
+
+#[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+struct ByName<V>(V);
+
+impl<V: Named> PartialEq for ByName<V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.name() == other.0.name()
+    }
+}
+impl<V: Named> Eq for ByName<V> {}
+
+impl<V: Named> core::hash::Hash for ByName<V> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.0.name().hash(state);
+    }
+}
+
+impl<V: Named> core::borrow::Borrow<str> for ByName<V> {
+    fn borrow(&self) -> &str {
+        self.0.name().as_str()
+    }
+}

--- a/crates/aranya-policy-module/src/named.rs
+++ b/crates/aranya-policy-module/src/named.rs
@@ -97,10 +97,12 @@ impl<V> Default for NamedMap<V> {
 impl<V: Named + PartialEq> PartialEq for NamedMap<V> {
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len()
-            && self
-                .set
-                .iter()
-                .all(|x| other.set.get(x.0.name().as_str()).is_some_and(|y| x == y))
+            && self.set.iter().all(|x| {
+                other
+                    .set
+                    .get(x.0.name().as_str())
+                    .is_some_and(|y| V::eq(&x.0, &y.0))
+            })
     }
 }
 impl<V: Named + Eq> Eq for NamedMap<V> {}

--- a/crates/aranya-runtime/src/vm_policy.rs
+++ b/crates/aranya-runtime/src/vm_policy.rs
@@ -226,23 +226,25 @@ fn get_command_priorities(
     machine: &Machine,
 ) -> Result<BTreeMap<Identifier, VmPriority>, AttributeError> {
     let mut priority_map = BTreeMap::new();
-    for (name, attrs) in &machine.command_attributes {
+    for def in machine.command_defs.iter() {
+        let name = &def.name;
+        let attrs = &def.attributes;
         let finalize = attrs
             .get("finalize")
-            .map(|attr| match *attr {
+            .map(|attr| match attr.value {
                 Value::Bool(b) => Ok(b),
                 _ => Err(AttributeError::type_mismatch(
                     name.as_str(),
                     "finalize",
                     "Bool",
-                    &attr.type_name(),
+                    &attr.value.type_name(),
                 )),
             })
             .transpose()?
             == Some(true);
         let priority: Option<u32> = attrs
             .get("priority")
-            .map(|attr| match *attr {
+            .map(|attr| match attr.value {
                 Value::Int(b) => b.try_into().map_err(|_| {
                     AttributeError::int_range(
                         name.as_str(),
@@ -255,17 +257,17 @@ fn get_command_priorities(
                     name.as_str(),
                     "priority",
                     "Int",
-                    &attr.type_name(),
+                    &attr.value.type_name(),
                 )),
             })
             .transpose()?;
         match (finalize, priority) {
             (false, None) => {}
             (false, Some(p)) => {
-                priority_map.insert(name.clone(), VmPriority::Basic(p));
+                priority_map.insert(name.name.clone(), VmPriority::Basic(p));
             }
             (true, None) => {
-                priority_map.insert(name.clone(), VmPriority::Finalize);
+                priority_map.insert(name.name.clone(), VmPriority::Finalize);
             }
             (true, Some(_)) => {
                 return Err(AttributeError::exclusive(
@@ -481,7 +483,7 @@ impl From<VmPriority> for Priority {
 
 impl<E> VmPolicy<E> {
     fn get_command_priority(&self, name: &Identifier) -> VmPriority {
-        debug_assert!(self.machine.command_defs.contains_key(name));
+        debug_assert!(self.machine.command_defs.contains(name));
         self.priority_map.get(name).copied().unwrap_or_default()
     }
 }


### PR DESCRIPTION
Alternate approach to #360.

Since all of the maps in the module use identifier keys, I added a `NamedMap` type which is roughly `IndexSet<HashByName<T>>`.

I only added action and command defs for now since those are needed for #354 and #380.