### PR TITLE
policy-vm: clean up calling interface and check context

### DIFF
--- a/crates/aranya-policy-vm-explorer/src/main.rs
+++ b/crates/aranya-policy-vm-explorer/src/main.rs
@@ -260,23 +260,20 @@ fn main() -> anyhow::Result<()> {
     // which will return the commands or effects produced.
     match mode {
         Mode::Exec | Mode::Debug => {
-            let name;
             let mut rs;
             let ctx;
 
-            if let Some(action) = &args.action {
-                name = action.clone();
+            if let Some(action) = args.action {
                 ctx = CommandContext::Action(ActionContext {
-                    name: name.clone(),
+                    name: action.clone(),
                     head_id: CmdId::default(),
                 });
                 rs = machine.create_run_state(&io, ctx);
                 let call_args = args.args.into_iter().map(convert_arg_value);
-                rs.setup_action(action.clone(), call_args)?;
+                rs.setup_action(action, call_args)?;
             } else if let Some(command) = args.command {
-                name = command.clone();
                 ctx = CommandContext::Policy(PolicyContext {
-                    name: name.clone(),
+                    name: command.clone(),
                     id: CmdId::default(),
                     author: DeviceId::default(),
                     version: Id::default(),
@@ -293,11 +290,11 @@ fn main() -> anyhow::Result<()> {
                         )
                     })
                     .collect();
-                let self_data = Struct {
-                    name: command.clone(),
+                let this_data = Struct {
+                    name: command,
                     fields,
                 };
-                rs.setup_command(command.clone(), LabelType::CommandPolicy, &self_data)?;
+                rs.setup_command(LabelType::CommandPolicy, this_data)?;
             } else {
                 return Err(anyhow::anyhow!("Neither action nor command specified"));
             }

--- a/crates/aranya-policy-vm/src/error.rs
+++ b/crates/aranya-policy-vm/src/error.rs
@@ -88,6 +88,9 @@ pub enum MachineErrorType {
     /// FFI module was found, but the procedure index is invalid.
     #[error("FFI proc {0} not defined in module {1}")]
     FfiProcedureNotDefined(Identifier, usize),
+    /// Context mismatch
+    #[error("Attempted call with invalid context")]
+    ContextMismatch,
     /// An implementation bug
     #[error("bug: {0}")]
     Bug(Bug),

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -276,8 +276,7 @@ impl Machine {
     /// Call a command
     pub fn call_command_policy<M>(
         &mut self,
-        name: Identifier,
-        this_data: &Struct,
+        this_data: Struct,
         envelope: Struct,
         io: &'_ RefCell<M>,
         ctx: CommandContext,
@@ -286,7 +285,7 @@ impl Machine {
         M: MachineIO<MachineStack>,
     {
         let mut rs = self.create_run_state(io, ctx);
-        rs.call_command_policy(name, this_data, envelope)
+        rs.call_command_policy(this_data, envelope)
     }
 }
 
@@ -1076,10 +1075,11 @@ where
     /// Set up machine state for a command policy call
     pub fn setup_command(
         &mut self,
-        name: Identifier,
         label_type: LabelType,
-        this_data: &Struct,
+        this_data: Struct,
     ) -> Result<(), MachineError> {
+        let name = this_data.name.clone();
+
         #[cfg(feature = "bench")]
         self.stopwatch
             .start(format!("setup_command: {}", name).as_str());
@@ -1115,7 +1115,7 @@ where
             }
         }
         self.scope
-            .set(ident!("this"), Value::Struct(this_data.to_owned()))
+            .set(ident!("this"), Value::Struct(this_data))
             .map_err(|e| self.err(e))?;
 
         #[cfg(feature = "bench")]
@@ -1130,11 +1130,10 @@ where
     /// If the command check-exits, its recall block will be executed.
     pub fn call_command_policy(
         &mut self,
-        name: Identifier,
-        this_data: &Struct,
+        this_data: Struct,
         envelope: Struct,
     ) -> Result<ExitReason, MachineError> {
-        self.setup_command(name, LabelType::CommandPolicy, this_data)?;
+        self.setup_command(LabelType::CommandPolicy, this_data)?;
         self.ipush(envelope)?;
         self.run()
     }
@@ -1144,11 +1143,10 @@ where
     /// structs or a MachineError.
     pub fn call_command_recall(
         &mut self,
-        name: Identifier,
-        this_data: &Struct,
+        this_data: Struct,
         envelope: Struct,
     ) -> Result<ExitReason, MachineError> {
-        self.setup_command(name, LabelType::CommandRecall, this_data)?;
+        self.setup_command(LabelType::CommandRecall, this_data)?;
         self.ipush(envelope)?;
         self.run()
     }
@@ -1232,11 +1230,8 @@ where
     /// Call the seal block on this command to produce an envelope. The
     /// seal block is given an implicit parameter `this` and should
     /// return an opaque envelope struct on the stack.
-    pub fn call_seal(
-        &mut self,
-        name: Identifier,
-        this_data: Struct,
-    ) -> Result<ExitReason, MachineError> {
+    pub fn call_seal(&mut self, this_data: Struct) -> Result<ExitReason, MachineError> {
+        let name = this_data.name.clone();
         self.setup_function(&Label::new(name, LabelType::CommandSeal))?;
 
         // Seal/Open pushes the argument and defines it itself, because

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -297,14 +297,14 @@ fn test_command_policy() -> anyhow::Result<()> {
     let ctx = dummy_ctx_policy(name.clone());
     let io = RefCell::new(TestIO::new());
 
-    let self_data = Struct {
-        name: ident!("Bar"),
+    let this_data = Struct {
+        name,
         fields: vec![(ident!("a"), Value::Int(3)), (ident!("b"), Value::Int(4))]
             .into_iter()
             .collect(),
     };
     machine
-        .call_command_policy(name.clone(), &self_data, dummy_envelope(), &io, ctx)
+        .call_command_policy(this_data, dummy_envelope(), &io, ctx)
         .expect("Could not call command policy")
         .success();
 
@@ -328,18 +328,12 @@ fn test_command_invalid_this() {
     // invalid field count
     {
         let io = RefCell::new(TestIO::new());
-        let self_data = Struct {
-            name: ident!("Bar"),
+        let this_data = Struct {
+            name: name.clone(),
             fields: vec![(ident!("b"), Value::Int(4))].into_iter().collect(),
         };
         let err = machine
-            .call_command_policy(
-                name.clone(),
-                &self_data,
-                dummy_envelope(),
-                &io,
-                ctx.to_owned(),
-            )
+            .call_command_policy(this_data, dummy_envelope(), &io, ctx.to_owned())
             .unwrap_err()
             .err_type;
         assert_eq!(
@@ -353,20 +347,14 @@ fn test_command_invalid_this() {
     // invalid field name
     {
         let io = RefCell::new(TestIO::new());
-        let self_data = Struct {
-            name: ident!("Bar"),
+        let this_data = Struct {
+            name: name.clone(),
             fields: vec![(ident!("aaa"), Value::Int(3)), (ident!("b"), Value::Int(4))]
                 .into_iter()
                 .collect(),
         };
         let err = machine
-            .call_command_policy(
-                name.clone(),
-                &self_data,
-                dummy_envelope(),
-                &io,
-                ctx.to_owned(),
-            )
+            .call_command_policy(this_data, dummy_envelope(), &io, ctx.to_owned())
             .unwrap_err()
             .err_type;
         assert_eq!(err, MachineErrorType::InvalidStructMember(ident!("aaa")));
@@ -375,8 +363,8 @@ fn test_command_invalid_this() {
     // invalid type
     {
         let io = RefCell::new(TestIO::new());
-        let self_data = Struct {
-            name: ident!("Bar"),
+        let this_data = Struct {
+            name,
             fields: vec![
                 (ident!("a"), Value::Int(3)),
                 (ident!("b"), Value::Bool(false)),
@@ -385,7 +373,7 @@ fn test_command_invalid_this() {
             .collect(),
         };
         let err = machine
-            .call_command_policy(name.clone(), &self_data, dummy_envelope(), &io, ctx)
+            .call_command_policy(this_data, dummy_envelope(), &io, ctx)
             .unwrap_err()
             .err_type;
         assert_eq!(
@@ -414,7 +402,7 @@ fn test_fact_create_delete() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let self_struct = Struct::new(name.clone(), [(KVPair::new_int(ident!("a"), 3))]);
         machine
-            .call_command_policy(name.clone(), &self_struct, dummy_envelope(), &io, ctx)?
+            .call_command_policy(self_struct, dummy_envelope(), &io, ctx)?
             .success();
     }
 
@@ -427,7 +415,7 @@ fn test_fact_create_delete() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let self_struct = Struct::new(name.clone(), &[]);
         machine
-            .call_command_policy(name.clone(), &self_struct, dummy_envelope(), &io, ctx)?
+            .call_command_policy(self_struct, dummy_envelope(), &io, ctx)?
             .success();
     }
 
@@ -451,14 +439,14 @@ fn test_fact_query() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let self_struct = Struct::new(name.clone(), [KVPair::new_int(ident!("a"), 3)]);
         machine
-            .call_command_policy(name.clone(), &self_struct, dummy_envelope(), &io, ctx)?
+            .call_command_policy(self_struct, dummy_envelope(), &io, ctx)?
             .success();
 
         let name = ident!("Increment");
         let ctx = dummy_ctx_policy(name.clone());
         let self_struct = Struct::new(name.clone(), &[]);
         machine
-            .call_command_policy(name.clone(), &self_struct, dummy_envelope(), &io, ctx)?
+            .call_command_policy(self_struct, dummy_envelope(), &io, ctx)?
             .success();
     }
 
@@ -486,13 +474,13 @@ fn test_invalid_update() -> anyhow::Result<()> {
             let self_struct =
                 Struct::new(name.clone(), [KVPair::new_int(ident!("a"), initial_value)]);
             machine
-                .call_command_policy(name.clone(), &self_struct, dummy_envelope(), &io, ctx)?
+                .call_command_policy(self_struct, dummy_envelope(), &io, ctx)?
                 .success();
 
             let name = ident!("Increment");
             let ctx = dummy_ctx_policy(name.clone());
             let self_struct = Struct::new(name.clone(), &[]);
-            machine.call_command_policy(name.clone(), &self_struct, dummy_envelope(), &io, ctx)?
+            machine.call_command_policy(self_struct, dummy_envelope(), &io, ctx)?
         };
 
         let fk = (ident!("Foo"), vec![]);
@@ -565,7 +553,7 @@ fn test_fact_exists() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         let self_struct = Struct::new(name.clone(), &[]);
-        rs.call_command_policy(name.clone(), &self_struct, dummy_envelope())?
+        rs.call_command_policy(self_struct, dummy_envelope())?
             .success();
     }
 
@@ -661,7 +649,7 @@ fn test_counting() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         let self_struct = Struct::new(name.clone(), &[]);
-        rs.call_command_policy(name.clone(), &self_struct, dummy_envelope())?
+        rs.call_command_policy(self_struct, dummy_envelope())?
             .success();
     }
 
@@ -671,7 +659,7 @@ fn test_counting() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         let self_struct = Struct::new(name.clone(), &[]);
-        rs.call_command_policy(name.clone(), &self_struct, dummy_envelope())?
+        rs.call_command_policy(self_struct, dummy_envelope())?
             .success();
     }
 
@@ -681,7 +669,7 @@ fn test_counting() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         let self_struct = Struct::new(name.clone(), &[]);
-        rs.call_command_policy(name.clone(), &self_struct, dummy_envelope())?
+        rs.call_command_policy(self_struct, dummy_envelope())?
             .success();
     }
 
@@ -691,7 +679,7 @@ fn test_counting() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         let self_struct = Struct::new(name.clone(), &[]);
-        rs.call_command_policy(name.clone(), &self_struct, dummy_envelope())?
+        rs.call_command_policy(self_struct, dummy_envelope())?
             .success();
     }
 
@@ -701,7 +689,7 @@ fn test_counting() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         let self_struct = Struct::new(name.clone(), &[]);
-        rs.call_command_policy(name.clone(), &self_struct, dummy_envelope())?
+        rs.call_command_policy(self_struct, dummy_envelope())?
             .success();
     }
 
@@ -780,7 +768,7 @@ fn test_fact_function_return() -> anyhow::Result<()> {
                 KVPair::new(ident!("x"), Value::Int(2)),
             ],
         );
-        rs.call_command_policy(name.clone(), &self_struct, dummy_envelope())?
+        rs.call_command_policy(self_struct, dummy_envelope())?
             .success();
     }
 
@@ -790,7 +778,7 @@ fn test_fact_function_return() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(cmd_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         let self_struct = Struct::new(cmd_name.clone(), [KVPair::new(ident!("a"), a)]);
-        rs.call_command_policy(cmd_name.clone(), &self_struct, dummy_envelope())?
+        rs.call_command_policy(self_struct, dummy_envelope())?
             .success();
     }
 
@@ -874,7 +862,7 @@ fn test_query_partial_key() -> anyhow::Result<()> {
 
         let ctx = dummy_ctx_open(cmd_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
-        rs.call_command_policy(cmd_name.clone(), &this_data, dummy_envelope())?
+        rs.call_command_policy(this_data, dummy_envelope())?
             .success();
     }
 
@@ -935,7 +923,7 @@ fn test_query_enum_keys() -> anyhow::Result<()> {
 
         let ctx = dummy_ctx_open(cmd_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
-        rs.call_command_policy(cmd_name.clone(), &this_data, dummy_envelope())?
+        rs.call_command_policy(this_data, dummy_envelope())?
             .success();
     }
 
@@ -1483,7 +1471,7 @@ fn test_finish_function() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let self_struct = Struct::new(name.clone(), [KVPair::new(ident!("x"), Value::Int(3))]);
         machine
-            .call_command_policy(name.clone(), &self_struct, dummy_envelope(), &io, ctx)?
+            .call_command_policy(self_struct, dummy_envelope(), &io, ctx)?
             .success();
     }
 
@@ -1546,7 +1534,7 @@ fn test_serialize_deserialize() -> anyhow::Result<()> {
     let this_bytes: Vec<u8> = {
         let ctx = dummy_ctx_seal(name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
-        rs.call_seal(name.clone(), this_struct.clone())?.success();
+        rs.call_seal(this_struct.clone())?.success();
         let result = rs.consume_return()?;
         let mut envelope: Struct = result.try_into()?;
         let payload = envelope
@@ -1624,7 +1612,7 @@ fn test_check_unwrap() -> anyhow::Result<()> {
 
         let ctx = dummy_ctx_open(cmd_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
-        rs.call_command_policy(cmd_name.clone(), &this_data, dummy_envelope())?
+        rs.call_command_policy(this_data, dummy_envelope())?
             .success();
     }
 
@@ -1682,8 +1670,7 @@ fn test_envelope_in_policy_and_recall() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         rs.call_command_policy(
-            name.clone(),
-            &Struct::new(
+            Struct::new(
                 ident!("Foo"),
                 [KVPair::new(ident!("test"), test_data.clone().into())],
             ),
@@ -1700,8 +1687,7 @@ fn test_envelope_in_policy_and_recall() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         rs.call_command_recall(
-            name.clone(),
-            &Struct::new(
+            Struct::new(
                 ident!("Foo"),
                 [KVPair::new(ident!("test"), test_data.clone().into())],
             ),
@@ -2163,7 +2149,7 @@ fn test_map() -> anyhow::Result<()> {
         let ctx = dummy_ctx_policy(name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         let self_struct = Struct::new(name.clone(), &[]);
-        rs.call_command_policy(name.clone(), &self_struct, dummy_envelope())?
+        rs.call_command_policy(self_struct, dummy_envelope())?
             .success();
     }
     {
@@ -2274,12 +2260,8 @@ fn test_optional_type_validation() -> anyhow::Result<()> {
             let mut rs = machine.create_run_state(&io, ctx);
 
             assert_eq!(
-                rs.call_command_policy(
-                    name.clone(),
-                    &Struct::new(name.clone(), args),
-                    dummy_envelope()
-                )
-                .map_err(|e| e.err_type),
+                rs.call_command_policy(Struct::new(name.clone(), args), dummy_envelope())
+                    .map_err(|e| e.err_type),
                 expected
             );
         }

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -44,6 +44,15 @@ fn dummy_ctx_policy(name: Identifier) -> CommandContext {
     })
 }
 
+fn dummy_ctx_recall(name: Identifier) -> CommandContext {
+    CommandContext::Recall(PolicyContext {
+        name,
+        id: CmdId::default(),
+        author: DeviceId::default(),
+        version: Id::default(),
+    })
+}
+
 fn dummy_envelope() -> Struct {
     Struct {
         name: ident!("Envelope"),
@@ -264,7 +273,7 @@ fn test_action_call_action() -> anyhow::Result<()> {
     let mut published = Vec::new();
 
     let action_name = ident!("bar");
-    let ctx = dummy_ctx_policy(action_name.clone());
+    let ctx = dummy_ctx_action(action_name.clone());
     let mut rs = machine.create_run_state(&io, ctx);
     call_action(
         &mut rs,
@@ -860,7 +869,7 @@ fn test_query_partial_key() -> anyhow::Result<()> {
             fields: [].into(),
         };
 
-        let ctx = dummy_ctx_open(cmd_name.clone());
+        let ctx = dummy_ctx_policy(cmd_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         rs.call_command_policy(this_data, dummy_envelope())?
             .success();
@@ -868,7 +877,7 @@ fn test_query_partial_key() -> anyhow::Result<()> {
 
     {
         let action_name = ident!("test_query");
-        let ctx = dummy_ctx_open(action_name.clone());
+        let ctx = dummy_ctx_action(action_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         rs.call_action(action_name.clone(), iter::empty::<Value>())?
             .success();
@@ -876,7 +885,7 @@ fn test_query_partial_key() -> anyhow::Result<()> {
 
     {
         let action_name = ident!("test_exists");
-        let ctx = dummy_ctx_open(action_name.clone());
+        let ctx = dummy_ctx_action(action_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         rs.call_action(action_name.clone(), iter::empty::<Value>())?
             .success();
@@ -921,7 +930,7 @@ fn test_query_enum_keys() -> anyhow::Result<()> {
             fields: [].into(),
         };
 
-        let ctx = dummy_ctx_open(cmd_name.clone());
+        let ctx = dummy_ctx_policy(cmd_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         rs.call_command_policy(this_data, dummy_envelope())?
             .success();
@@ -929,7 +938,7 @@ fn test_query_enum_keys() -> anyhow::Result<()> {
 
     {
         let action_name = ident!("test_query");
-        let ctx = dummy_ctx_open(action_name.clone());
+        let ctx = dummy_ctx_action(action_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         rs.call_action(action_name.clone(), iter::empty::<Value>())?
             .success();
@@ -952,7 +961,7 @@ fn test_not_operator() -> anyhow::Result<()> {
     )?;
 
     let name = ident!("test");
-    let ctx = dummy_ctx_policy(name.clone());
+    let ctx = dummy_ctx_action(name.clone());
     let io = RefCell::new(TestIO::new());
     let module = Compiler::new(&policy).compile()?;
     let machine = Machine::from_module(module)?;
@@ -1610,7 +1619,7 @@ fn test_check_unwrap() -> anyhow::Result<()> {
             fields: [].into(),
         };
 
-        let ctx = dummy_ctx_open(cmd_name.clone());
+        let ctx = dummy_ctx_policy(cmd_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         rs.call_command_policy(this_data, dummy_envelope())?
             .success();
@@ -1618,7 +1627,7 @@ fn test_check_unwrap() -> anyhow::Result<()> {
 
     {
         let action_name = ident!("test_existing");
-        let ctx = dummy_ctx_open(action_name.clone());
+        let ctx = dummy_ctx_action(action_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         rs.call_action(action_name.clone(), iter::empty::<Value>())?
             .success();
@@ -1626,7 +1635,7 @@ fn test_check_unwrap() -> anyhow::Result<()> {
 
     {
         let action_name = ident!("test_nonexistent");
-        let ctx = dummy_ctx_open(action_name.clone());
+        let ctx = dummy_ctx_action(action_name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         let status = rs.call_action(action_name.clone(), iter::empty::<Value>())?;
         assert_eq!(status, ExitReason::Check);
@@ -1684,7 +1693,7 @@ fn test_envelope_in_policy_and_recall() -> anyhow::Result<()> {
 
     {
         let name = ident!("Foo");
-        let ctx = dummy_ctx_policy(name.clone());
+        let ctx = dummy_ctx_recall(name.clone());
         let mut rs = machine.create_run_state(&io, ctx);
         rs.call_command_recall(
             Struct::new(
@@ -1737,7 +1746,7 @@ fn test_debug_assert() -> anyhow::Result<()> {
         io: &RefCell<TestIO>,
         action_name: Identifier,
     ) -> Result<ExitReason, MachineError> {
-        let ctx = dummy_ctx_open(action_name.clone());
+        let ctx = dummy_ctx_action(action_name.clone());
         let mut rs = machine.create_run_state(io, ctx);
         rs.call_action(action_name.clone(), iter::empty::<Value>())
     }
@@ -1928,7 +1937,7 @@ fn test_enum_reference() -> anyhow::Result<()> {
     let io = RefCell::new(TestIO::new());
     let mut published = Vec::new();
     let name = ident!("test");
-    let ctx = dummy_ctx_policy(name.clone());
+    let ctx = dummy_ctx_action(name.clone());
     let mut rs = machine.create_run_state(&io, ctx);
     call_action(
         &mut rs,


### PR DESCRIPTION
Remove unnecessary `name` parameter which is in `this_data`, and check it against the name in the context.