### PR TITLE
afc: add serde impls to shm path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
+ "serde_test",
  "serial_test",
  "thiserror 2.0.7",
 ]
@@ -2764,6 +2765,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.177"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/crates/aranya-fast-channels/Cargo.toml
+++ b/crates/aranya-fast-channels/Cargo.toml
@@ -108,6 +108,7 @@ thiserror = { workspace = true }
 aranya-fast-channels = { path = ".", features = ["testing"] }
 
 criterion = { workspace = true }
+serde_test = { version = "1" }
 serial_test = { version = "3.1.1" }
 
 

--- a/crates/aranya-fast-channels/src/shm/path.rs
+++ b/crates/aranya-fast-channels/src/shm/path.rs
@@ -18,7 +18,7 @@ const fn bad_path(msg: &'static str) -> Result<(), InvalidPathError> {
 
 /// A borrowed shared memory path.
 ///
-/// It's like `&str`, but syntactically valid.
+/// It's like `&CStr`, but syntactically valid.
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct Path(CStr);

--- a/crates/aranya-fast-channels/src/shm/path.rs
+++ b/crates/aranya-fast-channels/src/shm/path.rs
@@ -211,11 +211,27 @@ mod alloc_impls {
         }
     }
 
+    impl TryFrom<&[u8]> for Box<Path> {
+        type Error = InvalidPathError;
+
+        fn try_from(path: &[u8]) -> Result<Self, Self::Error> {
+            <&Path>::try_from(path).map(Self::from)
+        }
+    }
+
     impl TryFrom<Vec<u8>> for Box<Path> {
         type Error = InvalidPathError;
 
         fn try_from(path: Vec<u8>) -> Result<Self, Self::Error> {
             path.into_boxed_slice().try_into()
+        }
+    }
+
+    impl TryFrom<&str> for Box<Path> {
+        type Error = InvalidPathError;
+
+        fn try_from(path: &str) -> Result<Self, Self::Error> {
+            <&Path>::try_from(path).map(Self::from)
         }
     }
 
@@ -232,6 +248,14 @@ mod alloc_impls {
 
         fn try_from(path: Box<str>) -> Result<Self, Self::Error> {
             path.into_boxed_bytes().try_into()
+        }
+    }
+
+    impl TryFrom<&CStr> for Box<Path> {
+        type Error = InvalidPathError;
+
+        fn try_from(path: &CStr) -> Result<Self, Self::Error> {
+            <&Path>::try_from(path).map(Self::from)
         }
     }
 

--- a/crates/aranya-fast-channels/src/shm/path.rs
+++ b/crates/aranya-fast-channels/src/shm/path.rs
@@ -1,6 +1,6 @@
 use core::{
     ffi::{CStr, c_char},
-    fmt, str,
+    fmt, ptr, str,
 };
 
 use cfg_if::cfg_if;
@@ -21,7 +21,7 @@ const fn bad_path(msg: &'static str) -> Result<(), InvalidPathError> {
 /// It's like `&str`, but syntactically valid.
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct Path([u8]);
+pub struct Path(CStr);
 
 impl Path {
     /// The maximum number of bytes allowed in a `Path`.
@@ -35,7 +35,8 @@ impl Path {
     /// - starts with "/"
     /// - has at most one "/"
     /// - has a trailing nul byte
-    pub fn validate(path: &[u8]) -> Result<(), InvalidPathError> {
+    pub fn validate(path: &CStr) -> Result<(), InvalidPathError> {
+        let path = path.to_bytes();
         if path.len() > Self::NAME_MAX {
             return bad_path("path too long");
         }
@@ -45,9 +46,6 @@ impl Path {
         if first != &b'/' {
             return bad_path("path missing leading '/'");
         }
-        if !rest.ends_with(b"\x00") {
-            return bad_path("path missing trailing null byte");
-        }
         if rest.contains(&b'/') {
             return bad_path("path has more than one '/'");
         }
@@ -56,19 +54,24 @@ impl Path {
 
     /// Create a [`Path`] from a C string.
     pub fn from_cstr(path: &CStr) -> Result<&Self, InvalidPathError> {
-        Self::from_bytes(path.to_bytes_with_nul())
+        Self::validate(path)?;
+        // SAFETY: Path and CStr have the same layout.
+        Ok(unsafe { &*(ptr::from_ref(path) as *const Self) })
     }
 
     /// Create a [`Path`] from bytes.
     pub fn from_bytes(path: &[u8]) -> Result<&Self, InvalidPathError> {
-        Self::validate(path)?;
+        let cstr = CStr::from_bytes_with_nul(path)
+            .map_err(|_| InvalidPathError("path is not nul terminated"))?;
+        Self::from_cstr(cstr)
+    }
 
-        // SAFETY: Path and [u8] must have the same layout.
-        Ok(unsafe { &*(path as *const [u8] as *const Self) })
+    pub(crate) fn as_cstr(&self) -> &CStr {
+        &self.0
     }
 
     pub(crate) fn as_ptr(&self) -> *const c_char {
-        self.0.as_ptr().cast::<_>()
+        self.0.as_ptr()
     }
 }
 
@@ -104,11 +107,34 @@ impl AsRef<Path> for Path {
 
 impl fmt::Display for Path {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Skip the null byte.
-        let data = self.0.strip_suffix(&[0]).unwrap_or(&self.0);
+        let data = self.as_cstr().to_bytes();
         match str::from_utf8(data) {
             Ok(s) => write!(f, "{s}"),
             Err(_) => write!(f, "invalid UTF-8: {:?}", &data),
+        }
+    }
+}
+
+impl PartialEq for Path {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+impl Eq for Path {}
+
+impl serde::Serialize for Path {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let data = self.as_cstr().to_bytes();
+        if serializer.is_human_readable() {
+            match str::from_utf8(data) {
+                Ok(s) => serializer.serialize_str(s),
+                Err(_) => serializer.serialize_bytes(data),
+            }
+        } else {
+            serializer.serialize_bytes(data)
         }
     }
 }
@@ -151,7 +177,7 @@ pub enum Mode {
 #[cfg(feature = "alloc")]
 mod alloc_impls {
     use alloc::{boxed::Box, ffi::CString, string::String, vec::Vec};
-    use core::ffi::CStr;
+    use core::{ffi::CStr, fmt};
 
     use super::{InvalidPathError, Path};
 
@@ -159,18 +185,22 @@ mod alloc_impls {
         type Error = InvalidPathError;
 
         fn try_from(path: Box<[u8]>) -> Result<Self, Self::Error> {
+            let path = CString::from_vec_with_nul(path.into_vec())
+                .map_err(|_| InvalidPathError("path is not nul terminated"))?
+                .into_boxed_c_str();
+
             Path::validate(&path)?;
 
-            // SAFETY: Path and [u8] must have the same layout.
+            // SAFETY: Path and CStr have the same layout.
             Ok(unsafe { Box::from_raw(Box::into_raw(path) as *mut Path) })
         }
     }
 
     impl From<&Path> for Box<Path> {
         fn from(path: &Path) -> Self {
-            let path = Box::<[u8]>::from(&path.0);
+            let path = Box::<CStr>::from(&path.0);
 
-            // SAFETY: Path and [u8] must have the same layout.
+            // SAFETY: Path and CStr have the same layout.
             unsafe { Box::from_raw(Box::into_raw(path) as *mut Path) }
         }
     }
@@ -221,21 +251,113 @@ mod alloc_impls {
         }
     }
 
+    impl<'de> serde::Deserialize<'de> for Box<Path> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            use serde::de;
+
+            struct Visitor;
+            impl de::Visitor<'_> for Visitor {
+                type Value = Box<Path>;
+                fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    write!(f, "a valid shared memory path")
+                }
+                fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                    self.visit_bytes(v.as_bytes())
+                }
+                fn visit_string<E: de::Error>(self, v: String) -> Result<Self::Value, E> {
+                    self.visit_byte_buf(v.into_bytes())
+                }
+                fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                    let mut bytes: Vec<u8> = Vec::with_capacity(v.len() + 1);
+                    bytes.extend_from_slice(v);
+                    bytes.push(0);
+                    bytes.try_into().map_err(E::custom)
+                }
+                fn visit_byte_buf<E: de::Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+                    let mut bytes = v;
+                    bytes.reserve_exact(1);
+                    bytes.push(0);
+                    bytes.try_into().map_err(E::custom)
+                }
+            }
+
+            if deserializer.is_human_readable() {
+                deserializer.deserialize_string(Visitor)
+            } else {
+                deserializer.deserialize_byte_buf(Visitor)
+            }
+        }
+    }
+
     #[cfg(test)]
     mod test {
         use super::*;
 
         #[test]
         fn test_boxing() {
-            let bytes = b"/asdf\0".as_slice();
+            let cstr = c"/asdf";
+            let bytes = cstr.to_bytes_with_nul();
             let path: Box<Path> = Path::from_bytes(bytes).unwrap().into();
-            assert_eq!(&path.as_ref().0, bytes);
+            assert_eq!(path.as_ref().0, *cstr);
 
             let path: Box<Path> = (Box::<[u8]>::from(bytes)).try_into().unwrap();
-            assert_eq!(&path.as_ref().0, bytes);
+            assert_eq!(path.as_ref().0, *cstr);
 
             let path: Box<Path> = path.clone();
-            assert_eq!(&path.as_ref().0, bytes);
+            assert_eq!(path.as_ref().0, *cstr);
         }
+
+        #[test]
+        fn test_boxed_path_serde_utf8() {
+            use serde_test::{Configure, Token, assert_de_tokens, assert_tokens};
+
+            let bytes = b"/asdf\0".as_slice();
+            let path: Box<Path> = Path::from_bytes(bytes).unwrap().into();
+
+            assert_tokens(&path.clone().readable(), &[Token::Str("/asdf")]);
+            assert_tokens(&path.clone().compact(), &[Token::Bytes(b"/asdf")]);
+
+            assert_de_tokens(&path.clone().readable(), &[Token::String("/asdf")]);
+            assert_de_tokens(&path.clone().compact(), &[Token::ByteBuf(b"/asdf")]);
+        }
+
+        #[test]
+        fn test_boxed_path_serde_non_utf8() {
+            use serde_test::{Configure, Token, assert_tokens};
+
+            let bytes = b"/\xFF\0".as_slice();
+            let path: Box<Path> = Path::from_bytes(bytes).unwrap().into();
+
+            assert_tokens(&path.clone().readable(), &[Token::Bytes(b"/\xFF")]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_path_ser_utf8() {
+        use serde_test::{Configure, Token, assert_ser_tokens};
+
+        let bytes = b"/asdf\0".as_slice();
+        let path: &Path = Path::from_bytes(bytes).unwrap();
+
+        assert_ser_tokens(&path.readable(), &[Token::Str("/asdf")]);
+        assert_ser_tokens(&path.compact(), &[Token::Bytes(b"/asdf")]);
+    }
+
+    #[test]
+    fn test_path_ser_non_utf8() {
+        use serde_test::{Configure, Token, assert_ser_tokens};
+
+        let bytes = b"/\xFF\0".as_slice();
+        let path: &Path = Path::from_bytes(bytes).unwrap();
+
+        assert_ser_tokens(&path.readable(), &[Token::Bytes(b"/\xFF")]);
     }
 }

--- a/crates/aranya-fast-channels/src/shm/path.rs
+++ b/crates/aranya-fast-channels/src/shm/path.rs
@@ -271,6 +271,10 @@ mod alloc_impls {
                     self.visit_byte_buf(v.into_bytes())
                 }
                 fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                    #[allow(
+                        clippy::arithmetic_side_effects,
+                        reason = "isize::MAX + 1 < usize::MAX"
+                    )]
                     let mut bytes: Vec<u8> = Vec::with_capacity(v.len() + 1);
                     bytes.extend_from_slice(v);
                     bytes.push(0);

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -46,6 +46,11 @@ who = "Jonathan Dygert <jdygert@spideroak.com>"
 criteria = "safe-to-run"
 delta = "3.0.5 -> 3.0.7"
 
+[[audits.serde_test]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-run"
+version = "1.0.177"
+
 [[audits.sha3-utils]]
 who = "Eric Lagergren <elagergren@spideroak.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Adds `Path: Serialize` and `Box<Path>: Serialize + Deserialize`.

I also changed the representation to `CStr`.