### PR TITLE
capi: add blanket Typed impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "ciborium-io",
  "const_format",
  "elain",
+ "fnv",
  "libc",
  "thiserror 2.0.7",
  "tracing",

--- a/crates/aranya-capi-codegen-test/src/defs.rs
+++ b/crates/aranya-capi-codegen-test/src/defs.rs
@@ -1,8 +1,4 @@
-use aranya_capi_core::{
-    InvalidArg,
-    prelude::*,
-    safe::{TypeId, Typed},
-};
+use aranya_capi_core::{InvalidArg, prelude::*};
 
 pub fn test_unit_unit0() {}
 #[allow(clippy::unused_unit)]
@@ -114,10 +110,6 @@ pub fn test_enum_result_enum_error(a: Enum) -> Result<Enum, crate::Error> {
 pub struct Struct {
     pub a: u32,
     // pub b: Enum,
-}
-
-impl Typed for Struct {
-    const TYPE_ID: TypeId = TypeId::new(1234);
 }
 
 pub fn test_struct_unit(_a: Struct) {}

--- a/crates/aranya-capi-codegen-test/src/generated.rs
+++ b/crates/aranya-capi-codegen-test/src/generated.rs
@@ -4,7 +4,7 @@ extern crate aranya_capi_core as __capi;
 use __capi::Builder;
 use __capi::internal::tracing;
 mod __imports {
-    pub(super) use aranya_capi_core::{InvalidArg, prelude::*, safe::{TypeId, Typed}};
+    pub(super) use aranya_capi_core::{InvalidArg, prelude::*};
 }
 #[derive(::core::marker::Copy)]
 #[derive(::core::clone::Clone)]

--- a/crates/aranya-capi-codegen-test/src/lib.rs
+++ b/crates/aranya-capi-codegen-test/src/lib.rs
@@ -9,11 +9,7 @@ mod generated {
 
 use std::{ffi::c_char, mem::MaybeUninit};
 
-use aranya_capi_core::{
-    ExtendedError, InvalidArg, WriteCStrError,
-    safe::{TypeId, Typed},
-    write_c_str,
-};
+use aranya_capi_core::{ExtendedError, InvalidArg, WriteCStrError, write_c_str};
 use buggy::Bug;
 use tracing::warn;
 
@@ -63,10 +59,6 @@ impl ExtError {
             write_c_str(msg, &"", len).map_err(Into::into)
         }
     }
-}
-
-impl Typed for ExtError {
-    const TYPE_ID: TypeId = TypeId::new(0xa2a040);
 }
 
 impl ExtendedError for ExtError {

--- a/crates/aranya-capi-core/Cargo.toml
+++ b/crates/aranya-capi-core/Cargo.toml
@@ -38,6 +38,7 @@ buggy = { version = "0.1.0", default-features = false }
 cfg-if = { workspace = true, default-features = false }
 const_format = { version = "0.2.31", default-features = false, features = ["assertcp"] }
 elain = "0.3"
+fnv = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, default-features = false }
 

--- a/crates/aranya-capi-core/src/internal/conv/ptr.rs
+++ b/crates/aranya-capi-core/src/internal/conv/ptr.rs
@@ -377,13 +377,10 @@ mod tests {
     use core::ptr;
 
     use super::*;
-    use crate::{error::InvalidArg, safe::TypeId};
+    use crate::error::InvalidArg;
 
     #[derive(Debug, Default, Eq, PartialEq)]
     struct Dummy(u32);
-    impl Typed for Dummy {
-        const TYPE_ID: TypeId = TypeId::new(0);
-    }
 
     /// Test specialization for [`try_as_ref`].
     #[test]

--- a/crates/aranya-capi-core/src/safe.rs
+++ b/crates/aranya-capi-core/src/safe.rs
@@ -97,7 +97,7 @@ impl<T: Typed> Safe<T> {
     pub fn init(out: &mut MaybeUninit<Self>, v: T) {
         let addr = out as *mut MaybeUninit<Self> as usize;
         out.write(Self {
-            id: T::TYPE_ID,
+            id: T::id(),
             flags: Flags::INIT,
             addr,
             inner: MaybeUninit::new(v),
@@ -107,7 +107,7 @@ impl<T: Typed> Safe<T> {
 
     /// Is the type ID correct?
     fn is_valid(&self) -> bool {
-        self.id == T::TYPE_ID
+        self.id == T::id()
     }
 
     /// Is the type initialized?
@@ -139,7 +139,7 @@ impl<T: Typed> Safe<T> {
         if !self.is_valid() {
             error!(
                 got = %self.id,
-                want = %T::TYPE_ID,
+                want = %T::id(),
                 name = self.name(),
                 "invalid type ID",
             );
@@ -169,7 +169,7 @@ impl<T: Typed> Safe<T> {
             if !self.is_valid() {
                 error!(
                     got = %self.id,
-                    want = %T::TYPE_ID,
+                    want = %T::id(),
                     name = self.name(),
                     "invalid type ID",
                 );
@@ -294,7 +294,7 @@ impl<T: Typed + Default> InitDefault for Safe<T> {
 impl<T: Typed> Drop for Safe<T> {
     fn drop(&mut self) {
         tracing::debug!(addr = self as *mut Safe<T> as usize, "dropping");
-        debug_assert_eq!(self.id, T::TYPE_ID);
+        debug_assert_eq!(self.id, T::id());
 
         if !self.is_valid() {
             // We shouldn't ever hit this code path. But `Drop`
@@ -354,14 +354,25 @@ impl<T: Typed + fmt::Debug> fmt::Debug for Safe<T> {
     }
 }
 
-impl<T: Typed> Typed for Safe<T> {
-    const TYPE_ID: TypeId = T::TYPE_ID;
-}
-
 /// Implemented by types that can be used with [`Safe`].
 pub trait Typed {
     /// Uniquely identifies the type.
-    const TYPE_ID: TypeId;
+    fn id() -> TypeId;
+}
+
+impl<T: core::any::Any> Typed for T {
+    fn id() -> TypeId {
+        let mut id = {
+            let mut hasher = fnv::FnvHasher::default();
+            core::any::TypeId::of::<T>().hash(&mut hasher);
+            hasher.finish() as u32
+        };
+        // This is very unlikely but it doesn't hurt to check.
+        if id == 0 {
+            id = !0;
+        };
+        TypeId(id)
+    }
 }
 
 /// Uniquely identifies types.
@@ -1060,9 +1071,6 @@ mod tests {
         const fn new(x: u32) -> Self {
             Self { _pad: x }
         }
-    }
-    impl Typed for Dummy {
-        const TYPE_ID: TypeId = TypeId::new(42);
     }
 
     /// Tests that we detect when a `Safe` is copied.

--- a/crates/aranya-capi-core/src/types/allowed.rs
+++ b/crates/aranya-capi-core/src/types/allowed.rs
@@ -212,16 +212,12 @@ mod tests {
     };
 
     use super::*;
-    use crate::safe::TypeId;
 
     #[test]
     fn test_assertions() {
         #[derive(Copy, Clone)]
         #[allow(dead_code)] // used in constant assertions
         struct Dummy;
-        impl Typed for Dummy {
-            const TYPE_ID: TypeId = TypeId::new(0);
-        }
         unsafe impl Input for Dummy {}
         unsafe impl ByConstPtr for Dummy {}
         unsafe impl ByMutPtr for Dummy {}

--- a/crates/aranya-capi-core/src/utf8.rs
+++ b/crates/aranya-capi-core/src/utf8.rs
@@ -1,7 +1,7 @@
 pub use core::str::Utf8Error;
 use core::{mem::MaybeUninit, ptr, slice, str};
 
-use crate::safe::{TypeId, Typed, Valid};
+use crate::safe::Valid;
 
 // TODO
 // unsafe impl AllowedAsConstPtr for Utf8Str {}
@@ -121,8 +121,4 @@ impl Default for Utf8Str {
         // SAFETY: The lifetime is `'static`.
         unsafe { Self::new("") }
     }
-}
-
-impl Typed for Utf8Str {
-    const TYPE_ID: TypeId = TypeId::new(0xfcf564a);
 }


### PR DESCRIPTION
We can hash the `core::any::TypeId` to get our type ID.

I verified that it optimizes down to a constant. It'd be nice to have some way to validate that remains true.

This ID won't necessarily be consistent across different compiles, but that should be fine in the way we are using it.

We now have a possibility of random collisions. It's not a huge issue since we are just using this for additional safety checks. We could increase the ID size easily, although it'd increase the size of `Safe` unless we shove the flags into either the ID or the address.

This blanket impl only applies for static types. All uses are currently static. I don't think it really makes much sense to use `Safe` with non-static types. Note we can't add manual impls since they would overlap.