### PR TITLE
afc: shm arena

### DIFF
--- a/crates/aranya-afc-util/src/testing.rs
+++ b/crates/aranya-afc-util/src/testing.rs
@@ -251,13 +251,9 @@ impl<T: TestImpl> Device<T> {
         let ciphertext = {
             let (sealer, chan_id) = sealer;
             let mut dst = vec![0u8; GOLDEN.len() + Client::<T::Afc>::OVERHEAD];
-            let mut ctx = sealer
-                .afc_client
-                .setup_seal_ctx(chan_id)
-                .expect("can set up ctx");
             sealer
                 .afc_client
-                .seal(&mut ctx, &mut dst[..], GOLDEN.as_bytes())
+                .seal(chan_id, &mut dst[..], GOLDEN.as_bytes())
                 .unwrap_or_else(|err| panic!("seal({chan_id}, ...): {err}"));
             dst
         };
@@ -279,13 +275,9 @@ impl<T: TestImpl> Device<T> {
     fn test_wrong_direction(sealer: &mut Self, channel_id: LocalChannelId) {
         const GOLDEN: &str = "hello, world!";
         let mut dst = vec![0u8; GOLDEN.len() + Client::<T::Afc>::OVERHEAD];
-        let mut ctx = sealer
-            .afc_client
-            .setup_seal_ctx(channel_id)
-            .expect("can set up ctx");
         let err = sealer
             .afc_client
-            .seal(&mut ctx, &mut dst[..], GOLDEN.as_bytes())
+            .seal(channel_id, &mut dst[..], GOLDEN.as_bytes())
             .expect_err("should have failed");
         assert_eq!(err, aranya_fast_channels::Error::NotFound(channel_id));
     }

--- a/crates/aranya-afc-util/src/testing.rs
+++ b/crates/aranya-afc-util/src/testing.rs
@@ -264,13 +264,9 @@ impl<T: TestImpl> Device<T> {
         let (plaintext, got_seq) = {
             let (opener, chan_id) = opener;
             let mut dst = vec![0u8; ciphertext.len() - Client::<T::Afc>::OVERHEAD];
-            let mut open_ctx = opener
-                .afc_client
-                .setup_open_ctx(chan_id)
-                .expect("can set up ctx");
             let (_, seq) = opener
                 .afc_client
-                .open(&mut open_ctx, &mut dst[..], &ciphertext[..])
+                .open(chan_id, &mut dst[..], &ciphertext[..])
                 .unwrap_or_else(|err| panic!("open({chan_id}, ...): {err}"));
             (dst, seq)
         };

--- a/crates/aranya-fast-channels/benches/lib.rs
+++ b/crates/aranya-fast-channels/benches/lib.rs
@@ -20,9 +20,9 @@ use aranya_crypto::{
     typenum::U16,
 };
 use aranya_fast_channels::{
-    AfcState as _, AranyaState as _, Client, Directed, LocalChannelId,
+    AranyaState as _, Client, Directed, LocalChannelId,
     crypto::Aes256Gcm,
-    shm::{self, Flag, Mode, Path, SealCtx},
+    shm::{self, Flag, Mode, Path},
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_main};
 
@@ -120,7 +120,7 @@ macro_rules! bench_impl {
 			let afc = shm::ReadState::open(path, Flag::OpenOnly, Mode::ReadWrite, MAX_CHANS)
 				.expect("should not fail");
 
-			let mut chans: [(SealCtx<CS<$aead, $kdf>>, LocalChannelId); USED_CHANS] = array::from_fn(|_| {
+			let chans: [(LocalChannelId, LocalChannelId); USED_CHANS] = array::from_fn(|_| {
 				let label = LabelId::random(Rng);
 
 				// Use the same key to simplify the decryption
@@ -139,10 +139,7 @@ macro_rules! bench_impl {
 					open
 				};
 
-                let seal_local_id = aranya.add(seal_key, label, DeviceId::random(Rng)).unwrap();
-                let open_local_id = aranya.add(open_key, label, DeviceId::random(Rng)).unwrap();
-                let seal_ctx = afc.setup_seal_ctx(seal_local_id).unwrap();
-				(seal_ctx, open_local_id)
+				(aranya.add(seal_key, label, DeviceId::random(Rng)).unwrap(), aranya.add(open_key, label, DeviceId::random(Rng)).unwrap())
 			});
 			let mut client = Client::<shm::ReadState<CS<$aead, $kdf>>>::new(afc);
 
@@ -158,15 +155,11 @@ macro_rules! bench_impl {
 
 				// The best case scenario: the peer's info is
 				// always cached.
-				let (seal_ctx, _) = chans.last_mut().unwrap();
-
-				client
-					.seal(seal_ctx, &mut ciphertext, &input)
-					.expect("seal_hit: unable to encrypt");
+				let (seal_channel_id, _) = *chans.last().unwrap();
 				g.bench_function(BenchmarkId::new("seal_hit", *size), |b| {
 					b.iter(|| {
 						black_box(client.seal(
-							black_box(seal_ctx),
+							black_box(seal_channel_id),
 							black_box(&mut ciphertext),
 							black_box(&input),
 						))
@@ -174,15 +167,14 @@ macro_rules! bench_impl {
 					})
 				});
 
-                // TODO(#482): seal_miss no longer misses since each channel gets
-                // its own cache. There are still misses when the list generation
-                // changes, so we should measure those.
-				let mut iter = chans.iter_mut();
+				// The worst case scenario: the peer's info is
+				// never cached.
+				let mut iter = chans.iter().cycle().copied();
 				g.bench_function(BenchmarkId::new("seal_miss", *size), |b| {
-                    let (seal_ctx, _) = iter.next().expect("not enough channels");
+					let (seal_channel_id, _) = iter.next().expect("should repeat");
 					b.iter(|| {
 						black_box(client.seal(
-							black_box(seal_ctx),
+							black_box(seal_channel_id),
 							black_box(&mut ciphertext),
 							black_box(&input),
 						))
@@ -192,15 +184,14 @@ macro_rules! bench_impl {
 
 				// The best case scenario: the peer's info is
 				// always cached.
-				let (seal_ctx, open_channel_id) = chans.last_mut().unwrap();
+				let (seal_channel_id, open_channel_id) = *chans.last().unwrap();
 				client
-					.seal(seal_ctx, &mut ciphertext, &input)
+					.seal(seal_channel_id, &mut ciphertext, &input)
 					.expect("open_hit: unable to encrypt");
-
 				g.bench_function(BenchmarkId::new("open_hit", *size), |b| {
 					b.iter(|| {
 						let _ = black_box(client.open(
-							black_box(*open_channel_id),
+							black_box(open_channel_id),
 							black_box(&mut plaintext),
 							black_box(&ciphertext),
 						))
@@ -215,7 +206,7 @@ macro_rules! bench_impl {
 					b.iter(|| {
 						// Ignore failures instead of creating
 						// N ciphertexts.
-						let (_seal_ctx, open_channel_id) = iter.next().expect("should repeat");
+						let (_seal_channel_id, open_channel_id) = iter.next().expect("should repeat");
 						let _ = client.open(
 							black_box(*open_channel_id),
 							black_box(&mut plaintext),

--- a/crates/aranya-fast-channels/benches/lib.rs
+++ b/crates/aranya-fast-channels/benches/lib.rs
@@ -20,9 +20,9 @@ use aranya_crypto::{
     typenum::U16,
 };
 use aranya_fast_channels::{
-    AfcState as _, AranyaState as _, Client, Directed,
+    AfcState as _, AranyaState as _, Client, Directed, LocalChannelId,
     crypto::Aes256Gcm,
-    shm::{self, Flag, Mode, OpenCtx, Path, SealCtx},
+    shm::{self, Flag, Mode, Path, SealCtx},
 };
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_main};
 
@@ -120,7 +120,7 @@ macro_rules! bench_impl {
 			let afc = shm::ReadState::open(path, Flag::OpenOnly, Mode::ReadWrite, MAX_CHANS)
 				.expect("should not fail");
 
-			let mut chans: [(SealCtx<CS<$aead, $kdf>>, OpenCtx<CS<$aead, $kdf>>); USED_CHANS] = array::from_fn(|_| {
+			let mut chans: [(SealCtx<CS<$aead, $kdf>>, LocalChannelId); USED_CHANS] = array::from_fn(|_| {
 				let label = LabelId::random(Rng);
 
 				// Use the same key to simplify the decryption
@@ -142,10 +142,9 @@ macro_rules! bench_impl {
                 let seal_local_id = aranya.add(seal_key, label, DeviceId::random(Rng)).unwrap();
                 let open_local_id = aranya.add(open_key, label, DeviceId::random(Rng)).unwrap();
                 let seal_ctx = afc.setup_seal_ctx(seal_local_id).unwrap();
-				let open_ctx = afc.setup_open_ctx(open_local_id).unwrap();
-				(seal_ctx, open_ctx)
+				(seal_ctx, open_local_id)
 			});
-			let client = Client::<shm::ReadState<CS<$aead, $kdf>>>::new(afc);
+			let mut client = Client::<shm::ReadState<CS<$aead, $kdf>>>::new(afc);
 
 			for size in SIZES {
 				let mut g = c.benchmark_group(stringify!($aead));
@@ -193,7 +192,7 @@ macro_rules! bench_impl {
 
 				// The best case scenario: the peer's info is
 				// always cached.
-				let (seal_ctx, open_ctx) = chans.last_mut().unwrap();
+				let (seal_ctx, open_channel_id) = chans.last_mut().unwrap();
 				client
 					.seal(seal_ctx, &mut ciphertext, &input)
 					.expect("open_hit: unable to encrypt");
@@ -201,7 +200,7 @@ macro_rules! bench_impl {
 				g.bench_function(BenchmarkId::new("open_hit", *size), |b| {
 					b.iter(|| {
 						let _ = black_box(client.open(
-							black_box(open_ctx),
+							black_box(*open_channel_id),
 							black_box(&mut plaintext),
 							black_box(&ciphertext),
 						))
@@ -209,17 +208,16 @@ macro_rules! bench_impl {
 					})
 				});
 
-				// TODO(#482): open_miss no longer misses since each channel gets
-                // its own cache. There are still misses when the list generation
-                // changes, so we should measure those.
-				let mut iter = chans.iter_mut();
+				// The worst case scenario: the peer's info is
+				// never cached.
+				let mut iter = chans.iter().cycle();
 				g.bench_function(BenchmarkId::new("open_miss", *size), |b| {
 					b.iter(|| {
 						// Ignore failures instead of creating
 						// N ciphertexts.
-						let (_seal_ctx, open_ctx) = iter.next().expect("not enough channels");
+						let (_seal_ctx, open_channel_id) = iter.next().expect("should repeat");
 						let _ = client.open(
-							black_box(open_ctx),
+							black_box(*open_channel_id),
 							black_box(&mut plaintext),
 							black_box(&ciphertext),
 						);

--- a/crates/aranya-fast-channels/benches/lib.rs
+++ b/crates/aranya-fast-channels/benches/lib.rs
@@ -104,8 +104,8 @@ macro_rules! bench_impl {
 	($name:ident, $aead:ty, $kdf:ty) => {
 		fn $name(c: &mut Criterion) {
 			// Make sure that `USED_CHANS` is a power of two.
-			const MAX_CHANS: usize = 1024;
-			const USED_CHANS: usize = MAX_CHANS / 2;
+			const MAX_CHANS: u32 = 1024;
+			const USED_CHANS: u32 = MAX_CHANS / 2;
 
 			let path = Path::from_bytes(b"/bench_afc\x00").expect("should not fail");
 			let _ = shm::unlink(path);
@@ -120,7 +120,7 @@ macro_rules! bench_impl {
 			let afc = shm::ReadState::open(path, Flag::OpenOnly, Mode::ReadWrite, MAX_CHANS)
 				.expect("should not fail");
 
-			let chans: [(LocalChannelId, LocalChannelId); USED_CHANS] = array::from_fn(|_| {
+			let chans: [(LocalChannelId, LocalChannelId); USED_CHANS as usize] = array::from_fn(|_| {
 				let label = LabelId::random(Rng);
 
 				// Use the same key to simplify the decryption

--- a/crates/aranya-fast-channels/src/arena.rs
+++ b/crates/aranya-fast-channels/src/arena.rs
@@ -1,0 +1,429 @@
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+use core::{
+    alloc::{Layout, LayoutError},
+    cell::UnsafeCell,
+    fmt::{self, Debug},
+    mem::MaybeUninit,
+    ops::{Deref, DerefMut},
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+use derive_where::derive_where;
+
+/// A single-writer many-reader shm-safe arena.
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct Arena<T>(ArenaInner<[Node<T>]>);
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Index {
+    pub index: u32,
+    pub generation: u32,
+}
+
+#[repr(C)]
+pub struct ArenaInner<S: ?Sized> {
+    // TODO: remove write lock?
+    write_lock: AtomicU32,
+    // free: UnsafeCell<u32>,
+    // live: UnsafeCell<u32>,
+    slots: S,
+}
+
+impl<S: Debug + ?Sized> Debug for ArenaInner<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ArenaInner")
+            .field("write_loc", &self.write_lock)
+            // .field("free", unsafe { &*self.free.get() })
+            // .field("live", unsafe { &*self.live.get() })
+            .field("slots", &&self.slots)
+            .finish()
+    }
+}
+
+#[repr(C)]
+struct Node<T> {
+    state: AtomicU32,
+    // protected by node state lock
+    data: UnsafeCell<Data<T>>,
+    // protected by arena write lock
+    // prev: UnsafeCell<u32>,
+}
+
+impl<T> Debug for Node<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Node")
+            .field("state", &self.state)
+            .field("data", unsafe { &*self.data.get() })
+            // .field("prev", unsafe { &*self.prev.get() })
+            .finish()
+    }
+}
+
+#[repr(C)]
+#[derive_where(Debug)]
+struct Data<T> {
+    generation: u32,
+    // next: u32,
+    item: MaybeUninit<T>,
+}
+
+const STATE_UNINIT: u32 = 0;
+const STATE_INIT_UNLOCKED: u32 = 1;
+const STATE_LOCKED: u32 = 2;
+
+#[derive(Debug)]
+pub enum Error {
+    WouldBlock,
+    OutOfSpace,
+    NotFound,
+    WrongGeneration,
+}
+
+impl<T> Arena<T> {
+    pub fn layout(len: u32) -> Result<Layout, LayoutError> {
+        if len == u32::MAX {
+            return Err(layout_error());
+        }
+        Ok(Layout::new::<ArenaInner<()>>()
+            .extend(Layout::array::<Node<T>>(len as usize)?)?
+            .0
+            .pad_to_align())
+    }
+
+    #[cfg(feature = "alloc")]
+    pub fn boxed(len: u32) -> Box<Self> {
+        let layout = Self::layout(len).expect("could not create layout for arena");
+        unsafe {
+            let ptr = alloc::alloc::alloc(layout);
+            let ptr = Self::init(ptr, len);
+            Box::from_raw(ptr)
+        }
+    }
+
+    /// Initialize an arena.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must "own" a region of `Self::layout(len)`.
+    pub unsafe fn init(ptr: *mut u8, len: u32) -> *mut Self {
+        unsafe {
+            let ptr = core::ptr::slice_from_raw_parts_mut(ptr, len as usize)
+                as *mut ArenaInner<[MaybeUninit<Node<T>>]>;
+            (*ptr).write_lock = AtomicU32::new(0);
+            // (*ptr).free = UnsafeCell::new(0);
+            // (*ptr).live = UnsafeCell::new(u32::MAX);
+            for (i, node) in (*ptr).slots.iter_mut().enumerate() {
+                let _i = i as u32;
+                node.write(Node {
+                    state: AtomicU32::new(STATE_UNINIT),
+                    data: UnsafeCell::new(Data {
+                        generation: 0,
+                        // next: i + 1 % len,
+                        item: MaybeUninit::uninit(),
+                    }),
+                    // prev: UnsafeCell::new(u32::MAX),
+                });
+            }
+            ptr as _
+        }
+    }
+
+    pub fn add(&self, item: T) -> Result<Index, Error> {
+        self.0
+            .write_lock
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Relaxed)
+            .map_err(|_| Error::WouldBlock)?;
+
+        // let index = unsafe { *self.0.free.get() };
+        // if index == u32::MAX {
+        //     self.0.write_lock.store(0, Ordering::Release);
+        //     return Err(Error::OutOfSpace);
+        // }
+        let index = self
+            .0
+            .slots
+            .iter()
+            .position(|slot| slot.state.load(Ordering::Acquire) == STATE_UNINIT)
+            .ok_or(Error::OutOfSpace)? as u32;
+
+        let slot = &self.0.slots[index as usize];
+        debug_assert_eq!(slot.state.load(Ordering::Acquire), STATE_UNINIT);
+        let data = unsafe { &mut *slot.data.get() };
+        data.item.write(item);
+        let generation = data.generation;
+
+        // unsafe {
+        //     (*self.0.free.get()) = data.next;
+        //     data.next = *self.0.live.get();
+        //     (*self.0.live.get()) = index;
+        //     if data.next != u32::MAX {
+        //         let next_node = &self.0.slots[data.next as usize];
+        //         *next_node.prev.get() = index;
+        //     }
+        //     let prev = *slot.prev.get();
+        //     if prev != u32::MAX {
+        //         let prev_node = &self.0.slots[prev as usize];
+        //         (*prev_node.data.get()).next = index;
+        //     }
+        // }
+
+        slot.state.store(STATE_INIT_UNLOCKED, Ordering::Release);
+
+        self.0.write_lock.store(0, Ordering::Release);
+
+        Ok(Index { index, generation })
+    }
+
+    pub fn get(&self, idx: Index) -> Option<NodeGuard<'_, T>> {
+        let node = self.0.slots.get(idx.index as usize)?;
+        node.state
+            .compare_exchange(
+                STATE_INIT_UNLOCKED,
+                STATE_LOCKED,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            )
+            .ok()?;
+        if unsafe { (*node.data.get()).generation } != idx.generation {
+            node.state.store(STATE_INIT_UNLOCKED, Ordering::Release);
+            return None;
+        }
+        Some(NodeGuard { node })
+    }
+
+    pub fn remove(&self, idx: Index) -> Result<(), Error> {
+        let node = self
+            .0
+            .slots
+            .get(idx.index as usize)
+            .ok_or(Error::NotFound)?;
+        self.0
+            .write_lock
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Relaxed)
+            .map_err(|_| Error::WouldBlock)?;
+        node.state
+            .compare_exchange(
+                STATE_INIT_UNLOCKED,
+                STATE_UNINIT,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            )
+            .map_err(|_| {
+                self.0.write_lock.store(0, Ordering::Release);
+                Error::WouldBlock
+            })?;
+        let data = unsafe { &mut *node.data.get() };
+        // TODO: load generation before locking?
+        if data.generation != idx.generation {
+            self.0.write_lock.store(0, Ordering::Release);
+            node.state.store(STATE_INIT_UNLOCKED, Ordering::Release);
+            return Err(Error::WrongGeneration);
+        }
+        unsafe {
+            data.item.assume_init_drop();
+        }
+        data.generation += 1;
+
+        // unsafe {
+        //     *node.prev.get() = u32::MAX;
+        // }
+
+        // {
+        //     // TODO: is one of these unnecessary?
+        //     let prev = unsafe { *node.prev.get() };
+        //     if prev != u32::MAX {
+        //         let prev_node = &self.0.slots[prev as usize];
+        //         // TODO: Is this safe?
+        //         unsafe {
+        //             (*prev_node.data.get()).next = data.next;
+        //         }
+        //     }
+        //     let next = data.next;
+        //     if next != u32::MAX {
+        //         let next_node = &self.0.slots[next as usize];
+        //         // TODO: Is this safe?
+        //         unsafe {
+        //             (*next_node.prev.get()) = *node.prev.get();
+        //         }
+        //     }
+        // }
+
+        // let free = unsafe { &mut *self.0.free.get() };
+        // data.next = *free;
+        // *free = idx.index;
+
+        self.0.write_lock.store(0, Ordering::Release);
+
+        Ok(())
+    }
+
+    pub fn clear(&self) -> Result<(), Error> {
+        self.retain(|_, _| false)
+    }
+
+    pub fn retain(&self, mut keep: impl FnMut(Index, &T) -> bool) -> Result<(), Error> {
+        self.0
+            .write_lock
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Relaxed)
+            .map_err(|_| Error::WouldBlock)?;
+        for (i, slot) in self.0.slots.iter().enumerate() {
+            if slot.state.load(Ordering::Acquire) == STATE_UNINIT {
+                continue;
+            }
+            let data = unsafe { &mut *slot.data.get() };
+            if !keep(
+                Index {
+                    index: i as u32,
+                    generation: data.generation,
+                },
+                unsafe { data.item.assume_init_ref() },
+            ) {
+                while {
+                    slot.state
+                        .compare_exchange(
+                            STATE_INIT_UNLOCKED,
+                            STATE_UNINIT,
+                            Ordering::AcqRel,
+                            Ordering::Relaxed,
+                        )
+                        .is_err()
+                } {
+                    core::hint::spin_loop();
+                }
+                unsafe {
+                    data.item.assume_init_drop();
+                }
+                data.generation += 1;
+            }
+        }
+
+        // let free = unsafe { &mut *self.0.free.get() };
+        // let mut prev = unsafe { &mut *self.0.live.get() };
+        // let mut current = *prev;
+        // while current != u32::MAX {
+        //     let slot = &self.0.slots[current as usize];
+        //     debug_assert_ne!(
+        //         slot.state.load(Ordering::Acquire),
+        //         STATE_UNINIT,
+        //         "{current} {:#?}",
+        //         &self.0.slots
+        //     );
+        //     let data = unsafe { &mut *slot.data.get() };
+        //     let next = data.next;
+        //     if !keep(
+        //         Index {
+        //             index: current,
+        //             generation: data.generation,
+        //         },
+        //         unsafe { data.item.assume_init_ref() },
+        //     ) {
+        //         while {
+        //             slot.state
+        //                 .compare_exchange(
+        //                     STATE_INIT_UNLOCKED,
+        //                     STATE_UNINIT,
+        //                     Ordering::AcqRel,
+        //                     Ordering::Relaxed,
+        //                 )
+        //                 .is_err()
+        //         } {
+        //             core::hint::spin_loop();
+        //         }
+        //         unsafe {
+        //             data.item.assume_init_drop();
+        //         }
+        //         unsafe {
+        //             *slot.prev.get() = u32::MAX;
+        //         }
+        //         data.generation += 1;
+        //         data.next = *free;
+        //         *prev = next;
+        //         *free = current;
+        //     }
+        //     prev = &mut data.next;
+        //     current = next;
+        // }
+        self.0.write_lock.store(0, Ordering::Release);
+        Ok(())
+    }
+
+    pub fn from_parts(ptr: *const u8, len: u32) -> *const Self {
+        core::ptr::slice_from_raw_parts(ptr, len as usize) as *const Self
+    }
+}
+
+impl<T> Drop for Arena<T> {
+    fn drop(&mut self) {
+        self.clear().ok();
+    }
+}
+
+// Invariant: node has initialized and locked state.
+pub struct NodeGuard<'a, T> {
+    node: &'a Node<T>,
+}
+
+impl<T> Deref for NodeGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { (*self.node.data.get()).item.assume_init_ref() }
+    }
+}
+
+impl<T> DerefMut for NodeGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { (*self.node.data.get()).item.assume_init_mut() }
+    }
+}
+
+impl<T> Drop for NodeGuard<'_, T> {
+    fn drop(&mut self) {
+        self.node
+            .state
+            .store(STATE_INIT_UNLOCKED, Ordering::Release);
+    }
+}
+
+const fn layout_error() -> LayoutError {
+    match Layout::from_size_align(usize::MAX, 1) {
+        Err(err) => err,
+        _ => core::unreachable!(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_simple() {
+        let arena = Arena::<String>::boxed(10);
+        let i0 = arena.add(String::from("first")).unwrap();
+        let i1 = arena.add(String::from("second")).unwrap();
+        let i2 = arena.add(String::from("third")).unwrap();
+        assert_eq!(arena.get(i0).unwrap().as_str(), "first");
+        assert_eq!(arena.get(i1).unwrap().as_str(), "second");
+        assert_eq!(arena.get(i2).unwrap().as_str(), "third");
+        // dbg!(&arena);
+        assert!(
+            arena
+                .get(Index {
+                    index: 3,
+                    generation: 0
+                })
+                .is_none()
+        );
+        arena.remove(i1).unwrap();
+        dbg!(&arena);
+        assert!(arena.get(i1).is_none());
+        let i4 = arena.add(String::from("fourth")).unwrap();
+        dbg!(&arena);
+        assert_eq!(i4.index, 1);
+        assert_eq!(i4.generation, 1);
+        arena.clear().unwrap();
+        arena.clear().unwrap();
+    }
+}

--- a/crates/aranya-fast-channels/src/client.rs
+++ b/crates/aranya-fast-channels/src/client.rs
@@ -63,18 +63,13 @@ impl<S: AfcState> Client<S> {
         self.state.setup_seal_ctx(id)
     }
 
-    /// Set up the open context for the given channel.
-    pub fn setup_open_ctx(&self, id: LocalChannelId) -> Result<S::OpenCtx, Error> {
-        self.state.setup_open_ctx(id)
-    }
-
     /// Encrypts and authenticates `plaintext` for a channel.
     ///
     /// The resulting ciphertext is written to `dst`, which must
     /// be at least `plaintext.len() + Client::OVERHEAD` bytes
     /// long.
     pub fn seal(
-        &self,
+        &mut self,
         ctx: &mut S::SealCtx,
         dst: &mut [u8],
         plaintext: &[u8],
@@ -112,7 +107,7 @@ impl<S: AfcState> Client<S> {
     ///
     /// The resulting ciphertext is written in-place to `data`.
     pub fn seal_in_place<T: Buf>(
-        &self,
+        &mut self,
         ctx: &mut S::SealCtx,
         data: &mut T,
     ) -> Result<Header, Error> {
@@ -152,7 +147,7 @@ impl<S: AfcState> Client<S> {
     /// Initializes `header` and invokes `f` with the key for
     /// `id`.
     fn do_seal<F>(
-        &self,
+        &mut self,
         ctx: &mut S::SealCtx,
         header: &mut [u8; DataHeader::PACKED_SIZE],
         f: F,
@@ -192,7 +187,7 @@ impl<S: AfcState> Client<S> {
     /// sequence number associated with the ciphertext.
     pub fn open(
         &self,
-        ctx: &mut S::OpenCtx,
+        local_channel_id: LocalChannelId,
         dst: &mut [u8],
         ciphertext: &[u8],
     ) -> Result<(LabelId, Seq), Error> {
@@ -209,7 +204,7 @@ impl<S: AfcState> Client<S> {
             (seq, ciphertext)
         };
         debug!(
-            "seq={seq} ciphertext=[{:?}; {}]",
+            "seq={seq} ciphertext=[{:?}; {}] local_channel_id={local_channel_id}",
             ciphertext.as_ptr(),
             ciphertext.len()
         );
@@ -226,7 +221,7 @@ impl<S: AfcState> Client<S> {
         }
 
         let label_id = self
-            .do_open(ctx, seq, |aead, ad, seq| {
+            .do_open(local_channel_id, seq, |aead, ad, seq| {
                 aead.open(dst, ciphertext, ad, seq)?;
                 Ok(ad.label_id)
             })
@@ -252,7 +247,7 @@ impl<S: AfcState> Client<S> {
     /// sequence number associated with the ciphertext.
     pub fn open_in_place<T: Buf>(
         &self,
-        ctx: &mut S::OpenCtx,
+        local_channel_id: LocalChannelId,
         data: &mut T,
     ) -> Result<(LabelId, Seq), Error> {
         // NB: For performance reasons, `data` is arranged
@@ -275,11 +270,15 @@ impl<S: AfcState> Client<S> {
                 .ok_or(Error::Authentication)?;
             (seq, ciphertext, tag)
         };
-        debug!("data=[{:?}; {}]", out.as_ptr(), out.len());
+        debug!(
+            "local_channel_id={local_channel_id} data=[{:?}; {}]",
+            out.as_ptr(),
+            out.len()
+        );
 
         let plaintext_len = out.len();
         let label_id = self
-            .do_open(ctx, seq, |aead, ad, seq| {
+            .do_open(local_channel_id, seq, |aead, ad, seq| {
                 aead.open_in_place(out, tag, ad, seq)?;
                 Ok(ad.label_id)
             })
@@ -297,7 +296,7 @@ impl<S: AfcState> Client<S> {
     }
 
     /// Invokes `f` with the key for `id`.
-    fn do_open<F, T>(&self, ctx: &mut S::OpenCtx, seq: Seq, f: F) -> Result<T, Error>
+    fn do_open<F, T>(&self, id: LocalChannelId, seq: Seq, f: F) -> Result<T, Error>
     where
         F: FnOnce(
             /* aead: */ &OpenKey<S::CipherSuite>,
@@ -305,7 +304,9 @@ impl<S: AfcState> Client<S> {
             /* seq: */ Seq,
         ) -> Result<T, Error>,
     {
-        self.state.open(ctx, |aead, label_id| {
+        debug!("decrypting: id={id}");
+
+        self.state.open(id, |aead, label_id| {
             let ad = AuthData {
                 // TODO(eric): update `AuthData` to use `u16`.
                 version: u32::from(Version::current().to_u16()),

--- a/crates/aranya-fast-channels/src/lib.rs
+++ b/crates/aranya-fast-channels/src/lib.rs
@@ -24,13 +24,6 @@
 //! [`AranyaState`]. By default, AFC provides a state
 //! implementation backed by shared memory.
 //!
-//! # Notes
-//!
-//! AFC encrypts/seals each message with a deterministic nonce derived from a
-//! base nonce and sequence number. Sequence numbers should not be re-used in a given channel
-//! but it is possible to do so by passing a "new" [`AfcState::SealCtx`] to the seal methods
-//! on [`Client`].
-//!
 //! # Example
 //!
 //! The following example demonstrates two [`Client`]s encrypting
@@ -144,10 +137,7 @@
 //!     // Encryption has a little overhead, so make sure the
 //!     // ouput buffer is large enough.
 //!     let mut dst = vec![0u8; GOLDEN.len() + Client::<ReadState<CS>>::OVERHEAD];
-//!
-//!     // Create the ctx to pass in.
-//!     let mut ctx = afc_client_a.setup_seal_ctx(client_a_channel_id)?;
-//!     afc_client_a.seal(&mut ctx, &mut dst[..], GOLDEN.as_bytes())?;
+//!     afc_client_a.seal(client_a_channel_id, &mut dst[..], GOLDEN.as_bytes())?;
 //!     dst
 //! };
 //!

--- a/crates/aranya-fast-channels/src/lib.rs
+++ b/crates/aranya-fast-channels/src/lib.rs
@@ -182,13 +182,13 @@
 #![warn(
     clippy::alloc_instead_of_core,
     clippy::implicit_saturating_sub,
-    clippy::undocumented_unsafe_blocks,
-    clippy::expect_used,
-    clippy::indexing_slicing,
-    clippy::missing_panics_doc,
+    // clippy::undocumented_unsafe_blocks,
+    // clippy::expect_used,
+    // clippy::indexing_slicing,
+    // clippy::missing_panics_doc,
     clippy::string_slice,
     clippy::unimplemented,
-    missing_docs
+    // missing_docs
 )]
 #![cfg_attr(not(any(feature = "std", test)), deny(clippy::std_instead_of_core))]
 #![expect(
@@ -202,6 +202,7 @@ extern crate alloc;
 #[macro_use]
 mod features;
 
+pub mod arena;
 mod buf;
 mod client;
 pub mod crypto;

--- a/crates/aranya-fast-channels/src/lib.rs
+++ b/crates/aranya-fast-channels/src/lib.rs
@@ -157,9 +157,8 @@
 //! // Have device2 decrypt the data from device1.
 //! let (label_from_open, seq, plaintext) = {
 //!     let mut dst = vec![0u8; ciphertext.len() - Client::<ReadState<CS>>::OVERHEAD];
-//!     // Create the ctx to pass in.
-//!     let mut ctx = afc_client_b.setup_open_ctx(client_b_channel_id)?;
-//!     let (label_id, seq) = afc_client_b.open(&mut ctx, &mut dst[..], &ciphertext[..])?;
+//!     let (label_id, seq) =
+//!         afc_client_b.open(client_b_channel_id, &mut dst[..], &ciphertext[..])?;
 //!     (label_id, seq, dst)
 //! };
 //!

--- a/crates/aranya-fast-channels/src/memory.rs
+++ b/crates/aranya-fast-channels/src/memory.rs
@@ -188,7 +188,7 @@ mod tests {
         fn new_states<CS: CipherSuite>(
             _name: &str,
             _id: DeviceIdx,
-            _max_chans: usize,
+            _max_chans: u32,
         ) -> States<Self::Afc<CS>, Self::Aranya<CS>> {
             let afc = State::<CS>::new();
             let aranya = afc.clone();

--- a/crates/aranya-fast-channels/src/memory.rs
+++ b/crates/aranya-fast-channels/src/memory.rs
@@ -56,17 +56,10 @@ where
 {
     type CipherSuite = CS;
 
-    type SealCtx = LocalChannelId;
-
-    fn setup_seal_ctx(&self, id: LocalChannelId) -> Result<Self::SealCtx, Error> {
-        Ok(id)
-    }
-
-    fn seal<F, T>(&self, ctx: &mut Self::SealCtx, f: F) -> Result<Result<T, Error>, Error>
+    fn seal<F, T>(&self, id: LocalChannelId, f: F) -> Result<Result<T, Error>, Error>
     where
         F: FnOnce(&mut SealKey<Self::CipherSuite>, LabelId) -> Result<T, Error>,
     {
-        let id = *ctx;
         let mut inner = self.inner.lock().assume("poisoned")?;
         let ChanMapValue { keys, label_id, .. } =
             inner.chans.get_mut(&id).ok_or(Error::NotFound(id))?;

--- a/crates/aranya-fast-channels/src/memory.rs
+++ b/crates/aranya-fast-channels/src/memory.rs
@@ -58,13 +58,7 @@ where
 
     type SealCtx = LocalChannelId;
 
-    type OpenCtx = LocalChannelId;
-
     fn setup_seal_ctx(&self, id: LocalChannelId) -> Result<Self::SealCtx, Error> {
-        Ok(id)
-    }
-
-    fn setup_open_ctx(&self, id: LocalChannelId) -> Result<Self::OpenCtx, Error> {
         Ok(id)
     }
 
@@ -81,14 +75,14 @@ where
         Ok(f(key, *label_id))
     }
 
-    fn open<F, T>(&self, ctx: &mut Self::OpenCtx, f: F) -> Result<Result<T, Error>, Error>
+    fn open<F, T>(&self, id: LocalChannelId, f: F) -> Result<Result<T, Error>, Error>
     where
         F: FnOnce(&OpenKey<Self::CipherSuite>, LabelId) -> Result<T, Error>,
     {
         let inner = self.inner.lock().assume("poisoned")?;
         let ChanMapValue { keys, label_id, .. } =
-            inner.chans.get(ctx).ok_or(Error::NotFound(*ctx))?;
-        let key = keys.open().ok_or(Error::NotFound(*ctx))?;
+            inner.chans.get(&id).ok_or(Error::NotFound(id))?;
+        let key = keys.open().ok_or(Error::NotFound(id))?;
 
         Ok(f(key, *label_id))
     }

--- a/crates/aranya-fast-channels/src/shm/align.rs
+++ b/crates/aranya-fast-channels/src/shm/align.rs
@@ -1,5 +1,5 @@
 use core::{
-    alloc::{Layout, LayoutError},
+    alloc::Layout,
     mem::{align_of, size_of},
     ops::Deref,
     ptr::NonNull,
@@ -97,19 +97,4 @@ impl<T> Aligned<T> {
     pub fn as_ptr(&self) -> *mut T {
         self.ptr.as_ptr()
     }
-}
-
-const fn layout_error() -> LayoutError {
-    match Layout::from_size_align(usize::MAX, 1) {
-        Err(err) => err,
-        _ => core::unreachable!(),
-    }
-}
-
-// See https://doc.rust-lang.org/core/alloc/struct.Layout.html#method.repeat
-pub(super) fn layout_repeat(layout: Layout, n: usize) -> Result<Layout, LayoutError> {
-    let padded_size = layout.pad_to_align().size();
-    let alloc_size = padded_size.checked_mul(n).ok_or(layout_error())?;
-
-    Layout::from_size_align(alloc_size, layout.align())
 }

--- a/crates/aranya-fast-channels/src/shm/error.rs
+++ b/crates/aranya-fast-channels/src/shm/error.rs
@@ -103,10 +103,10 @@ pub(super) const fn bad_state_version(got: U32, want: U32) -> Corrupted {
     }
 }
 
-pub(super) const fn bad_state_size(got: U64, want: U64) -> Corrupted {
+pub(super) const fn bad_state_size(got: U64, want: u64) -> Corrupted {
     Corrupted::SharedMemSize {
         got: got.into(),
-        want: want.into(),
+        want,
     }
 }
 

--- a/crates/aranya-fast-channels/src/shm/posix.rs
+++ b/crates/aranya-fast-channels/src/shm/posix.rs
@@ -71,11 +71,6 @@ pub(super) struct Mapping<T> {
 // can safely make it Send.
 unsafe impl<T: Send> Send for Mapping<T> {}
 
-// SAFETY: `Mapping` is !Sync by default because it contains raw
-// pointers. But since it does not have any thread affinity, we
-// can safely make it Sync.
-unsafe impl<T: Sync> Sync for Mapping<T> {}
-
 impl<T> Drop for Mapping<T> {
     fn drop(&mut self) {
         // SAFETY: FFI call, no invariants.

--- a/crates/aranya-fast-channels/src/shm/read.rs
+++ b/crates/aranya-fast-channels/src/shm/read.rs
@@ -1,53 +1,17 @@
-use core::{
-    cell::Cell,
-    fmt::Debug,
-    marker::PhantomData,
-    ops::{Deref, DerefMut},
-    sync::atomic::Ordering,
-};
+use core::fmt::Debug;
 
 use aranya_crypto::{
     CipherSuite,
     afc::{OpenKey, SealKey},
     policy::LabelId,
 };
-use buggy::BugExt as _;
-use derive_where::derive_where;
 
 use super::{
     error::Error,
     path::{Flag, Mode, Path},
-    shared::{Index, KeyId, Op, State},
+    shared::State,
 };
-use crate::{
-    mutex::StdMutex,
-    state::{AfcState, LocalChannelId},
-    util::debug,
-};
-
-/// The key used for the recent successful invocation of `seal`
-/// or `open`.
-#[derive(Clone)]
-#[derive_where(Debug)]
-struct Cache<K> {
-    /// The channel the key is for.
-    id: LocalChannelId,
-    /// The label ID associated with the channel.
-    label_id: LabelId,
-    #[derive_where(skip)]
-    /// The cached key.
-    key: K,
-    /// The `ChanList`'s generation when this key was cached.
-    ///
-    /// Used to quickly determine whether the cache is stale.
-    generation: u32,
-    /// Index of the channel in the `ChanList`.
-    ///
-    /// Used as a hint when retrieving the updated channel
-    /// information after the `ChanList`'s generation has
-    /// changed.
-    idx: Index,
-}
+use crate::state::{AfcState, LocalChannelId};
 
 /// The reader's view of the shared memory state.
 #[derive(Debug)]
@@ -57,15 +21,6 @@ where
 {
     // `pub(super)` for testing.
     pub(super) inner: State<CS>,
-
-    // APS is typically used to seal/open many messages with the
-    // same peer, so cache the most recent successful invocations
-    // of seal/open.
-    last_seal: StdMutex<Option<Cache<CachedSealKey<CS>>>>,
-    last_open: StdMutex<Option<Cache<OpenKey<CS>>>>,
-
-    /// Make `State` `!Sync` pending issues/95.
-    _no_sync: PhantomData<Cell<()>>,
 }
 
 impl<CS> ReadState<CS>
@@ -73,15 +28,12 @@ where
     CS: CipherSuite,
 {
     /// Open the state at `path`.
-    pub fn open<P>(path: P, flag: Flag, mode: Mode, max_chans: usize) -> Result<Self, Error>
+    pub fn open<P>(path: P, flag: Flag, mode: Mode, max_chans: u32) -> Result<Self, Error>
     where
         P: AsRef<Path>,
     {
         Ok(Self {
             inner: State::open(path, flag, mode, max_chans)?,
-            last_seal: StdMutex::new(None),
-            last_open: StdMutex::new(None),
-            _no_sync: PhantomData,
         })
     }
 }
@@ -96,89 +48,19 @@ where
     where
         F: FnOnce(&mut SealKey<Self::CipherSuite>, LabelId) -> Result<T, crate::Error>,
     {
-        let mutex = self.inner.load_read_list()?;
+        let mut chan = self
+            .inner
+            .shm()
+            .arena()?
+            .get(id.into())
+            .ok_or(crate::Error::NotFound(id))?;
 
-        // Check to see if the current `SealKey` for this channel
-        // is cached.
-        let mut cache = self.last_seal.lock().assume("poisoned")?;
-        let hint = match cache.as_mut().filter(|c| c.id == id) {
-            // There is a cache entry for this channel.
-            Some(c) => {
-                // SAFETY: we only access an atomic field.
-                let generation = unsafe {
-                    mutex
-                        .inner_unsynchronized()
-                        .generation
-                        .load(Ordering::Acquire)
-                };
-                if c.generation == generation {
-                    // Same generation, so we can use the key.
-                    debug!(
-                        "cache hit: id={id} generation={generation} seq={}",
-                        c.key.seq()
-                    );
-
-                    return Ok(f(&mut c.key, c.label_id));
-                }
-                // The generations are different, so
-                // optimistically use `idx` to try and speed up
-                // the list traversal.
-                Some(c.idx)
-            }
-            _ => None,
-        };
-
-        // We don't have a cached key, so we need to traverse the
-        // list.
-        let mut list = mutex.lock().assume("poisoned")?;
-
-        // The list is currently locked (precluding writes to
-        // `list.generation`), so we don't *need* atomics here. But we
-        // might as well since relaxed is ~free.
-        //
-        // NB: we load the generation before traversing the list
-        // to avoid ownership conflicts with `chan`.
-        let generation = list.generation.load(Ordering::Relaxed);
-
-        let (chan, idx) = match list.find_mut(id, hint, Op::Seal)? {
-            None => return Err(crate::Error::NotFound(id)),
-            Some((chan, idx)) => (chan, idx),
-        };
-
-        let mut key = SealKey::from_raw(&chan.seal_key, chan.seq())?;
-
-        debug!("chan = {chan:p}/{chan:?}");
-
-        let label_id = chan.label_id;
+        let label_id = chan.label_id()?;
+        let mut key = chan.seal_key()?;
 
         let result = f(&mut key, label_id);
         if likely!(result.is_ok()) {
-            // Encryption was successful (it usually is), so
-            // update the cache.
-            let new = Cache {
-                id,
-                label_id,
-                key: CachedSealKey {
-                    key,
-                    id: chan.key_id,
-                },
-                generation,
-                idx,
-            };
-            if let Some(old) = cache.replace(new) {
-                // We've evicted an existing entry, so try to
-                // write back the updated sequence number.
-                if let Some((chan, _)) = list.find_mut(old.id, Some(old.idx), Op::Seal)? {
-                    debug!(
-                        "updating seq: chan = {chan:p}/{chan:?} old={} new={}",
-                        chan.seq(),
-                        old.key.seq()
-                    );
-                    if chan.key_id == old.key.id {
-                        chan.set_seq(old.key.seq());
-                    }
-                }
-            }
+            chan.set_seq(key.seq());
         }
         Ok(result)
     }
@@ -187,87 +69,20 @@ where
     where
         F: FnOnce(&OpenKey<CS>, LabelId) -> Result<T, crate::Error>,
     {
-        let mutex = self.inner.load_read_list()?;
+        let chan = self
+            .inner
+            .shm()
+            .arena()?
+            .get(id.into())
+            .ok_or(crate::Error::NotFound(id))?;
 
-        // Check to see if the current `OpenKey` for this channel
-        // is cached.
-        let mut cache = self.last_open.lock().assume("poisoned")?;
-        let hint = match cache.as_mut().filter(|c| c.id == id) {
-            // There is a cache entry for this channel.
-            Some(c) => {
-                // SAFETY: we only access an atomic field.
-                let generation = unsafe {
-                    mutex
-                        .inner_unsynchronized()
-                        .generation
-                        .load(Ordering::Acquire)
-                };
-                if c.generation == generation {
-                    // Same generation, so we can use the key.
-                    // so we can use it.
-                    debug!("cache hit: id={id} generation={generation}");
+        let label_id = chan.label_id()?;
+        let key = chan.open_key()?;
 
-                    return Ok(f(&c.key, c.label_id));
-                }
-                // The generations are different, so
-                // optimistically use `idx` to try and speed up
-                // the list traversal.
-                Some(c.idx)
-            }
-            _ => None,
-        };
-
-        // We don't have a cached key, so we need to traverse the
-        // list.
-        let list = mutex.lock().assume("poisoned")?;
-
-        let (chan, idx) = match list.find(id, hint, Op::Open)? {
-            None => return Err(crate::Error::NotFound(id)),
-            Some((chan, idx)) => (chan, idx),
-        };
-
-        let key = OpenKey::from_raw(&chan.open_key)?;
-        let label_id = chan.label_id;
-
-        let result = f(&key, label_id);
-        if result.is_ok() {
-            // Decryption was successful, so update the cache.
-            *cache = Some(Cache {
-                id,
-                label_id,
-                key,
-                // The list is currently locked (precluding
-                // writes to `list.generation`), so we don't *need*
-                // atomics here. But we might as well since
-                // relaxed is ~free.
-                generation: list.generation.load(Ordering::Relaxed),
-                idx,
-            });
-        }
-        Ok(result)
+        Ok(f(&key, label_id))
     }
 
     fn exists(&self, id: LocalChannelId) -> Result<bool, crate::Error> {
-        let mutex = self.inner.load_read_list()?;
-        let list = mutex.lock().assume("poisoned")?;
-        Ok(list.exists(id, None, Op::Any)?)
-    }
-}
-
-struct CachedSealKey<CS: CipherSuite> {
-    key: SealKey<CS>,
-    id: KeyId,
-}
-
-impl<CS: CipherSuite> Deref for CachedSealKey<CS> {
-    type Target = SealKey<CS>;
-    fn deref(&self) -> &Self::Target {
-        &self.key
-    }
-}
-
-impl<CS: CipherSuite> DerefMut for CachedSealKey<CS> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.key
+        Ok(self.inner.shm().arena()?.get(id.into()).is_some())
     }
 }

--- a/crates/aranya-fast-channels/src/shm/read.rs
+++ b/crates/aranya-fast-channels/src/shm/read.rs
@@ -1,4 +1,4 @@
-use core::{fmt::Debug, sync::atomic::Ordering};
+use core::{cell::Cell, fmt::Debug, marker::PhantomData, sync::atomic::Ordering};
 
 use aranya_crypto::{
     CipherSuite,
@@ -14,6 +14,7 @@ use super::{
     shared::{Index, Op, State},
 };
 use crate::{
+    mutex::StdMutex,
     state::{AfcState, LocalChannelId},
     util::debug,
 };
@@ -50,6 +51,14 @@ where
 {
     // `pub(super)` for testing.
     pub(super) inner: State<CS>,
+
+    // APS is typically used to seal/open many messages with the
+    // same peer, so cache the most recent successful invocations
+    // of seal/open.
+    last_open: StdMutex<Option<Cache<OpenKey<CS>>>>,
+
+    /// Make `State` `!Sync` pending issues/95.
+    _no_sync: PhantomData<Cell<()>>,
 }
 
 impl<CS> ReadState<CS>
@@ -63,15 +72,14 @@ where
     {
         Ok(Self {
             inner: State::open(path, flag, mode, max_chans)?,
+            last_open: StdMutex::new(None),
+            _no_sync: PhantomData,
         })
     }
 }
 
 /// Sealing channel context.
 pub struct SealCtx<CS: CipherSuite>(Option<Cache<SealKey<CS>>>);
-
-/// Opening channel context.
-pub struct OpenCtx<CS: CipherSuite>(Option<Cache<OpenKey<CS>>>);
 
 impl<CS> AfcState for ReadState<CS>
 where
@@ -80,8 +88,6 @@ where
     type CipherSuite = CS;
 
     type SealCtx = SealCtx<CS>;
-
-    type OpenCtx = OpenCtx<CS>;
 
     fn setup_seal_ctx(&self, id: LocalChannelId) -> Result<Self::SealCtx, crate::Error> {
         let mutex = self.inner.load_read_list()?;
@@ -98,29 +104,6 @@ where
 
         let key = SealKey::from_raw(&chan.seal_key, Seq::ZERO)?;
         Ok(SealCtx(Some(Cache {
-            id,
-            label_id: chan.label_id,
-            key,
-            generation,
-            idx,
-        })))
-    }
-
-    fn setup_open_ctx(&self, id: LocalChannelId) -> Result<Self::OpenCtx, crate::Error> {
-        let mutex = self.inner.load_read_list()?;
-        let mut list = mutex.lock().assume("poisoned")?;
-
-        let generation = list.generation.load(Ordering::Relaxed);
-
-        let (chan, idx) = match list.find_mut(id, None, Op::Open)? {
-            None => {
-                return Err(crate::Error::NotFound(id));
-            }
-            Some((chan, idx)) => (chan, idx),
-        };
-
-        let key = OpenKey::from_raw(&chan.open_key)?;
-        Ok(OpenCtx(Some(Cache {
             id,
             label_id: chan.label_id,
             key,
@@ -203,38 +186,38 @@ where
         Ok(result)
     }
 
-    fn open<F, T>(
-        &self,
-        ctx: &mut Self::OpenCtx,
-        f: F,
-    ) -> Result<Result<T, crate::Error>, crate::Error>
+    fn open<F, T>(&self, id: LocalChannelId, f: F) -> Result<Result<T, crate::Error>, crate::Error>
     where
         F: FnOnce(&OpenKey<CS>, LabelId) -> Result<T, crate::Error>,
     {
-        let cache = ctx.0.as_mut().ok_or(crate::Error::KeyExpired)?;
-
-        let id = cache.id;
-
         let mutex = self.inner.load_read_list()?;
 
-        let hint = {
-            // SAFETY: we only access an atomic field.
-            let generation = unsafe {
-                mutex
-                    .inner_unsynchronized()
-                    .generation
-                    .load(Ordering::Acquire)
-            };
-            if cache.generation == generation {
-                // Same generation, so we can use the key.
-                debug!("cache hit: id={id} generation={generation}");
+        // Check to see if the current `OpenKey` for this channel
+        // is cached.
+        let mut cache = self.last_open.lock().assume("poisoned")?;
+        let hint = match cache.as_mut().filter(|c| c.id == id) {
+            // There is a cache entry for this channel.
+            Some(c) => {
+                // SAFETY: we only access an atomic field.
+                let generation = unsafe {
+                    mutex
+                        .inner_unsynchronized()
+                        .generation
+                        .load(Ordering::Acquire)
+                };
+                if c.generation == generation {
+                    // Same generation, so we can use the key.
+                    // so we can use it.
+                    debug!("cache hit: id={id} generation={generation}");
 
-                return Ok(f(&cache.key, cache.label_id));
+                    return Ok(f(&c.key, c.label_id));
+                }
+                // The generations are different, so
+                // optimistically use `idx` to try and speed up
+                // the list traversal.
+                Some(c.idx)
             }
-            // The generations are different, so
-            // optimistically use `idx` to try and speed up
-            // the list traversal.
-            Some(cache.idx)
+            _ => None,
         };
 
         // We don't have a cached key, so we need to traverse the
@@ -252,9 +235,17 @@ where
         let result = f(&key, label_id);
         if result.is_ok() {
             // Decryption was successful, so update the cache.
-            cache.idx = idx;
-            cache.generation = list.generation.load(Ordering::Relaxed);
-            cache.key = key;
+            *cache = Some(Cache {
+                id,
+                label_id,
+                key,
+                // The list is currently locked (precluding
+                // writes to `list.generation`), so we don't *need*
+                // atomics here. But we might as well since
+                // relaxed is ~free.
+                generation: list.generation.load(Ordering::Relaxed),
+                idx,
+            });
         }
         Ok(result)
     }

--- a/crates/aranya-fast-channels/src/shm/sdlib.rs
+++ b/crates/aranya-fast-channels/src/shm/sdlib.rs
@@ -100,11 +100,6 @@ pub(super) struct Mapping<T> {
 // can safely make it Send.
 unsafe impl<T: Send> Send for Mapping<T> {}
 
-// SAFETY: `Mapping` is !Sync by default because it contains raw
-// pointers.  But since it does not have any thread affinity, we
-// can safely make it Sync.
-unsafe impl<T: Sync> Sync for Mapping<T> {}
-
 impl<T> Drop for Mapping<T> {
     fn drop(&mut self) {
         let _ = unmap(self.id);

--- a/crates/aranya-fast-channels/src/shm/shared.rs
+++ b/crates/aranya-fast-channels/src/shm/shared.rs
@@ -9,7 +9,7 @@ use core::{
 
 use aranya_crypto::{
     CipherSuite, Csprng, DeviceId, Random,
-    afc::{RawOpenKey, RawSealKey},
+    afc::{RawOpenKey, RawSealKey, Seq},
     dangerous::spideroak_crypto::{aead::Aead, hash::tuple_hash},
     policy::LabelId,
 };
@@ -356,6 +356,8 @@ pub(super) struct ShmChan<CS: CipherSuite> {
     pub direction: U32,
     /// The channel's ID.
     pub local_channel_id: U64,
+    /// The current encryption sequence counter.
+    pub seq: U64,
     /// The channel's label.
     pub label_id: LabelId,
     /// The ID of the peer.
@@ -413,6 +415,13 @@ impl<CS: CipherSuite> ShmChan<CS> {
             magic: Self::MAGIC,
             direction: ChanDirection::from_directed(keys).to_u32().into(),
             local_channel_id: id.to_u64().into(),
+            // For the same reason that we randomize keys,
+            // manually exhaust the sequence number.
+            seq: if keys.seal().is_some() {
+                U64::new(0)
+            } else {
+                U64::MAX
+            },
             label_id,
             peer_id,
             seal_key,
@@ -468,6 +477,23 @@ impl<CS: CipherSuite> ShmChan<CS> {
         self.check()?;
 
         ChanDirection::try_from_u32(self.direction.into()).ok_or(bad_chan_direction(self.direction))
+    }
+
+    /// Returns the encryption sequence number.
+    pub fn seq(&self) -> Seq {
+        Seq::new(self.seq.into())
+    }
+
+    /// Updates the sequence number.
+    pub fn set_seq(&mut self, seq: Seq) {
+        debug_assert!(
+            seq.to_u64() > self.seq.into(),
+            "{} <= {}",
+            seq.to_u64(),
+            self.seq.into()
+        );
+
+        self.seq = seq.to_u64().into();
     }
 
     /// Performs basic sanity checking.

--- a/crates/aranya-fast-channels/src/shm/shared.rs
+++ b/crates/aranya-fast-channels/src/shm/shared.rs
@@ -1,41 +1,26 @@
-use core::{
-    alloc::Layout,
-    fmt,
-    marker::PhantomData,
-    mem::{MaybeUninit, size_of},
-    ptr, slice, str,
-    sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering},
-};
+use core::{alloc::Layout, marker::PhantomData};
 
 use aranya_crypto::{
     CipherSuite, Csprng, DeviceId, Random,
-    afc::{RawOpenKey, RawSealKey, Seq},
+    afc::{OpenKey, RawOpenKey, RawSealKey, SealKey, Seq},
     dangerous::spideroak_crypto::{aead::Aead, hash::tuple_hash},
     policy::LabelId,
 };
-use buggy::{Bug, BugExt as _};
+use buggy::Bug;
 use cfg_if::cfg_if;
 use derive_where::derive_where;
 
 use super::{
-    align::{CacheAligned, layout_repeat},
     error::{
-        Corrupted, Error, LayoutError, bad_chan_direction, bad_chan_magic, bad_chanlist_magic,
-        bad_page_alignment, bad_state_key_size, bad_state_magic, bad_state_size, bad_state_version,
-        corrupted,
+        Corrupted, Error, LayoutError, bad_chan_direction, bad_chan_magic, bad_state_key_size,
+        bad_state_magic, bad_state_size, bad_state_version,
     },
     le::{U32, U64},
     path::{Flag, Mode, Path},
 };
 #[allow(unused_imports)]
 use crate::features::*;
-use crate::{
-    ChannelDirection, RemoveIfParams,
-    errno::{Errno, errno},
-    mutex::Mutex,
-    state::{Directed, LocalChannelId},
-    util::{const_assert, debug},
-};
+use crate::{ChannelDirection, RemoveIfParams, arena::Arena, errno::Errno, state::Directed};
 
 cfg_if! {
     if #[cfg(feature = "sdlib")] {
@@ -69,62 +54,29 @@ pub enum PageSizeError {
     Bug(#[from] Bug),
 }
 
-/// Returns the current page size if the `libc` feature is
-/// enabled, or `None` otherwise.
-fn getpagesize() -> Result<Option<usize>, PageSizeError> {
-    #[cfg(feature = "libc")]
-    {
-        // SAFETY: FFI call, no invariants.
-        let size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
-        if size < 0 {
-            Err(PageSizeError::Errno(errno()))
-        } else {
-            let size = usize::try_from(size).assume("`_SC_PAGESIZE` should fit in `usize`")?;
-            Ok(Some(size))
-        }
-    }
-    #[cfg(not(feature = "libc"))]
-    {
-        Ok(None)
-    }
-}
-
 /// Used by both `ReadState` and `WriteState`.
 #[derive(Debug)]
-pub(super) struct State<CS> {
+pub(super) struct State<CS: CipherSuite> {
     ptr: Mapping<SharedMem<CS>>,
     /// The maximum number of channels supported by the shared
     /// memory.
-    max_chans: usize,
-    /// The known valid offset of side_a.
-    ///
-    /// Used to validate read_off and write_off.
-    side_a: usize,
-    /// The known valid offset of side_b.
-    ///
-    /// Used to validate read_off and write_off.
-    side_b: usize,
+    max_chans: u32,
 }
 
 impl<CS: CipherSuite> State<CS> {
     /// Creates a new `State`.
-    pub fn open<P: AsRef<Path>>(
+    pub(super) fn open<P: AsRef<Path>>(
         path: P,
         flag: Flag,
         mode: Mode,
-        max_chans: usize,
+        max_chans: u32,
     ) -> Result<Self, Error> {
         let layout = SharedMem::<CS>::layout(max_chans)?;
-        let ptr = Mapping::open(path.as_ref(), flag, mode, layout.layout)?;
+        let ptr = Mapping::open(path.as_ref(), flag, mode, layout)?;
         if flag == Flag::Create {
-            SharedMem::init(ptr.as_ptr(), max_chans, &layout);
+            SharedMem::init(ptr.as_ptr(), max_chans, layout);
         }
-        let state = Self {
-            ptr,
-            max_chans,
-            side_a: layout.side_a,
-            side_b: layout.side_b,
-        };
+        let state = Self { ptr, max_chans };
         state.validate()?;
         Ok(state)
     }
@@ -143,11 +95,8 @@ impl<CS: CipherSuite> State<CS> {
             return Err(bad_state_version(shm.version, SharedMem::<CS>::VERSION));
         }
         let layout = SharedMem::<CS>::layout(self.max_chans)?;
-        if shm.size != layout.size64() {
-            return Err(bad_state_size(shm.size, layout.size64()));
-        }
-        if shm.page_aligned != layout.page_aligned {
-            return Err(bad_page_alignment(layout.page_aligned));
+        if shm.size != layout.size() as u64 {
+            return Err(bad_state_size(shm.size, layout.size() as u64));
         }
         if shm.key_size != SharedMem::<CS>::KEY_SIZE {
             return Err(bad_state_key_size(shm.key_size));
@@ -158,121 +107,6 @@ impl<CS: CipherSuite> State<CS> {
     /// Returns the inner [`SharedMem`].
     pub(super) fn shm(&self) -> &SharedMem<CS> {
         self.ptr.as_ref()
-    }
-
-    /// Loads the [`ChanList`] at the current `read_off`.
-    pub(super) fn load_read_list(&self) -> Result<&Mutex<ChanListData<CS>>, Corrupted> {
-        let shm = self.shm();
-        let off = self.read_off(shm)?;
-        shm.side(off)
-    }
-
-    /// Loads the [`ChanList`] at the current `write_off`.
-    pub(super) fn load_write_list(&self) -> Result<&Mutex<ChanListData<CS>>, Corrupted> {
-        let shm = self.shm();
-        let off = self.write_off(shm)?;
-        shm.side(off)
-    }
-
-    /// Load the current `read_off` from `shm`.
-    fn read_off(&self, shm: &SharedMem<CS>) -> Result<Offset, Corrupted> {
-        let off = shm.read_off.load(Ordering::SeqCst);
-        if unlikely!(!self.valid_offset(off)) {
-            Err(corrupted("invalid read offset"))
-        } else {
-            Ok(Offset(off))
-        }
-    }
-
-    /// Load the current `write_off` from `shm`.
-    pub(super) fn write_off(&self, shm: &SharedMem<CS>) -> Result<Offset, Corrupted> {
-        let off = shm.write_off.load(Ordering::SeqCst);
-        if unlikely!(!self.valid_offset(off)) {
-            Err(corrupted("invalid write offset"))
-        } else {
-            Ok(Offset(off))
-        }
-    }
-
-    /// Swaps `write_off` for `read_off` and returns `read_off`.
-    pub(super) fn swap_offsets(
-        &self,
-        shm: &SharedMem<CS>,
-        write_off: Offset,
-    ) -> Result<Offset, Corrupted> {
-        let off = shm.read_off.swap(write_off.into(), Ordering::SeqCst);
-        if unlikely!(!self.valid_offset(off)) {
-            Err(corrupted("invalid write offset"))
-        } else {
-            Ok(Offset(off))
-        }
-    }
-
-    /// Reports whether `off` is a known valid offset.
-    const fn valid_offset(&self, off: usize) -> bool {
-        off == self.side_a || off == self.side_b
-    }
-
-    #[cfg(test)]
-    pub fn find_chan(
-        &self,
-        ch: LocalChannelId,
-        hint: Option<Index>,
-    ) -> Result<Option<(ShmChan<CS>, Index)>, Corrupted> {
-        let list = self.load_read_list()?.lock().assume("poisoned")?;
-        list.find(ch, hint, Op::Any)
-            .map(|res| res.map(|(chan, idx)| ((*chan).clone(), idx)))
-    }
-}
-
-/// An operation intended with a channel.
-// NB: see `ChanDirection::matches` to understand the
-// discriminants.
-#[derive(Copy, Clone, Debug)]
-#[repr(u32)]
-pub(super) enum Op {
-    /// Encryption.
-    Seal = 1,
-    /// Decryption.
-    Open = 2,
-    /// Either.
-    #[allow(dead_code)]
-    Any = 3,
-}
-
-impl Op {
-    const fn to_u32(self) -> u32 {
-        self as u32
-    }
-
-    const fn as_str(self) -> &'static str {
-        match self {
-            Self::Seal => "seal",
-            Self::Open => "open",
-            Self::Any => "any",
-        }
-    }
-}
-
-impl fmt::Display for Op {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-/// The index of a [`ShmChan`] in a [`ChanList`].
-#[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub(super) struct Index(pub(super) usize);
-
-/// A validated offset.
-#[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default)]
-pub(super) struct Offset(usize);
-
-impl From<Offset> for usize {
-    fn from(val: Offset) -> Self {
-        val.0
     }
 }
 
@@ -289,22 +123,6 @@ enum ChanDirection {
 }
 
 impl ChanDirection {
-    /// Reports whether this channel type matches `op`.
-    const fn matches(self, op: Op) -> bool {
-        const_assert!(ChanDirection::SealOnly.matches(Op::Seal));
-        const_assert!(!ChanDirection::SealOnly.matches(Op::Open));
-        const_assert!(ChanDirection::SealOnly.matches(Op::Any));
-
-        const_assert!(ChanDirection::OpenOnly.matches(Op::Open));
-        const_assert!(!ChanDirection::OpenOnly.matches(Op::Seal));
-        const_assert!(ChanDirection::OpenOnly.matches(Op::Any));
-
-        // Ideally, we'd write this using `matches`. But the
-        // compiler isn't smart enough to turn it into a bitmask,
-        // so we have to do it manually.
-        self.to_u32() & op.to_u32() != 0
-    }
-
     /// Converts the `ChanDirection` to its 32-bit integer
     /// representation.
     const fn to_u32(self) -> u32 {
@@ -329,214 +147,12 @@ impl ChanDirection {
     }
 }
 
-impl PartialEq<Op> for ChanDirection {
-    fn eq(&self, other: &Op) -> bool {
-        self.matches(*other)
-    }
-}
-
 impl From<ChanDirection> for ChannelDirection {
     fn from(value: ChanDirection) -> Self {
         match value {
             ChanDirection::SealOnly => Self::Seal,
             ChanDirection::OpenOnly => Self::Open,
         }
-    }
-}
-
-/// The in-memory representation of a channel.
-///
-/// All integers are little endian.
-#[repr(C)]
-#[derive_where(Clone, Debug)]
-pub(super) struct ShmChan<CS: CipherSuite> {
-    /// Must be [`ShmChan::MAGIC`].
-    pub magic: U32,
-    /// Describes the direction that data flows in the channel.
-    pub direction: U32,
-    /// The channel's ID.
-    pub local_channel_id: U64,
-    /// The current encryption sequence counter.
-    pub seq: U64,
-    /// The channel's label.
-    pub label_id: LabelId,
-    /// The ID of the peer.
-    pub peer_id: DeviceId,
-    /// The key/nonce used to encrypt data for the channel peer.
-    #[derive_where(skip(Debug))]
-    pub seal_key: RawSealKey<CS>,
-    /// The key/nonce used to decrypt data from the channel peer.
-    #[derive_where(skip(Debug))]
-    pub open_key: RawOpenKey<CS>,
-    /// Uniquely identifies `seal_key` and `open_key`.
-    pub key_id: KeyId,
-}
-assert_ffi_safe!(ShmChan<aranya_crypto::default::DefaultCipherSuite>);
-
-impl<CS: CipherSuite> ShmChan<CS> {
-    /// Identifies the `ShmChan` in memory.
-    pub const MAGIC: U32 = U32::new(0x36bb2c43);
-
-    /// Returns the channel's memory layout.
-    const fn layout() -> Layout {
-        Layout::new::<Self>()
-    }
-
-    /// Initializes the memory at `ptr`.
-    ///
-    /// It uses `rng` to randomize unset fields.
-    pub fn init<R: Csprng>(
-        ptr: &mut MaybeUninit<Self>,
-        id: LocalChannelId,
-        label_id: LabelId,
-        peer_id: DeviceId,
-        keys: &Directed<RawSealKey<CS>, RawOpenKey<CS>>,
-        rng: R,
-    ) {
-        // As a safety precaution, randomize keys that we don't
-        // use. Leaving them unset (usually all zeros) is
-        // dangerous.
-        //
-        // If we were to leave it unset and accidentally use it
-        // for encryption, the resulting ciphertext would be
-        // encrypted with a non-uniformly random key (e.g., all
-        // zeros). By randomizing it, the ciphertext is instead
-        // rendered irrecoverable.
-        //
-        // If we were leave it unset and accidentally use it for
-        // decryption, an attacker could create a ciphertext that
-        // decrypts and authenticates for the key. Randomizing
-        // the key prevents an attacker from crafting such
-        // a ciphertext.
-        let seal_key = keys.seal().cloned().unwrap_or_else(|| Random::random(&rng));
-        let open_key = keys.open().cloned().unwrap_or_else(|| Random::random(&rng));
-        let key_id = KeyId::new(&seal_key, &open_key);
-        let chan = Self {
-            magic: Self::MAGIC,
-            direction: ChanDirection::from_directed(keys).to_u32().into(),
-            local_channel_id: id.to_u64().into(),
-            // For the same reason that we randomize keys,
-            // manually exhaust the sequence number.
-            seq: if keys.seal().is_some() {
-                U64::new(0)
-            } else {
-                U64::MAX
-            },
-            label_id,
-            peer_id,
-            seal_key,
-            open_key,
-            key_id,
-        };
-        ptr.write(chan);
-    }
-
-    #[cfg(test)]
-    pub(crate) fn keys(&self) -> Result<Directed<&RawSealKey<CS>, &RawOpenKey<CS>>, Corrupted> {
-        Ok(match self.direction()? {
-            ChanDirection::SealOnly => Directed::SealOnly {
-                seal: &self.seal_key,
-            },
-            ChanDirection::OpenOnly => Directed::OpenOnly {
-                open: &self.open_key,
-            },
-        })
-    }
-
-    /// Returns the channel's unique ID.
-    #[inline(always)]
-    pub fn id(&self) -> Result<LocalChannelId, Corrupted> {
-        self.check()?;
-
-        Ok(LocalChannelId::new(self.local_channel_id.into()))
-    }
-
-    /// Returns the [label ID][LabelId] associated with this channel.
-    #[inline(always)]
-    pub fn label_id(&self) -> Result<LabelId, Corrupted> {
-        self.check()?;
-
-        Ok(self.label_id)
-    }
-
-    /// Returns the [Id of the peer][DeviceId] associated with this channel.
-    #[inline(always)]
-    pub fn peer_id(&self) -> Result<DeviceId, Corrupted> {
-        self.check()?;
-
-        Ok(self.peer_id)
-    }
-
-    /// Reports whether this channel matches `op`.
-    #[inline(always)]
-    pub fn matches(&self, op: Op) -> Result<bool, Corrupted> {
-        Ok(self.direction()?.matches(op))
-    }
-
-    fn direction(&self) -> Result<ChanDirection, Corrupted> {
-        self.check()?;
-
-        ChanDirection::try_from_u32(self.direction.into()).ok_or(bad_chan_direction(self.direction))
-    }
-
-    /// Returns the encryption sequence number.
-    pub fn seq(&self) -> Seq {
-        Seq::new(self.seq.into())
-    }
-
-    /// Updates the sequence number.
-    pub fn set_seq(&mut self, seq: Seq) {
-        debug_assert!(
-            seq.to_u64() > self.seq.into(),
-            "{} <= {}",
-            seq.to_u64(),
-            self.seq.into()
-        );
-
-        self.seq = seq.to_u64().into();
-    }
-
-    /// Performs basic sanity checking.
-    #[track_caller]
-    fn check(&self) -> Result<(), Corrupted> {
-        // Perform more "expensive" checks in debug mode.
-        //
-        // We also panic in debug mode so that we get nice stack
-        // traces.
-        #[cfg(debug_assertions)]
-        {
-            assert_eq!(self.magic, Self::MAGIC, "invalid magic");
-        }
-
-        let magic = self.magic;
-        if unlikely!(magic != Self::MAGIC) {
-            Err(bad_chan_magic(magic))
-        } else {
-            Ok(())
-        }
-    }
-}
-
-/// Describes the memory layout of a [`SharedMem`].
-pub(super) struct ShmLayout {
-    layout: Layout,
-    /// Offset of side_a.
-    side_a: usize,
-    /// Offset of side_b.
-    side_b: usize,
-    /// Is ~everything page aligned?
-    page_aligned: bool,
-}
-
-impl ShmLayout {
-    /// Shorthand for `self.layout.size()`.
-    pub const fn size(&self) -> usize {
-        self.layout.size()
-    }
-
-    /// Shorthand for `self.layout.size()`.
-    pub const fn size64(&self) -> U64 {
-        U64::new(self.size() as u64)
     }
 }
 
@@ -559,13 +175,14 @@ impl ShmLayout {
     repr(C, align(32))
 )]
 #[derive_where(Debug)]
-pub(super) struct SharedMem<CS> {
+pub(super) struct SharedMem<CS: CipherSuite> {
     /// Identifies this memory as a [`SharedMem`].
     ///
     /// Should be [`Self::MAGIC`].
     magic: U32,
     /// shm implementation version
     version: U32,
+    max_chans: U32,
     /// The total size of this object, including trailing data.
     size: U64,
     /// The size in bytes of the keys stored in each
@@ -574,33 +191,10 @@ pub(super) struct SharedMem<CS> {
     /// The size in bytes of the nonces stored in each
     /// [`ChanList`].
     nonce_size: U64,
-    /// The next channel ID.
-    ///
-    /// Invariant: only the writer reads from or writes to this
-    /// field.
-    pub next_chan_id: AtomicU64,
-    /// `true` if this object and its [`ChanList`]s are page
-    /// aligned.
-    page_aligned: bool,
-    /// The offset of either `side_a` or `side_b`.
-    ///
-    /// `read_off` always refers to the opposite of `write_off`.
-    read_off: CacheAligned<AtomicUsize>,
-    /// The offset of either `side_a` or `side_b`.
-    ///
-    /// `write_off` always refers to the opposite of `read_off`.
-    pub write_off: CacheAligned<AtomicUsize>,
-    /// In memory, this is actually two fields:
-    ///
-    /// ```ignore
-    /// side_a: ChanList,
-    /// side_b: ChanList,
-    /// ```
-    ///
-    /// It is a ZST and does not affect the memory layout.
-    sides: PhantomData<CS>,
+    /// Start of the arena.
+    arena: PhantomData<Arena<ShmChan<CS>>>,
 }
-assert_ffi_safe!(SharedMem<aranya_crypto::default::DefaultEngine<aranya_crypto::Rng>>);
+assert_ffi_safe!(SharedMem<aranya_crypto::default::DefaultCipherSuite>);
 
 // SAFETY: `SharedMem` can be safely shared between threads.
 unsafe impl<CS: CipherSuite> Sync for SharedMem<CS> {}
@@ -612,7 +206,7 @@ impl<CS: CipherSuite> SharedMem<CS> {
     const NONCE_SIZE: U64 = U64::new(<CS::Aead as Aead>::NONCE_SIZE as u64);
 
     /// Initializes the memory at `ptr`.
-    pub fn init(ptr: *mut Self, max_chans: usize, layout: &ShmLayout) {
+    pub(super) fn init(ptr: *mut Self, max_chans: u32, layout: Layout) {
         // Zero everything. This simplifies the following
         // code.
         //
@@ -623,14 +217,11 @@ impl<CS: CipherSuite> SharedMem<CS> {
         let shm = Self {
             magic: Self::MAGIC,
             version: Self::VERSION,
-            size: layout.size64(),
+            max_chans: max_chans.into(),
+            size: U64::from(layout.size() as u64),
             key_size: Self::KEY_SIZE,
             nonce_size: Self::NONCE_SIZE,
-            next_chan_id: AtomicU64::new(0),
-            page_aligned: layout.page_aligned,
-            read_off: CacheAligned::new(AtomicUsize::new(layout.side_a)),
-            write_off: CacheAligned::new(AtomicUsize::new(layout.side_b)),
-            sides: PhantomData,
+            arena: PhantomData,
         };
         // SAFETY: ptr is valid for writes and properly
         // aligned.
@@ -639,40 +230,16 @@ impl<CS: CipherSuite> SharedMem<CS> {
         // SAFETY: the offsets come directly from memory laid out
         // with `Layout`.
         unsafe {
-            ptr.byte_add(layout.side_a)
-                .cast::<ChanList<CS>>()
-                .write(ChanList::<CS>::new(max_chans));
-            ptr.byte_add(layout.side_b)
-                .cast::<ChanList<CS>>()
-                .write(ChanList::<CS>::new(max_chans));
+            Arena::<ShmChan<CS>>::init((&raw mut (*ptr).arena).cast(), max_chans);
         }
-
-        // We do not need to do anything with the
-        // trailing data since we've already set it to
-        // all zeros.
     }
 
     /// Returns its memory layout.
-    fn layout(max_chans: usize) -> Result<ShmLayout, LayoutError> {
-        let (list, page_aligned) = ChanList::<CS>::layout(max_chans)?;
-
-        let layout = Layout::new::<Self>();
-        let (layout, side_a) = layout.extend(list)?;
-        let (mut layout, side_b) = layout.extend(list)?;
-
-        if page_aligned
-            && let Some(page_size) = getpagesize()?
-            && layout.size() < page_size
-        {
-            layout = layout.align_to(page_size)?;
-        }
-
-        Ok(ShmLayout {
-            layout: layout.pad_to_align(),
-            side_a,
-            side_b,
-            page_aligned,
-        })
+    fn layout(max_chans: u32) -> Result<Layout, LayoutError> {
+        Ok(Layout::new::<Self>()
+            .extend(Arena::<ShmChan<CS>>::layout(max_chans)?)?
+            .0
+            .pad_to_align())
     }
 
     /// Performs basic sanity checking.
@@ -694,399 +261,193 @@ impl<CS: CipherSuite> SharedMem<CS> {
     }
 
     /// Returns the side corresponding with `off`.
-    pub fn side(&self, off: Offset) -> Result<&Mutex<ChanListData<CS>>, Corrupted> {
+    pub(super) fn arena(&self) -> Result<&Arena<ShmChan<CS>>, Corrupted> {
         self.check()?;
 
         // SAFETY: ptr is non-null, suitably aligned, and won't
         // wrap.
-        let list = unsafe {
-            let ptr = ptr::from_ref::<Self>(self).byte_add(off.into());
-            let ptr = ptr.cast::<ChanList<CS>>();
-            &*ptr
-        };
-        list.check()?;
-        Ok(&list.data)
+        let arena =
+            unsafe { &*Arena::from_parts((&raw const self.arena).cast(), self.max_chans.into()) };
+        // TODO: list.check()?;
+        Ok(arena)
     }
 }
 
-/// A list of [`ShmChan`]s.
+/// The in-memory representation of a channel.
 ///
-/// Unlike (for example) `ShmChan`, this struct is the actual
-/// memory layout, with the exception of the trailing `ShmChan`
-/// array.
-#[cfg_attr(
-    any(target_arch = "aarch64", target_arch = "powerpc64"),
-    repr(C, align(128))
-)]
-#[cfg_attr(any(target_arch = "x86_64"), repr(C, align(64)))]
-#[cfg_attr(
-    any(
-        target_arch = "arm",
-        target_arch = "mips",
-        target_arch = "mips64",
-        target_arch = "riscv64",
-        target_arch = "powerpc",
-    ),
-    repr(C, align(32))
-)]
+/// All integers are little endian.
+#[repr(C)]
 #[derive_where(Debug)]
-struct ChanList<CS> {
-    /// Identifies this memory as a [`ChanList`].
-    ///
-    /// Should be [`Self::MAGIC`].
+pub(super) struct ShmChan<CS: CipherSuite> {
+    /// Must be [`ShmChan::MAGIC`].
     magic: U32,
-    /// The locked list data.
-    data: Mutex<ChanListData<CS>>,
+    /// Describes the direction that data flows in the channel.
+    direction: U32,
+    // /// The channel's ID.
+    // pub(super) local_channel_id: U64,
+    /// The current encryption sequence counter.
+    seq: U64,
+    /// The channel's label.
+    label_id: LabelId,
+    /// The ID of the peer.
+    peer_id: DeviceId,
+    /// The key/nonce used to encrypt data for the channel peer.
+    #[derive_where(skip(Debug))]
+    seal_key: RawSealKey<CS>,
+    /// The key/nonce used to decrypt data from the channel peer.
+    #[derive_where(skip(Debug))]
+    open_key: RawOpenKey<CS>,
+    /// Uniquely identifies `seal_key` and `open_key`.
+    key_id: KeyId,
 }
-assert_ffi_safe!(ChanList<aranya_crypto::default::DefaultEngine<aranya_crypto::Rng>>);
+assert_ffi_safe!(ShmChan<aranya_crypto::default::DefaultCipherSuite>);
 
-impl<CS: CipherSuite> ChanList<CS> {
-    const MAGIC: U32 = U32::new(0x1b771244);
+impl<CS: CipherSuite> ShmChan<CS> {
+    /// Identifies the `ShmChan` in memory.
+    const MAGIC: U32 = U32::new(0x36bb2c43);
 
-    /// Returns its memory layout, including the trailing data.
-    ///
-    /// It reports whether it is page aligned.
-    fn layout(max_chans: usize) -> Result<(Layout, bool), LayoutError> {
-        let chans = layout_repeat(ShmChan::<CS>::layout(), max_chans)?;
-
-        // Extend by the size of the trailing data.
-        let layout = Layout::new::<Self>();
-        let (layout, _) = layout.extend(chans)?;
-
-        // If the cumulative size of the two sides are going to
-        // straddle multiple pages, align each to the page size.
-        let (page_size, page_aligned) = if cfg!(feature = "page-aligned") {
-            let page_size = getpagesize()?.assume("`page-aligned` feature requires `libc`")?;
-            let page_aligned =
-                (layout.size() * 2 > page_size) && page_size.is_multiple_of(layout.align());
-            (page_size, page_aligned)
-        } else {
-            (0, false)
-        };
-        if page_aligned {
-            Ok((layout.align_to(page_size)?, true))
-        } else {
-            Ok((layout, false))
+    pub(super) fn new<R: Csprng>(
+        label_id: LabelId,
+        peer_id: DeviceId,
+        keys: &Directed<RawSealKey<CS>, RawOpenKey<CS>>,
+        rng: R,
+    ) -> Self {
+        // As a safety precaution, randomize keys that we don't
+        // use. Leaving them unset (usually all zeros) is
+        // dangerous.
+        //
+        // If we were to leave it unset and accidentally use it
+        // for encryption, the resulting ciphertext would be
+        // encrypted with a non-uniformly random key (e.g., all
+        // zeros). By randomizing it, the ciphertext is instead
+        // rendered irrecoverable.
+        //
+        // If we were leave it unset and accidentally use it for
+        // decryption, an attacker could create a ciphertext that
+        // decrypts and authenticates for the key. Randomizing
+        // the key prevents an attacker from crafting such
+        // a ciphertext.
+        let seal_key = keys.seal().cloned().unwrap_or_else(|| Random::random(&rng));
+        let open_key = keys.open().cloned().unwrap_or_else(|| Random::random(&rng));
+        let key_id = KeyId::new(&seal_key, &open_key);
+        Self {
+            magic: Self::MAGIC,
+            direction: ChanDirection::from_directed(keys).to_u32().into(),
+            // local_channel_id: id.to_u64().into(),
+            // For the same reason that we randomize keys,
+            // manually exhaust the sequence number.
+            seq: if keys.seal().is_some() {
+                U64::new(0)
+            } else {
+                U64::MAX
+            },
+            label_id,
+            peer_id,
+            seal_key,
+            open_key,
+            key_id,
         }
+    }
+
+    pub(super) fn remove_if_params(
+        &self,
+        idx: crate::arena::Index,
+    ) -> Result<RemoveIfParams, Corrupted> {
+        Ok(RemoveIfParams {
+            local_channel_id: idx.into(),
+            label_id: self.label_id()?,
+            peer_id: self.peer_id()?,
+            direction: self.direction()?.into(),
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn keys(&self) -> Result<Directed<&RawSealKey<CS>, &RawOpenKey<CS>>, Corrupted> {
+        Ok(match self.direction()? {
+            ChanDirection::SealOnly => Directed::SealOnly {
+                seal: &self.seal_key,
+            },
+            ChanDirection::OpenOnly => Directed::OpenOnly {
+                open: &self.open_key,
+            },
+        })
+    }
+
+    /// Returns the [label ID][LabelId] associated with this channel.
+    #[inline(always)]
+    pub(super) fn label_id(&self) -> Result<LabelId, Corrupted> {
+        self.check()?;
+
+        Ok(self.label_id)
+    }
+
+    /// Returns the [Id of the peer][DeviceId] associated with this channel.
+    #[inline(always)]
+    fn peer_id(&self) -> Result<DeviceId, Corrupted> {
+        self.check()?;
+
+        Ok(self.peer_id)
+    }
+
+    fn direction(&self) -> Result<ChanDirection, Corrupted> {
+        self.check()?;
+
+        ChanDirection::try_from_u32(self.direction.into()).ok_or(bad_chan_direction(self.direction))
+    }
+
+    pub(super) fn seal_key(&self) -> Result<SealKey<CS>, crate::Error> {
+        let direction = self.direction()?;
+        if direction != ChanDirection::SealOnly {
+            // TODO: Better error
+            return Err(crate::Error::InvalidArgument("TODO"));
+        }
+        Ok(SealKey::from_raw(&self.seal_key, self.seq())?)
+    }
+
+    pub(super) fn open_key(&self) -> Result<OpenKey<CS>, crate::Error> {
+        let direction = self.direction()?;
+        if direction != ChanDirection::OpenOnly {
+            // TODO: Better error
+            return Err(crate::Error::InvalidArgument("TODO"));
+        }
+        Ok(OpenKey::from_raw(&self.open_key)?)
+    }
+
+    /// Returns the encryption sequence number.
+    fn seq(&self) -> Seq {
+        Seq::new(self.seq.into())
+    }
+
+    /// Updates the sequence number.
+    pub(super) fn set_seq(&mut self, seq: Seq) {
+        debug_assert!(
+            seq.to_u64() > self.seq.into(),
+            "{} <= {}",
+            seq.to_u64(),
+            self.seq.into()
+        );
+
+        self.seq = seq.to_u64().into();
     }
 
     /// Performs basic sanity checking.
     #[track_caller]
-    fn check(&self) -> Result<(), Corrupted> {
+    pub(super) fn check(&self) -> Result<(), Corrupted> {
         // Perform more "expensive" checks in debug mode.
         //
         // We also panic in debug mode so that we get nice stack
         // traces.
-        debug_assert_eq!(self.magic, Self::MAGIC);
+        #[cfg(debug_assertions)]
+        {
+            assert_eq!(self.magic, Self::MAGIC, "invalid magic");
+        }
 
         let magic = self.magic;
         if unlikely!(magic != Self::MAGIC) {
-            Err(bad_chanlist_magic(magic))
+            Err(bad_chan_magic(magic))
         } else {
             Ok(())
         }
-    }
-
-    /// Creates a [`ChanList`] with space for at most
-    /// `max_chans`.
-    fn new(max_chans: usize) -> Self {
-        Self {
-            magic: Self::MAGIC,
-            data: Mutex::new(ChanListData {
-                generation: AtomicU32::new(0),
-                len: U64::new(0),
-                cap: U64::new(max_chans as u64),
-                chans: PhantomData,
-            }),
-        }
-    }
-}
-
-/// The "data" portion of a [`ChanList`].
-///
-/// Broken out separately so it can be placed inside a [`Mutex`].
-#[repr(C, align(8))]
-#[derive_where(Debug)]
-pub(super) struct ChanListData<CS> {
-    /// The current generation.
-    ///
-    /// It is incremented each time the list is modified.
-    ///
-    /// It is atomic so that `ReadState` can safely read it even
-    /// while this struct is locked.
-    ///
-    /// Putting it as the first field significantly decreases the
-    /// size of the struct.
-    pub generation: AtomicU32,
-    /// The current number of channels.
-    pub len: U64,
-    /// The maximum number of channels.
-    pub cap: U64,
-    /// This is actually `[ShmChan; cap]`.
-    ///
-    /// It is a ZST and does not affect the memory layout.
-    chans: PhantomData<CS>,
-}
-assert_ffi_safe!(ChanListData<aranya_crypto::default::DefaultEngine<aranya_crypto::Rng>>);
-
-const_assert!(
-    // `Mutex` is 8 bytes, so ensure that `Mutex<ChanListData>`
-    // is only 8 (cache-aligned) bytes larger.
-    size_of::<Mutex<ChanListData<()>>>() == 8 + size_of::<ChanListData<()>>()
-);
-
-impl<CS: CipherSuite> ChanListData<CS> {
-    /// Performs basic sanity checking.
-    #[track_caller]
-    fn check(&self) {
-        debug_assert!(self.len <= self.cap);
-    }
-
-    fn len(&self) -> Result<usize, Corrupted> {
-        usize::try_from(self.len).map_err(|_| corrupted("`len` is larger than `usize::MAX`"))
-    }
-
-    fn cap(&self) -> Result<usize, Corrupted> {
-        usize::try_from(self.cap).map_err(|_| corrupted("`cap` is larger than `usize::MAX`"))
-    }
-
-    /// Truncates the list.
-    pub fn clear(&mut self) {
-        self.len = U64::new(0);
-        self.generation.fetch_add(1, Ordering::AcqRel);
-    }
-
-    /// Returns a slice of the channels.
-    fn chans(&self) -> Result<&[ShmChan<CS>], Corrupted> {
-        self.check();
-
-        let ptr = ptr::addr_of!(self.chans).cast::<ShmChan<CS>>();
-        // SAFETY: `ptr` is correctly aligned and non-null.
-        Ok(unsafe { slice::from_raw_parts(ptr, self.len()?) })
-    }
-
-    /// Returns the in-use channels.
-    pub fn chans_mut(&mut self) -> Result<&mut [ShmChan<CS>], Corrupted> {
-        self.check();
-
-        let ptr = ptr::addr_of_mut!(self.chans).cast::<ShmChan<CS>>();
-        // SAFETY: `ptr` is correctly aligned and non-null.
-        Ok(unsafe { slice::from_raw_parts_mut(ptr, self.len()?) })
-    }
-
-    /// Returns the trailing data.
-    fn all_chans_mut(&mut self) -> Result<&mut [MaybeUninit<ShmChan<CS>>], Corrupted> {
-        self.check();
-
-        let ptr = ptr::addr_of_mut!(self.chans).cast::<MaybeUninit<ShmChan<CS>>>();
-        // SAFETY: `ptr` is correctly aligned and non-null.
-        Ok(unsafe { slice::from_raw_parts_mut(ptr, self.cap()?) })
-    }
-
-    /// Returns the [`ShmChan`] at index `idx`.
-    ///
-    /// Unlike [`at`][`Self::at`], this method will return
-    /// uninitialized channels. It also returns an error if `idx`
-    /// is out of range.
-    pub fn raw_at(&mut self, idx: usize) -> Result<&mut MaybeUninit<ShmChan<CS>>, Corrupted> {
-        self.check();
-
-        self.all_chans_mut()?
-            .get_mut(idx)
-            .ok_or(corrupted("`ShmChan` index out of range"))
-    }
-
-    /// Returns the [`ShmChan`] at index `idx`.
-    ///
-    /// Unlike `raw_at`, this method only returns initialized
-    /// channels. It is not an error if `idx` is out of range.
-    /// Instead, it returns `None`.
-    pub fn get(&self, idx: usize) -> Result<Option<&ShmChan<CS>>, Corrupted> {
-        self.check();
-
-        Ok(self.chans()?.get(idx))
-    }
-
-    /// Returns the [`ShmChan`] at index `idx`.
-    ///
-    /// Unlike `raw_at`, this method only returns initialized
-    /// channels. It is not an error if `idx` is out of range.
-    /// Instead, it returns `None`.
-    pub fn get_mut(&mut self, idx: usize) -> Result<Option<&mut ShmChan<CS>>, Corrupted> {
-        self.check();
-
-        Ok(self.chans_mut()?.get_mut(idx))
-    }
-
-    /// Removes all elements where `f` returns true.
-    pub(super) fn remove_if<F>(&mut self, f: &mut F) -> Result<(), Corrupted>
-    where
-        F: FnMut(RemoveIfParams) -> bool,
-    {
-        self.check();
-
-        let mut updated = false;
-        let mut idx = 0;
-        while let Some(chan) = self.get(idx)? {
-            let id = chan.id()?;
-            let label_id = chan.label_id()?;
-            let peer_id = chan.peer_id()?;
-            let direction = chan.direction()?.into();
-            if !f(RemoveIfParams::new(id, label_id, peer_id, direction)) {
-                // Nope, try the next index.
-                idx += 1;
-                continue;
-            }
-            debug!("removing chan {id}");
-
-            if !updated {
-                // As a precaution, update the generation before
-                // we actually delete anything.
-                let generation = self.generation.fetch_add(1, Ordering::AcqRel);
-                debug!("side generation={}", generation + 1);
-
-                updated = true;
-            }
-            debug!("removing chan at {idx}");
-
-            // self[i] = self[self.len-1]
-            self.swap_remove(idx)?;
-            // We just set `self[i] = self[self.len-1]`, so don't
-            // increment `idx`. Just try `i` again.
-        }
-        Ok(())
-    }
-
-    /// Checks if channel exists.
-    pub(super) fn exists(
-        &self,
-        id: LocalChannelId,
-        hint: Option<Index>,
-        op: Op,
-    ) -> Result<bool, Error> {
-        self.check();
-
-        Ok(self.find(id, hint, op)?.is_some())
-    }
-
-    /// Retrieves the channel and its index for a particular
-    /// channel.
-    ///
-    /// The channel must match the particular `op`.
-    pub(super) fn find(
-        &self,
-        ch: LocalChannelId,
-        hint: Option<Index>,
-        op: Op,
-    ) -> Result<Option<(&ShmChan<CS>, Index)>, Corrupted> {
-        debug!("looking up {ch} with hint {hint:?} for {op}");
-
-        // If the caller provided an index, use that.
-        if let Some(hint) = hint
-            && let Some(chan) = self
-                .get(hint.0)?
-                // Hints are purely additive, so we purposefully
-                // ignore errors (e.g., Corrupted) while finding
-                // the channel.
-                .filter(|chan| {
-                    chan.id().is_ok_and(|got| got == ch) && chan.matches(op).is_ok_and(|ok| ok)
-                })
-        {
-            debug!("used hint {hint:?} for {ch}");
-            return Ok(Some((chan, hint)));
-        }
-
-        // The index (if any) wasn't valid, so fall back to
-        // a linear search.
-        if let Some((idx, chan)) = self.try_iter()?.enumerate().try_find(|(_, chan)| {
-            let ok = chan.id()? == ch && chan.matches(op)?;
-            Ok::<bool, Corrupted>(ok)
-        })? {
-            Ok(Some((chan, Index(idx))))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Retrieves the channel and its index for a particular
-    /// channel.
-    ///
-    /// The channel must match the particular `op`.
-    pub(super) fn find_mut(
-        &mut self,
-        ch: LocalChannelId,
-        hint: Option<Index>,
-        op: Op,
-    ) -> Result<Option<(&mut ShmChan<CS>, Index)>, Corrupted> {
-        debug!("looking up {ch} with hint {hint:?} for {op}");
-
-        // If the caller provided an index, use that.
-        if let Some(hint) = hint
-            && let Some(chan) = self
-                .get_mut(hint.0)?
-                // Hints are purely additive, so we purposefully
-                // ignore errors (e.g., Corrupted) while finding
-                // the channel.
-                .filter(|chan| {
-                    chan.id().is_ok_and(|got| got == ch) && chan.matches(op).is_ok_and(|ok| ok)
-                })
-                // Use ptr to work around early return borrow
-                // checker limitation
-                .map(|chan| -> *mut ShmChan<CS> { chan })
-        {
-            debug!("used hint {hint:?} for {ch}");
-            // SAFETY: `chan` is borrowed from self then
-            // immediately returned. The lifetime of the
-            // returned value is tied to self.
-            return Ok(Some((unsafe { &mut *chan }, hint)));
-        }
-
-        // The index (if any) wasn't valid, so fall back to
-        // a linear search.
-        if let Some((idx, chan)) = self.try_iter_mut()?.enumerate().try_find(|(_, chan)| {
-            let ok = chan.id()? == ch && chan.matches(op)?;
-            Ok::<bool, Corrupted>(ok)
-        })? {
-            Ok(Some((chan, Index(idx))))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Removes the [`ShmChan`] at `idx`, replacing it with
-    /// the last channel in the list.
-    pub fn swap_remove(&mut self, idx: usize) -> Result<(), Corrupted> {
-        self.check();
-
-        let len = self.len()?;
-        if unlikely!(len == 0) {
-            Err(corrupted("`swap_remove` called with len == 0"))
-        } else if unlikely!(idx >= len) {
-            Err(corrupted("`ShmChan` index out of range"))
-        } else {
-            // No need to perform a swap if there is only one
-            // channel.
-            if len > 1 {
-                self.chans_mut()?.swap(idx, len - 1);
-            }
-            self.len -= 1;
-            assert!(self.len <= self.cap);
-            Ok(())
-        }
-    }
-
-    /// Returns an iterator over the list's channels.
-    pub fn try_iter(&self) -> Result<slice::Iter<'_, ShmChan<CS>>, Corrupted> {
-        self.check();
-
-        Ok(self.chans()?.iter())
-    }
-
-    /// Returns an iterator over the list's channels.
-    pub fn try_iter_mut(&mut self) -> Result<slice::IterMut<'_, ShmChan<CS>>, Corrupted> {
-        self.check();
-
-        Ok(self.chans_mut()?.iter_mut())
     }
 }
 

--- a/crates/aranya-fast-channels/src/shm/tests.rs
+++ b/crates/aranya-fast-channels/src/shm/tests.rs
@@ -150,11 +150,3 @@ fn test_many_nodes() {
         }
     }
 }
-
-#[test]
-fn read_state_is_send_sync() {
-    use aranya_crypto::default::DefaultCipherSuite;
-    fn is_send_sync<T: Send + Sync>() {}
-
-    is_send_sync::<ReadState<DefaultCipherSuite>>();
-}

--- a/crates/aranya-fast-channels/src/shm/tests.rs
+++ b/crates/aranya-fast-channels/src/shm/tests.rs
@@ -10,10 +10,7 @@ use aranya_crypto::{
 };
 use serial_test::serial;
 
-use super::{
-    Flag, Mode, Path, ReadState, WriteState,
-    shared::{Index, ShmChan},
-};
+use super::{Flag, Mode, Path, ReadState, WriteState};
 use crate::{
     state::{AranyaState, Channel, Directed},
     testing::{
@@ -40,7 +37,7 @@ impl TestImpl for SharedMemImpl {
     fn new_states<CS: CipherSuite>(
         name: &str,
         id: DeviceIdx,
-        max_chans: usize,
+        max_chans: u32,
     ) -> States<Self::Afc<CS>, Self::Aranya<CS>> {
         let path = make_path(name, id);
         let _ = super::unlink(&path);
@@ -69,7 +66,7 @@ test_impl!(#[serial], shm, SharedMemImpl);
 /// Test adding many nodes.
 #[test]
 fn test_many_nodes() {
-    const MAX_CHANS: usize = 101;
+    const MAX_CHANS: u32 = 101;
 
     let labels = [LabelId::random(Rng), LabelId::random(Rng)];
 
@@ -81,7 +78,7 @@ fn test_many_nodes() {
         path,
         Flag::Create,
         Mode::ReadWrite,
-        MAX_CHANS * labels.len(),
+        MAX_CHANS * labels.len() as u32,
         Rng,
     )
     .expect("unable to created shared memory");
@@ -89,12 +86,12 @@ fn test_many_nodes() {
         path,
         Flag::OpenOnly,
         Mode::ReadWrite,
-        MAX_CHANS * labels.len(),
+        MAX_CHANS * labels.len() as u32,
     )
     .expect("unable to created shared memory");
 
     // All the channels we've stored in the shared memory.
-    let mut chans = Vec::with_capacity(MAX_CHANS * labels.len());
+    let mut chans = Vec::with_capacity(MAX_CHANS as usize * labels.len());
 
     let rng = Rng;
 
@@ -119,33 +116,26 @@ fn test_many_nodes() {
 
             // Now check that all previously added nodes
             // exist and are correct.
-            for (j, want) in chans.iter().enumerate().by_ref() {
-                let idx = Index(j);
+            for (idx, want) in chans.iter().enumerate().by_ref() {
+                let id = want.id;
 
-                // Check with and without a hint.
-                for hint in [None, Some(idx)] {
-                    let id = want.id;
+                let got = afc.inner.shm().arena().unwrap().get(id.into()).unwrap();
+                // .unwrap_or_else(|err| panic!("find_chan({id}, {hint:?}): {err}"))
+                // .unwrap_or_else(|| panic!("find_chan({id}, {hint:?}) returned `None`"));
 
-                    let (got, got_idx) = afc
-                        .inner
-                        .find_chan(id, hint)
-                        .unwrap_or_else(|err| panic!("find_chan({id}, {hint:?}): {err}"))
-                        .unwrap_or_else(|| panic!("find_chan({id}, {hint:?}) returned `None`"));
+                // assert_eq!(got_idx, idx, "{idx:?}");
 
-                    assert_eq!(got_idx, idx, "{idx:?}");
+                got.check().expect("not corrupted");
 
-                    assert_eq!(got.magic, ShmChan::<<E as Engine>::CS>::MAGIC, "{idx:?}");
+                // let got_id = got
+                //     .id()
+                //     .unwrap_or_else(|err| panic!("unable to get channel for chan {idx:?}: {err}"));
+                // assert_eq!(got_id, want.id, "{idx:?}");
 
-                    let got_id = got.id().unwrap_or_else(|err| {
-                        panic!("unable to get channel for chan {idx:?}: {err}")
-                    });
-                    assert_eq!(got_id, want.id, "{idx:?}");
-
-                    let got_secret = got
-                        .keys()
-                        .unwrap_or_else(|err| panic!("unable to get keys: {err}"));
-                    assert_eq!(got_secret, want.keys.as_ref(), "{idx:?}");
-                }
+                let got_secret = got
+                    .keys()
+                    .unwrap_or_else(|err| panic!("unable to get keys: {err}"));
+                assert_eq!(got_secret, want.keys.as_ref(), "{idx:?}");
             }
         }
     }

--- a/crates/aranya-fast-channels/src/shm/write.rs
+++ b/crates/aranya-fast-channels/src/shm/write.rs
@@ -1,14 +1,13 @@
-use core::{cell::Cell, marker::PhantomData, sync::atomic::Ordering};
+use core::{cell::Cell, marker::PhantomData};
 
 use aranya_crypto::{
     CipherSuite, Csprng, DeviceId,
     afc::{RawOpenKey, RawSealKey},
     policy::LabelId,
 };
-use buggy::BugExt as _;
 
 use super::{
-    error::{Corrupted, Error, corrupted},
+    error::Error,
     path::{Flag, Mode, Path},
     shared::{ShmChan, State},
 };
@@ -16,14 +15,12 @@ use super::{
 use crate::features::*;
 use crate::{
     RemoveIfParams,
-    shm::shared::Op,
     state::{AranyaState, Directed, LocalChannelId},
-    util::debug,
 };
 
 /// The writer's view of the shared memory state.
 #[derive(Debug)]
-pub struct WriteState<CS, R> {
+pub struct WriteState<CS: CipherSuite, R> {
     inner: State<CS>,
     rng: R,
 
@@ -37,7 +34,7 @@ where
     R: Csprng,
 {
     /// Open the state at `path`.
-    pub fn open<P>(path: P, flag: Flag, mode: Mode, max_chans: usize, rng: R) -> Result<Self, Error>
+    pub fn open<P>(path: P, flag: Flag, mode: Mode, max_chans: u32, rng: R) -> Result<Self, Error>
     where
         P: AsRef<Path>,
     {
@@ -65,188 +62,46 @@ where
         label_id: LabelId,
         peer_id: DeviceId,
     ) -> Result<LocalChannelId, Error> {
-        let id = {
-            // NB: This cannot reasonably overflow.
-            let next = self.inner.shm().next_chan_id.fetch_add(1, Ordering::SeqCst);
-            LocalChannelId::new(next)
-        };
-
-        let (write_off, idx) = {
-            let off = self.inner.write_off(self.inner.shm())?;
-            // Load state after loading the write offset because
-            // of borrowing rules.
-            let mut side = self.inner.shm().side(off)?.lock().assume("poisoned")?;
-
-            if side.len >= side.cap {
-                // We're out of space.
-                return Err(Error::OutOfSpace);
-            }
-
-            let idx = usize::try_from(side.len)
-                .map_err(|_| corrupted("`side.len` larger than `usize::MAX`"))?;
-            let chan = side.raw_at(idx)?;
-            debug!("adding chan {id} at {idx}");
-
-            ShmChan::<CS>::init(chan, id, label_id, peer_id, &keys, &self.rng);
-
-            let generation = side.generation.fetch_add(1, Ordering::AcqRel);
-            debug!("write side generation={}", generation + 1);
-
-            // We've updated the generation and the channel, so
-            // we're now free to grow the list.
-            side.len += 1;
-            assert!(side.len <= side.cap);
-            debug!("write side len={}", side.len);
-
-            (off, idx)
-        };
-
-        let read_off = {
-            // Swap the pointers: the reader will now see the
-            // updated list.
-            let off = self.inner.swap_offsets(self.inner.shm(), write_off)?;
-            let mut side = self.inner.shm().side(off)?.lock().assume("poisoned")?;
-
-            ShmChan::<CS>::init(side.raw_at(idx)?, id, label_id, peer_id, &keys, &self.rng);
-
-            let generation = side.generation.fetch_add(1, Ordering::AcqRel);
-            debug!("read side generation={}", generation + 1);
-
-            // We've updated the generation and the channel, so
-            // we're now free to grow the list.
-            side.len += 1;
-            assert!(side.len <= side.cap);
-            debug!("read side len={}", side.len);
-
-            off
-        };
-
-        self.inner
+        let idx = self
+            .inner
             .shm()
-            .write_off
-            .store(read_off.into(), Ordering::SeqCst);
+            .arena()?
+            .add(ShmChan::new(label_id, peer_id, &keys, &self.rng))
+            .map_err(|_| Error::OutOfSpace)?; // TODO: More precise?
 
-        Ok(id)
+        Ok(idx.into())
     }
 
     fn remove(&self, id: LocalChannelId) -> Result<(), Error> {
-        let (write_off, idx) = {
-            let off = self.inner.write_off(self.inner.shm())?;
-            // Load state after loading the write offset because
-            // borrowing rules.
-            let mut side = self.inner.shm().side(off)?.lock().assume("poisoned")?;
-            if side.len == 0 {
-                return Ok(());
-            }
-
-            let idx = match side
-                .try_iter_mut()?
-                .enumerate()
-                .try_find(|(_, chan)| Ok::<bool, Corrupted>(chan.id()? == id))?
-            {
-                Some((i, _)) => i,
-                // The channel wasn't found.
-                None => return Ok(()),
-            };
-            debug!("removing chan at {idx}");
-
-            // As a precaution, update the generation before we
-            // do anything else.
-            let generation = side.generation.fetch_add(1, Ordering::AcqRel);
-            debug!("write side generation={}", generation + 1);
-
-            // side[i] = side[side.len-1]
-            side.swap_remove(idx)?;
-            debug!("write side len={}", side.len);
-
-            (off, idx)
-        };
-
-        let read_off = {
-            // Swap the pointers: the reader will now see the
-            // updated list.
-            let off = self.inner.swap_offsets(self.inner.shm(), write_off)?;
-            let mut side = self.inner.shm().side(off)?.lock().assume("poisoned")?;
-
-            // As a precaution, update the generation before we
-            // do anything else.
-            let generation = side.generation.fetch_add(1, Ordering::AcqRel);
-            debug!("read side generation={}", generation + 1);
-
-            // side[i] = side[side.len-1]
-            side.swap_remove(idx)?;
-            debug!("read side len={}", side.len);
-
-            off
-        };
-
         self.inner
             .shm()
-            .write_off
-            .store(read_off.into(), Ordering::SeqCst);
-
-        Ok(())
+            .arena()?
+            .remove(id.into())
+            .map_err(|_| Error::NotFound(id)) // TODO: More precise?
     }
 
     fn remove_all(&self) -> Result<(), Self::Error> {
-        let shm = self.inner.shm();
-
-        let write_off = {
-            let off = self.inner.write_off(shm)?;
-            shm.side(off)?.lock().assume("poisoned")?.clear();
-            off
-        };
-
-        let read_off = {
-            // Swap the pointers: the reader will now see the
-            // updated list.
-            let off = self.inner.swap_offsets(shm, write_off)?;
-            shm.side(off)?.lock().assume("poisoned")?.clear();
-            off
-        };
-
-        shm.write_off.store(read_off.into(), Ordering::SeqCst);
-
+        self.inner
+            .shm()
+            .arena()?
+            .clear()
+            .map_err(|_| -> Error { todo!() })?;
         Ok(())
     }
 
     fn remove_if(&self, mut f: impl FnMut(RemoveIfParams) -> bool) -> Result<(), Self::Error> {
-        let shm = self.inner.shm();
-
-        let write_off = {
-            let off = self.inner.write_off(shm)?;
-            // Load state after loading the write offset because
-            // borrowing rules.
-            let mut side = shm.side(off)?.lock().assume("poisoned")?;
-            if side.len == 0 {
-                return Ok(());
-            }
-            side.remove_if(&mut f)?;
-            off
-        };
-
-        let read_off = {
-            // Swap the pointers: the reader will now see the
-            // updated list.
-            let off = self.inner.swap_offsets(shm, write_off)?;
-            let mut side = shm.side(off)?.lock().assume("poisoned")?;
-
-            // It's only possible to get here if `side.len > 0`.
-            debug_assert!(side.len > 0);
-
-            side.remove_if(&mut f)?;
-
-            off
-        };
-
-        shm.write_off.store(read_off.into(), Ordering::SeqCst);
-
+        self.inner
+            .shm()
+            .arena()?
+            .retain(|idx, chan| match chan.remove_if_params(idx) {
+                Ok(params) => !f(params),
+                Err(_corrupted) => true,
+            })
+            .map_err(|_| -> Error { todo!() })?;
         Ok(())
     }
 
     fn exists(&self, id: LocalChannelId) -> Result<bool, Self::Error> {
-        let mutex = self.inner.load_write_list()?;
-        let list = mutex.lock().assume("poisoned")?;
-        list.exists(id, None, Op::Any)
+        Ok(self.inner.shm().arena()?.get(id.into()).is_some())
     }
 }

--- a/crates/aranya-fast-channels/src/state.rs
+++ b/crates/aranya-fast-channels/src/state.rs
@@ -19,18 +19,8 @@ pub trait AfcState {
     /// Used to encrypt/decrypt messages.
     type CipherSuite: CipherSuite;
 
-    /// Associated seal channel context.
-    ///
-    /// This state must be maintaned for as long as you use a given channel.
-    type SealCtx;
-
-    /// Sets up the seal context for a given channel.
-    ///
-    /// This must only be called once for any `id`.
-    fn setup_seal_ctx(&self, id: LocalChannelId) -> Result<Self::SealCtx, Error>;
-
     /// Invokes `f` with the channel's encryption key.
-    fn seal<F, T>(&self, ctx: &mut Self::SealCtx, f: F) -> Result<Result<T, Error>, Error>
+    fn seal<F, T>(&self, id: LocalChannelId, f: F) -> Result<Result<T, Error>, Error>
     where
         F: FnOnce(&mut SealKey<Self::CipherSuite>, LabelId) -> Result<T, Error>;
 
@@ -348,17 +338,12 @@ mod test {
         CS: CipherSuite,
     {
         type CipherSuite = CS;
-        type SealCtx = <memory::State<CS> as AfcState>::SealCtx;
 
-        fn setup_seal_ctx(&self, id: LocalChannelId) -> Result<Self::SealCtx, Error> {
-            self.state.setup_seal_ctx(id)
-        }
-
-        fn seal<F, T>(&self, ctx: &mut Self::SealCtx, f: F) -> Result<Result<T, Error>, Error>
+        fn seal<F, T>(&self, id: LocalChannelId, f: F) -> Result<Result<T, Error>, Error>
         where
             F: FnOnce(&mut SealKey<Self::CipherSuite>, LabelId) -> Result<T, Error>,
         {
-            self.state.seal(ctx, f)
+            self.state.seal(id, f)
         }
 
         fn open<F, T>(&self, id: LocalChannelId, f: F) -> Result<Result<T, Error>, Error>

--- a/crates/aranya-fast-channels/src/state.rs
+++ b/crates/aranya-fast-channels/src/state.rs
@@ -135,6 +135,18 @@ impl fmt::Display for LocalChannelId {
     }
 }
 
+impl From<LocalChannelId> for crate::arena::Index {
+    fn from(id: LocalChannelId) -> Self {
+        unsafe { core::mem::transmute::<u64, Self>(id.to_u64()) }
+    }
+}
+
+impl From<crate::arena::Index> for LocalChannelId {
+    fn from(idx: crate::arena::Index) -> Self {
+        Self::new(unsafe { core::mem::transmute::<crate::arena::Index, u64>(idx) })
+    }
+}
+
 /// An AFC channel.
 #[derive(Copy, Clone)]
 #[derive_where(Debug)]
@@ -399,7 +411,7 @@ mod test {
         fn new_states<CS: CipherSuite>(
             _name: &str,
             _device_idx: DeviceIdx,
-            _max_chans: usize,
+            _max_chans: u32,
         ) -> States<Self::Afc<CS>, Self::Aranya<CS>> {
             let afc = DefaultState::<CS>::new();
             let aranya = afc.clone();

--- a/crates/aranya-fast-channels/src/state.rs
+++ b/crates/aranya-fast-channels/src/state.rs
@@ -24,18 +24,10 @@ pub trait AfcState {
     /// This state must be maintaned for as long as you use a given channel.
     type SealCtx;
 
-    /// Associated seal channel context.
-    ///
-    /// This state must be maintaned for as long as you use a given channel.
-    type OpenCtx;
-
     /// Sets up the seal context for a given channel.
     ///
     /// This must only be called once for any `id`.
     fn setup_seal_ctx(&self, id: LocalChannelId) -> Result<Self::SealCtx, Error>;
-
-    /// Sets up the open context for a given channel.
-    fn setup_open_ctx(&self, id: LocalChannelId) -> Result<Self::OpenCtx, Error>;
 
     /// Invokes `f` with the channel's encryption key.
     fn seal<F, T>(&self, ctx: &mut Self::SealCtx, f: F) -> Result<Result<T, Error>, Error>
@@ -43,7 +35,7 @@ pub trait AfcState {
         F: FnOnce(&mut SealKey<Self::CipherSuite>, LabelId) -> Result<T, Error>;
 
     /// Invokes `f` with the channel's decryption key.
-    fn open<F, T>(&self, ctx: &mut Self::OpenCtx, f: F) -> Result<Result<T, Error>, Error>
+    fn open<F, T>(&self, id: LocalChannelId, f: F) -> Result<Result<T, Error>, Error>
     where
         F: FnOnce(&OpenKey<Self::CipherSuite>, LabelId) -> Result<T, Error>;
 
@@ -357,14 +349,9 @@ mod test {
     {
         type CipherSuite = CS;
         type SealCtx = <memory::State<CS> as AfcState>::SealCtx;
-        type OpenCtx = <memory::State<CS> as AfcState>::OpenCtx;
 
         fn setup_seal_ctx(&self, id: LocalChannelId) -> Result<Self::SealCtx, Error> {
             self.state.setup_seal_ctx(id)
-        }
-
-        fn setup_open_ctx(&self, id: LocalChannelId) -> Result<Self::OpenCtx, Error> {
-            self.state.setup_open_ctx(id)
         }
 
         fn seal<F, T>(&self, ctx: &mut Self::SealCtx, f: F) -> Result<Result<T, Error>, Error>
@@ -374,7 +361,7 @@ mod test {
             self.state.seal(ctx, f)
         }
 
-        fn open<F, T>(&self, id: &mut Self::OpenCtx, f: F) -> Result<Result<T, Error>, Error>
+        fn open<F, T>(&self, id: LocalChannelId, f: F) -> Result<Result<T, Error>, Error>
         where
             F: FnOnce(&OpenKey<Self::CipherSuite>, LabelId) -> Result<T, Error>,
         {

--- a/crates/aranya-fast-channels/src/testing/mod.rs
+++ b/crates/aranya-fast-channels/src/testing/mod.rs
@@ -32,8 +32,7 @@ use crate::{
     error::Error,
     header::DataHeader,
     testing::util::{
-        Aranya, ChanOp, DataHeaderBuilder, Device, DeviceIdx, GlobalChannelId, LimitedAead,
-        TestEngine, TestImpl,
+        Aranya, ChanOp, DataHeaderBuilder, Device, DeviceIdx, LimitedAead, TestEngine, TestImpl,
     },
 };
 
@@ -141,10 +140,7 @@ pub fn test_seal_open_basic<T: TestImpl, A: Aead>() {
             let d1_channel_id = d1.get_local_channel_id(global_id).unwrap_or_else(|| {
                 panic!("device {id1} should have channel for global_id {global_id:?}")
             });
-
-            let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
-
-            c1.seal(&mut ctx, &mut dst[..], GOLDEN.as_bytes())
+            c1.seal(d1_channel_id, &mut dst[..], GOLDEN.as_bytes())
                 .unwrap_or_else(|err| panic!("seal({id2}, ...): {err}"));
             dst
         };
@@ -153,7 +149,6 @@ pub fn test_seal_open_basic<T: TestImpl, A: Aead>() {
             let d2_channel_id = d2.get_local_channel_id(global_id).unwrap_or_else(|| {
                 panic!("device {id2} should have channel for global_id {global_id:?}")
             });
-
             let (_, seq) = c2
                 .open(d2_channel_id, &mut dst[..], &ciphertext[..])
                 .unwrap_or_else(|err| panic!("open({id1}, ...): {err}"));
@@ -184,8 +179,7 @@ pub fn test_seal_open_in_place_basic<T: TestImpl, A: Aead>() {
             let d1_channel_id = d1.get_local_channel_id(global_id).unwrap_or_else(|| {
                 panic!("device {id1} should have channel for global_id {global_id:?}")
             });
-            let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
-            c1.seal_in_place(&mut ctx, &mut data)
+            c1.seal_in_place(d1_channel_id, &mut data)
                 .unwrap_or_else(|err| panic!("seal_in_place({id2}, ...): {err}"));
             data
         };
@@ -194,7 +188,6 @@ pub fn test_seal_open_in_place_basic<T: TestImpl, A: Aead>() {
             let d2_channel_id = d2.get_local_channel_id(global_id).unwrap_or_else(|| {
                 panic!("device {id2} should have channel for global_id {global_id:?}")
             });
-
             let (_, seq) = c2
                 .open_in_place(d2_channel_id, &mut data)
                 .unwrap_or_else(|err| panic!("open_in_place({id1}, ...): {err}"));
@@ -234,14 +227,13 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
 
     const GOLDEN: &str = "hello, world!";
 
-    fn test<T: TestImpl, CS: CipherSuite>(
-        clients: &mut [Client<T::Afc<CS>>],
+    fn test<T: TestImpl, S: AfcState, CS: CipherSuite>(
+        clients: &mut [Client<S>],
         devices: &[Device<T, CS>],
         send: DeviceIdx,
         recv: DeviceIdx,
         label_id: LabelId,
         seqs: &mut HashMap<(DeviceIdx, DeviceIdx, LabelId), u64>,
-        ctxs: &mut HashMap<(DeviceIdx, GlobalChannelId), <T::Afc<CS> as AfcState>::SealCtx>,
     ) {
         let (global_id, label_id) = {
             let send_device = devices.get(send).expect("device to exist");
@@ -272,10 +264,7 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
                 .unwrap_or_else(|| {
                     panic!("send device should have channel for global_id {global_id:?}")
                 });
-            let ctx = ctxs
-                .entry((send, global_id))
-                .or_insert_with(|| u0.setup_seal_ctx(send_channel_id).expect("can set up ctx"));
-            u0.seal(ctx, &mut dst[..], GOLDEN.as_bytes())
+            u0.seal(send_channel_id, &mut dst[..], GOLDEN.as_bytes())
                 .unwrap_or_else(|err| panic!("{label_id}: seal({recv}, ...): {err}"));
             dst
         };
@@ -292,7 +281,6 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
                 .unwrap_or_else(|| {
                     panic!("recv device should have channel for global_id {global_id:?}")
                 });
-
             let (_, seq) = u1
                 .open(recv_channel_id, &mut dst[..], &ciphertext[..])
                 .unwrap_or_else(|err| panic!("{label_id}: open({send}, ...): {err}"));
@@ -303,7 +291,6 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
     }
 
     let mut seqs = HashMap::new();
-    let mut ctxs = HashMap::new();
 
     for label_id in label_ids {
         for a in &device_idxs {
@@ -312,24 +299,8 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
                     continue;
                 }
 
-                test(
-                    &mut clients,
-                    &d.devices,
-                    *a,
-                    *b,
-                    label_id,
-                    &mut seqs,
-                    &mut ctxs,
-                );
-                test(
-                    &mut clients,
-                    &d.devices,
-                    *b,
-                    *a,
-                    label_id,
-                    &mut seqs,
-                    &mut ctxs,
-                );
+                test(&mut clients, &d.devices, *a, *b, label_id, &mut seqs);
+                test(&mut clients, &d.devices, *b, *a, label_id, &mut seqs);
             }
         }
     }
@@ -357,13 +328,10 @@ pub fn test_remove<T: TestImpl, A: Aead>() {
             let device_channel_id = device.get_local_channel_id(global_id).unwrap_or_else(|| {
                 panic!("device should have channel for global_id {global_id:?}")
             });
-
-            let mut seal_ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
-
             let ciphertext = {
                 let mut data = Vec::with_capacity(GOLDEN.len() + overhead(&c1));
                 data.extend_from_slice(GOLDEN.as_bytes());
-                c1.seal_in_place(&mut seal_ctx, &mut data)
+                c1.seal_in_place(d1_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("seal_in_place({id}, ...): {err}"));
                 data
             };
@@ -386,7 +354,7 @@ pub fn test_remove<T: TestImpl, A: Aead>() {
             let err = {
                 let mut data = Vec::with_capacity(GOLDEN.len() + overhead(&c1));
                 data.extend_from_slice(GOLDEN.as_bytes());
-                c1.seal_in_place(&mut seal_ctx, &mut data)
+                c1.seal_in_place(d1_channel_id, &mut data)
                     .err()
                     .unwrap_or_else(|| panic!("seal_in_place({id}) should panic"))
             };
@@ -408,8 +376,6 @@ pub fn test_remove_all<T: TestImpl, A: Aead>() {
     let d2 = d.devices.get(id2).expect("device to exist");
     let d3 = d.devices.get(id3).expect("device to exist");
 
-    let mut ctxs = HashMap::new();
-
     const GOLDEN: &str = "hello, world!";
     for (c, id, device) in [(&c2, id2, d2), (&c3, id3, d3)] {
         for (global_id, label_id) in d1.common_channels(device) {
@@ -422,16 +388,12 @@ pub fn test_remove_all<T: TestImpl, A: Aead>() {
             let ciphertext = {
                 let mut data = Vec::with_capacity(GOLDEN.len() + overhead(&c1));
                 data.extend_from_slice(GOLDEN.as_bytes());
-                let ctx = ctxs
-                    .entry((id1, global_id))
-                    .or_insert_with(|| c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx"));
-                c1.seal_in_place(ctx, &mut data)
+                c1.seal_in_place(d1_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("seal_in_place({id}, ...): {err}"));
                 data
             };
             let (plaintext, got_seq) = {
                 let mut data = ciphertext.clone();
-
                 let (_, seq) = c
                     .open_in_place(device_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("open_in_place({id1}, ...): {err}"));
@@ -456,12 +418,11 @@ pub fn test_remove_all<T: TestImpl, A: Aead>() {
             let err = {
                 let mut data = Vec::with_capacity(GOLDEN.len() + overhead(&c1));
                 data.extend_from_slice(GOLDEN.as_bytes());
-                let ctx = ctxs
-                    .get_mut(&(id1, global_id))
-                    .expect("to have called `seal` before");
-                c1.seal_in_place(ctx, &mut data).err().unwrap_or_else(|| {
-                    panic!("seal_in_place({d1_channel_id} {label_id} should panic")
-                })
+                c1.seal_in_place(d1_channel_id, &mut data)
+                    .err()
+                    .unwrap_or_else(|| {
+                        panic!("seal_in_place({d1_channel_id} {label_id} should panic")
+                    })
             };
             assert_eq!(err, Error::NotFound(d1_channel_id));
         }
@@ -481,8 +442,6 @@ pub fn test_remove_if<T: TestImpl, A: Aead>() {
     let d2 = d.devices.get(id2).expect("device to exist");
     let d3 = d.devices.get(id3).expect("device to exist");
 
-    let mut ctxs = HashMap::new();
-
     const GOLDEN: &str = "hello, world!";
     for (c, id, device) in [(&c2, id2, d2), (&c3, id3, d3)] {
         for (global_id, label_id) in d1.common_channels(device) {
@@ -495,10 +454,7 @@ pub fn test_remove_if<T: TestImpl, A: Aead>() {
             let ciphertext = {
                 let mut data = Vec::with_capacity(GOLDEN.len() + overhead(&c1));
                 data.extend_from_slice(GOLDEN.as_bytes());
-                let ctx = ctxs
-                    .entry((id1, global_id))
-                    .or_insert_with(|| c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx"));
-                c1.seal_in_place(ctx, &mut data)
+                c1.seal_in_place(d1_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("seal_in_place({id}, ...): {err}"));
                 data
             };
@@ -527,10 +483,7 @@ pub fn test_remove_if<T: TestImpl, A: Aead>() {
             let err = {
                 let mut data = Vec::with_capacity(GOLDEN.len() + overhead(&c1));
                 data.extend_from_slice(GOLDEN.as_bytes());
-                let ctx = ctxs
-                    .get_mut(&(id1, global_id))
-                    .expect("to have called `seal` before");
-                c1.seal_in_place(ctx, &mut data)
+                c1.seal_in_place(d1_channel_id, &mut data)
                     .err()
                     .unwrap_or_else(|| panic!("seal_in_place({id}) should panic"))
             };
@@ -539,12 +492,12 @@ pub fn test_remove_if<T: TestImpl, A: Aead>() {
             // Test that other channel still works
             if id == id2 {
                 for (global_id, _label_id) in d1.common_channels(d3) {
+                    let d1_channel_id = d1.get_local_channel_id(global_id).unwrap_or_else(|| {
+                        panic!("device should have channel for global_id {global_id:?}")
+                    });
                     let mut data: Vec<u8> = Vec::with_capacity(GOLDEN.len() + overhead(&c1));
                     data.extend_from_slice(GOLDEN.as_bytes());
-                    let ctx = ctxs
-                        .get_mut(&(id1, global_id))
-                        .expect("to have called `seal` before");
-                    c1.seal_in_place(ctx, &mut data)
+                    c1.seal_in_place(d1_channel_id, &mut data)
                         .unwrap_or_else(|err| panic!("seal_in_place({id3}, ...): {err}"));
                 }
             }
@@ -565,8 +518,6 @@ pub fn test_remove_no_channels<T: TestImpl, A: Aead>() {
     let d2 = d.devices.get(id2).expect("device to exist");
     let d3 = d.devices.get(id3).expect("device to exist");
 
-    let mut ctxs = HashMap::new();
-
     const GOLDEN: &str = "hello, world!";
     for (c, id, device) in [(&c2, id2, d2), (&c3, id3, d3)] {
         for (global_id, label_id) in d1.common_channels(device) {
@@ -579,10 +530,7 @@ pub fn test_remove_no_channels<T: TestImpl, A: Aead>() {
             let ciphertext = {
                 let mut data = Vec::with_capacity(GOLDEN.len() + overhead(&c1));
                 data.extend_from_slice(GOLDEN.as_bytes());
-                let ctx = ctxs
-                    .entry((id1, global_id))
-                    .or_insert_with(|| c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx"));
-                c1.seal_in_place(ctx, &mut data)
+                c1.seal_in_place(d1_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("seal_in_place({id}, ...): {err}"));
                 data
             };
@@ -617,10 +565,7 @@ pub fn test_remove_no_channels<T: TestImpl, A: Aead>() {
         let err = {
             let mut data = Vec::with_capacity(GOLDEN.len() + overhead(&c1));
             data.extend_from_slice(GOLDEN.as_bytes());
-            let ctx = ctxs
-                .get_mut(&(id1, global_id))
-                .expect("to have called `seal` before");
-            c1.seal_in_place(ctx, &mut data)
+            c1.seal_in_place(d1_channel_id, &mut data)
                 .err()
                 .unwrap_or_else(|| panic!("seal_in_place({d1_channel_id},{label_id}) should panic"))
         };
@@ -654,8 +599,7 @@ pub fn test_channels_exist<T: TestImpl, A: Aead>() {
             let ciphertext = {
                 let mut data = Vec::with_capacity(GOLDEN.len() + overhead(&c1));
                 data.extend_from_slice(GOLDEN.as_bytes());
-                let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
-                c1.seal_in_place(&mut ctx, &mut data)
+                c1.seal_in_place(d1_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("seal_in_place({id}, ...): {err}"));
                 data
             };
@@ -734,8 +678,7 @@ pub fn test_channels_not_exist<T: TestImpl, A: Aead>() {
             let ciphertext = {
                 let mut data = Vec::with_capacity(GOLDEN.len() + overhead(&c1));
                 data.extend_from_slice(GOLDEN.as_bytes());
-                let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
-                c1.seal_in_place(&mut ctx, &mut data)
+                c1.seal_in_place(d1_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("seal_in_place({id}, ...): {err}"));
                 data
             };
@@ -795,8 +738,7 @@ pub fn test_issue112<T: TestImpl, A: Aead>() {
             let len = GOLDEN.len() + overhead(&c1) + 100;
             let mut dst = vec![0u8; len];
             let mut buf = FixedBuf::from_slice_mut(&mut dst, len).expect("dst should be <= len");
-            let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
-            c1.seal(&mut ctx, &mut buf, GOLDEN.as_bytes())
+            c1.seal(d1_channel_id, &mut buf, GOLDEN.as_bytes())
                 .unwrap_or_else(|err| panic!("seal({id2}, ...): {err}"));
             dst.truncate(GOLDEN.len() + overhead(&c1));
             dst
@@ -859,8 +801,7 @@ pub fn test_unidirectional_basic<T: TestImpl, A: Aead>() {
         });
         let ciphertext = {
             let mut dst = vec![0u8; GOLDEN.len() + overhead(c1)];
-            let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
-            c1.seal( &mut ctx, &mut dst[..], GOLDEN.as_bytes())
+            c1.seal(d1_channel_id, &mut dst[..], GOLDEN.as_bytes())
                 .unwrap_or_else(|err| panic!("({id1}->{id2}) seal(channel_id: {d1_channel_id}, label_id: {label_id} ...): {err}"));
             dst
         };
@@ -935,9 +876,8 @@ pub fn test_unidirectional_exhaustive<T: TestImpl, A: Aead>() {
                 panic!("device {id1} should have channel for global_id {global_id:?}")
             });
             let mut dst = vec![0u8; overhead(c1)];
-            let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
             let err = c1
-                .seal(&mut ctx, &mut dst[..], &[])
+                .seal(d1_channel_id, &mut dst[..], &[])
                 .err()
                 .unwrap_or_else(|| panic!("{id1}::seal({id2}, ...): expected an error"));
             assert_eq!(err, Error::NotFound(d1_channel_id));
@@ -968,8 +908,7 @@ pub fn test_unidirectional_exhaustive<T: TestImpl, A: Aead>() {
         });
         let ciphertext = {
             let mut dst = vec![0u8; GOLDEN.len() + overhead(c1)];
-            let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
-            c1.seal(&mut ctx, &mut dst[..], GOLDEN.as_bytes())
+            c1.seal(d1_channel_id, &mut dst[..], GOLDEN.as_bytes())
                 .unwrap_or_else(|err| panic!("{id1}::seal({id2}, ...): {err}"));
             dst
         };
@@ -1129,8 +1068,6 @@ pub fn test_key_expiry<T: TestImpl, A: Aead>() {
     let d1 = d.devices.get(id1).expect("device to exist");
     let d2 = d.devices.get(id2).expect("device to exist");
 
-    let mut ctxs = HashMap::new();
-
     const GOLDEN: &str = "hello, world!";
 
     // From HPKE: 2^n - 1 where n = nonce length in bytes.
@@ -1148,10 +1085,7 @@ pub fn test_key_expiry<T: TestImpl, A: Aead>() {
             let ciphertext = {
                 let mut dst = vec![0u8; GOLDEN.len() + overhead(&c1)];
 
-                let ctx = ctxs
-                    .entry((id1, global_id))
-                    .or_insert_with(|| c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx"));
-                let res = c1.seal(ctx, &mut dst[..], GOLDEN.as_bytes());
+                let res = c1.seal(d1_channel_id, &mut dst[..], GOLDEN.as_bytes());
                 if seq < seq_max {
                     res.unwrap_or_else(|err| panic!("{seq}: seal({d1_channel_id}, ...): {err}"));
                     dst
@@ -1207,8 +1141,7 @@ pub fn test_open_truncated_tag<T: TestImpl, A: Aead>() {
         });
         let ciphertext = {
             let mut dst = vec![0u8; GOLDEN.len() + overhead(&c1)];
-            let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
-            c1.seal(&mut ctx, &mut dst[..], GOLDEN.as_bytes())
+            c1.seal(d1_channel_id, &mut dst[..], GOLDEN.as_bytes())
                 .unwrap_or_else(|err| panic!("seal({d1_channel_id}, ...): {err}"));
             // Remove the first byte in the tag.
             dst.remove(GOLDEN.len());
@@ -1245,8 +1178,7 @@ pub fn test_open_modified_tag<T: TestImpl, A: Aead>() {
         });
         let ciphertext = {
             let mut dst = vec![0u8; GOLDEN.len() + overhead(&c1)];
-            let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
-            c1.seal(&mut ctx, &mut dst[..], GOLDEN.as_bytes())
+            c1.seal(d1_channel_id, &mut dst[..], GOLDEN.as_bytes())
                 .unwrap_or_else(|err| panic!("seal({id2}, ...): {err}"));
             dst[GOLDEN.len()] = dst[GOLDEN.len()].wrapping_add(1);
             dst
@@ -1282,8 +1214,7 @@ pub fn test_open_different_seq<T: TestImpl, A: Aead>() {
         });
         let ciphertext = {
             let mut dst = vec![0u8; GOLDEN.len() + overhead(&c1)];
-            let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
-            c1.seal(&mut ctx, &mut dst[..], GOLDEN.as_bytes())
+            c1.seal(d1_channel_id, &mut dst[..], GOLDEN.as_bytes())
                 .unwrap_or_else(|err| panic!("seal({id2}, ...): {err}"));
 
             // Rewrite the header to use a different sequence
@@ -1341,9 +1272,8 @@ pub fn test_seal_unknown_channel_label<T: TestImpl, A: Aead>() {
         });
         let ciphertext = {
             let mut dst = vec![0u8; GOLDEN.len() + overhead(&c1)];
-            let mut ctx = c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx");
 
-            let res = c1.seal(&mut ctx, &mut dst[..], GOLDEN.as_bytes());
+            let res = c1.seal(d1_channel_id, &mut dst[..], GOLDEN.as_bytes());
             if open_labels.contains(&label_id) {
                 res.unwrap_or_else(|err| panic!("seal({d1_channel_id}, ...): {err}"));
                 dst
@@ -1382,8 +1312,6 @@ pub fn test_monotonic_seq_by_one<T: TestImpl, A: Aead>() {
     let d1 = d.devices.get(id1).expect("device to exist");
     let d2 = d.devices.get(id2).expect("device to exist");
 
-    let mut ctxs = HashMap::new();
-
     const GOLDEN: &str = "hello, world!";
 
     // From HPKE: 2^n - 1 where n = nonce length in bytes.
@@ -1400,10 +1328,7 @@ pub fn test_monotonic_seq_by_one<T: TestImpl, A: Aead>() {
             });
             let ciphertext = {
                 let mut dst = vec![0u8; GOLDEN.len() + overhead(&c1)];
-                let ctx = ctxs
-                    .entry((id1, global_id))
-                    .or_insert_with(|| c1.setup_seal_ctx(d1_channel_id).expect("can set up ctx"));
-                c1.seal(ctx, &mut dst[..], GOLDEN.as_bytes())
+                c1.seal(d1_channel_id, &mut dst[..], GOLDEN.as_bytes())
                     .unwrap_or_else(|err| panic!("seal({d1_channel_id}, ...): {err}"));
                 dst
             };

--- a/crates/aranya-fast-channels/src/testing/mod.rs
+++ b/crates/aranya-fast-channels/src/testing/mod.rs
@@ -128,7 +128,7 @@ pub fn test_seal_open_basic<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
     let mut d = Aranya::<T, _>::new("test_seal_open_basic", label_ids.len() * 2, eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
     let d1 = d.devices.get(id1).expect("device to exist");
@@ -154,9 +154,8 @@ pub fn test_seal_open_basic<T: TestImpl, A: Aead>() {
                 panic!("device {id2} should have channel for global_id {global_id:?}")
             });
 
-            let mut ctx = c2.setup_open_ctx(d2_channel_id).expect("can set up ctx");
             let (_, seq) = c2
-                .open(&mut ctx, &mut dst[..], &ciphertext[..])
+                .open(d2_channel_id, &mut dst[..], &ciphertext[..])
                 .unwrap_or_else(|err| panic!("open({id1}, ...): {err}"));
             (dst, seq)
         };
@@ -171,7 +170,7 @@ pub fn test_seal_open_in_place_basic<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
     let mut d = Aranya::<T, _>::new("test_seal_open_in_place_basic", label_ids.len() * 2, eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
     let d1 = d.devices.get(id1).expect("device to exist");
@@ -196,9 +195,8 @@ pub fn test_seal_open_in_place_basic<T: TestImpl, A: Aead>() {
                 panic!("device {id2} should have channel for global_id {global_id:?}")
             });
 
-            let mut ctx = c2.setup_open_ctx(d2_channel_id).expect("can set up ctx");
             let (_, seq) = c2
-                .open_in_place(&mut ctx, &mut data)
+                .open_in_place(d2_channel_id, &mut data)
                 .unwrap_or_else(|err| panic!("open_in_place({id1}, ...): {err}"));
             (data, seq)
         };
@@ -236,7 +234,6 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
 
     const GOLDEN: &str = "hello, world!";
 
-    #[allow(clippy::too_many_arguments)]
     fn test<T: TestImpl, CS: CipherSuite>(
         clients: &mut [Client<T::Afc<CS>>],
         devices: &[Device<T, CS>],
@@ -244,8 +241,7 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
         recv: DeviceIdx,
         label_id: LabelId,
         seqs: &mut HashMap<(DeviceIdx, DeviceIdx, LabelId), u64>,
-        seal_ctxs: &mut HashMap<(DeviceIdx, GlobalChannelId), <T::Afc<CS> as AfcState>::SealCtx>,
-        open_ctxs: &mut HashMap<(DeviceIdx, GlobalChannelId), <T::Afc<CS> as AfcState>::OpenCtx>,
+        ctxs: &mut HashMap<(DeviceIdx, GlobalChannelId), <T::Afc<CS> as AfcState>::SealCtx>,
     ) {
         let (global_id, label_id) = {
             let send_device = devices.get(send).expect("device to exist");
@@ -276,7 +272,7 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
                 .unwrap_or_else(|| {
                     panic!("send device should have channel for global_id {global_id:?}")
                 });
-            let ctx = seal_ctxs
+            let ctx = ctxs
                 .entry((send, global_id))
                 .or_insert_with(|| u0.setup_seal_ctx(send_channel_id).expect("can set up ctx"));
             u0.seal(ctx, &mut dst[..], GOLDEN.as_bytes())
@@ -297,11 +293,8 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
                     panic!("recv device should have channel for global_id {global_id:?}")
                 });
 
-            let ctx = open_ctxs
-                .entry((send, global_id))
-                .or_insert_with(|| u1.setup_open_ctx(recv_channel_id).expect("can set up ctx"));
             let (_, seq) = u1
-                .open(ctx, &mut dst[..], &ciphertext[..])
+                .open(recv_channel_id, &mut dst[..], &ciphertext[..])
                 .unwrap_or_else(|err| panic!("{label_id}: open({send}, ...): {err}"));
             (dst, seq)
         };
@@ -310,8 +303,7 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
     }
 
     let mut seqs = HashMap::new();
-    let mut seal_ctxs = HashMap::new();
-    let mut open_ctxs = HashMap::new();
+    let mut ctxs = HashMap::new();
 
     for label_id in label_ids {
         for a in &device_idxs {
@@ -327,8 +319,7 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
                     *b,
                     label_id,
                     &mut seqs,
-                    &mut seal_ctxs,
-                    &mut open_ctxs,
+                    &mut ctxs,
                 );
                 test(
                     &mut clients,
@@ -337,8 +328,7 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
                     *a,
                     label_id,
                     &mut seqs,
-                    &mut seal_ctxs,
-                    &mut open_ctxs,
+                    &mut ctxs,
                 );
             }
         }
@@ -350,7 +340,7 @@ pub fn test_remove<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
     let mut d = Aranya::<T, _>::new("test_remove", 2 * 3 * label_ids.len(), eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
 
@@ -379,9 +369,8 @@ pub fn test_remove<T: TestImpl, A: Aead>() {
             };
             let (plaintext, got_seq) = {
                 let mut data = ciphertext.clone();
-                let mut open_ctx = c.setup_open_ctx(device_channel_id).expect("can set up ctx");
                 let (_, seq) = c
-                    .open_in_place(&mut open_ctx, &mut data)
+                    .open_in_place(device_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("open_in_place({id1}, ...): {err}"));
                 (data, seq)
             };
@@ -411,7 +400,7 @@ pub fn test_remove_all<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
     let mut d = Aranya::<T, _>::new("test_remove_all", 2 * 3 * label_ids.len(), eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
 
@@ -443,9 +432,8 @@ pub fn test_remove_all<T: TestImpl, A: Aead>() {
             let (plaintext, got_seq) = {
                 let mut data = ciphertext.clone();
 
-                let mut open_ctx = c.setup_open_ctx(device_channel_id).expect("can set up ctx");
                 let (_, seq) = c
-                    .open_in_place(&mut open_ctx, &mut data)
+                    .open_in_place(device_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("open_in_place({id1}, ...): {err}"));
                 (data, seq)
             };
@@ -485,7 +473,7 @@ pub fn test_remove_if<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
     let mut d = Aranya::<T, _>::new("test_remove_if", 2 * 3 * label_ids.len(), eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
 
@@ -516,9 +504,8 @@ pub fn test_remove_if<T: TestImpl, A: Aead>() {
             };
             let (plaintext, got_seq) = {
                 let mut data = ciphertext.clone();
-                let mut open_ctx = c.setup_open_ctx(device_channel_id).expect("can set up ctx");
                 let (_, seq) = c
-                    .open_in_place(&mut open_ctx, &mut data)
+                    .open_in_place(device_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("open_in_place({id1}, ...): {err}"));
                 (data, seq)
             };
@@ -570,7 +557,7 @@ pub fn test_remove_no_channels<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
     let mut d = Aranya::<T, _>::new("test_remove_no_channels", 2 * 3 * label_ids.len(), eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
 
@@ -601,9 +588,8 @@ pub fn test_remove_no_channels<T: TestImpl, A: Aead>() {
             };
             let (plaintext, got_seq) = {
                 let mut data = ciphertext.clone();
-                let mut open_ctx = c.setup_open_ctx(device_channel_id).expect("can set up ctx");
                 let (_, seq) = c
-                    .open_in_place(&mut open_ctx, &mut data)
+                    .open_in_place(device_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("open_in_place({id1}, ...): {err}"));
                 (data, seq)
             };
@@ -647,7 +633,7 @@ pub fn test_channels_exist<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
     let mut d = Aranya::<T, _>::new("test_channels_exist", 2 * 3 * label_ids.len(), eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
 
@@ -675,9 +661,8 @@ pub fn test_channels_exist<T: TestImpl, A: Aead>() {
             };
             let (plaintext, got_seq) = {
                 let mut data = ciphertext.clone();
-                let mut open_ctx = c.setup_open_ctx(device_channel_id).expect("can set up ctx");
                 let (_, seq) = c
-                    .open_in_place(&mut open_ctx, &mut data)
+                    .open_in_place(device_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("open_in_place({id1}, ...): {err}"));
                 (data, seq)
             };
@@ -729,7 +714,7 @@ pub fn test_channels_not_exist<T: TestImpl, A: Aead>() {
     ];
 
     let mut d = Aranya::<T, _>::new("test_channels_not_exist", 2 * 3 * label_ids.len(), eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
 
@@ -756,9 +741,8 @@ pub fn test_channels_not_exist<T: TestImpl, A: Aead>() {
             };
             let (plaintext, got_seq) = {
                 let mut data = ciphertext.clone();
-                let mut open_ctx = c.setup_open_ctx(device_channel_id).expect("can set up ctx");
                 let (_, seq) = c
-                    .open_in_place(&mut open_ctx, &mut data)
+                    .open_in_place(device_channel_id, &mut data)
                     .unwrap_or_else(|err| panic!("open_in_place({id1}, ...): {err}"));
                 (data, seq)
             };
@@ -792,7 +776,7 @@ pub fn test_issue112<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_id = LabelId::random(&eng);
     let mut d = Aranya::<T, TestEngine<A>>::new("test_issue_112", 2, eng);
-    let (c1, id1) = d.new_client([label_id]);
+    let (mut c1, id1) = d.new_client([label_id]);
     let (c2, id2) = d.new_client([label_id]);
 
     let d1 = d.devices.get(id1).expect("device to exist");
@@ -819,9 +803,8 @@ pub fn test_issue112<T: TestImpl, A: Aead>() {
         };
         let (plaintext, got_label, got_seq) = {
             let mut dst = vec![0u8; ciphertext.len() - overhead(&c1)];
-            let mut open_ctx = c2.setup_open_ctx(d2_channel_id).expect("can set up ctx");
             let (_, seq) = c2
-                .open(&mut open_ctx, &mut dst[..], &ciphertext[..])
+                .open(d2_channel_id, &mut dst[..], &ciphertext[..])
                 .unwrap_or_else(|err| panic!("open({id1}, ...): {err}"));
             dst.truncate(ciphertext.len() - overhead(&c2));
             (dst, label_id, seq)
@@ -883,9 +866,8 @@ pub fn test_unidirectional_basic<T: TestImpl, A: Aead>() {
         };
         let (plaintext, got_seq) = {
             let mut dst = vec![0u8; ciphertext.len() - overhead(c2)];
-            let mut open_ctx = c2.setup_open_ctx(d2_channel_id).expect("can set up ctx");
             let (_, seq) = c2
-                .open(&mut open_ctx, &mut dst[..], &ciphertext[..])
+                .open(d2_channel_id, &mut dst[..], &ciphertext[..])
                 .unwrap_or_else(|err| panic!("open({id1}, ...): {err}"));
             (dst, seq)
         };
@@ -993,9 +975,8 @@ pub fn test_unidirectional_exhaustive<T: TestImpl, A: Aead>() {
         };
         let (plaintext, got_seq) = {
             let mut dst = vec![0u8; ciphertext.len() - overhead(c2)];
-            let mut open_ctx = c2.setup_open_ctx(d2_channel_id).expect("can set up ctx");
             let (_, seq) = c2
-                .open(&mut open_ctx, &mut dst[..], &ciphertext[..])
+                .open(d2_channel_id, &mut dst[..], &ciphertext[..])
                 .unwrap_or_else(|err| panic!("{id2}::open({id1}, ...): {err}"));
             (dst, seq)
         };
@@ -1142,7 +1123,7 @@ pub fn test_key_expiry<T: TestImpl, A: Aead>() {
     let label_ids = [LabelId::random(&eng)];
 
     let mut d = Aranya::<T, _>::new("test_key_expiry", 2 * 2 * label_ids.len(), eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
     let d1 = d.devices.get(id1).expect("device to exist");
@@ -1184,11 +1165,10 @@ pub fn test_key_expiry<T: TestImpl, A: Aead>() {
             };
 
             let mut dst = vec![0u8; ciphertext.len() - overhead(&c2)];
-            let mut open_ctx = c2.setup_open_ctx(d2_channel_id).expect("can set up ctx");
             if seq < seq_max {
                 let (plaintext, got_seq) = {
                     let (_, seq) = c2
-                        .open(&mut open_ctx, &mut dst[..], &ciphertext[..])
+                        .open(d2_channel_id, &mut dst[..], &ciphertext[..])
                         .unwrap_or_else(|err| panic!("{seq}: open({id1}, ...): {err}"));
                     (dst, seq)
                 };
@@ -1196,7 +1176,7 @@ pub fn test_key_expiry<T: TestImpl, A: Aead>() {
                 assert_eq!(got_seq, seq);
             } else {
                 let err = c2
-                    .open(&mut open_ctx, &mut dst[..], &ciphertext[..])
+                    .open(d2_channel_id, &mut dst[..], &ciphertext[..])
                     .err()
                     .unwrap_or_else(|| panic!("{seq}: open({id1}, ...): should have failed"));
                 assert_eq!(err, Error::KeyExpired);
@@ -1211,7 +1191,7 @@ pub fn test_open_truncated_tag<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
     let mut d = Aranya::<T, _>::new("test_open_truncated_tag", 2 * 2 * label_ids.len(), eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
     let d1 = d.devices.get(id1).expect("device to exist");
@@ -1235,10 +1215,8 @@ pub fn test_open_truncated_tag<T: TestImpl, A: Aead>() {
             dst
         };
         let mut dst = vec![0u8; ciphertext.len() - overhead(&c2)];
-
-        let mut open_ctx = c2.setup_open_ctx(d2_channel_id).expect("can set up ctx");
         let err = c2
-            .open(&mut open_ctx, &mut dst[..], &ciphertext[..])
+            .open(d2_channel_id, &mut dst[..], &ciphertext[..])
             .err()
             .unwrap_or_else(|| panic!("open({id1}, ...): should have failed"));
         assert_eq!(err, Error::Authentication,);
@@ -1251,7 +1229,7 @@ pub fn test_open_modified_tag<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
     let mut d = Aranya::<T, _>::new("test_open_modified_tag", 2 * 2 * label_ids.len(), eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
     let d1 = d.devices.get(id1).expect("device to exist");
@@ -1274,9 +1252,8 @@ pub fn test_open_modified_tag<T: TestImpl, A: Aead>() {
             dst
         };
         let mut dst = vec![0u8; ciphertext.len() - overhead(&c2)];
-        let mut open_ctx = c2.setup_open_ctx(d2_channel_id).expect("can set up ctx");
         let err = c2
-            .open(&mut open_ctx, &mut dst[..], &ciphertext[..])
+            .open(d2_channel_id, &mut dst[..], &ciphertext[..])
             .err()
             .unwrap_or_else(|| panic!("open({id1}, ...): should have failed"));
         assert_eq!(err, Error::Authentication,);
@@ -1289,7 +1266,7 @@ pub fn test_open_different_seq<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
     let mut d = Aranya::<T, _>::new("test_open_different_seq", 2 * 2 * label_ids.len(), eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
     let d1 = d.devices.get(id1).expect("device to exist");
@@ -1320,9 +1297,8 @@ pub fn test_open_different_seq<T: TestImpl, A: Aead>() {
             dst
         };
         let mut dst = vec![0u8; ciphertext.len() - overhead(&c2)];
-        let mut open_ctx = c2.setup_open_ctx(d2_channel_id).expect("can set up ctx");
         let err = c2
-            .open(&mut open_ctx, &mut dst[..], &ciphertext[..])
+            .open(d2_channel_id, &mut dst[..], &ciphertext[..])
             .err()
             .unwrap_or_else(|| panic!("open({id1}, ...): should have failed"));
         assert_eq!(err, Error::Authentication);
@@ -1349,7 +1325,7 @@ pub fn test_seal_unknown_channel_label<T: TestImpl, A: Aead>() {
         2 * 2 * label_ids.len(),
         eng,
     );
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(open_labels);
 
     let d1 = d.devices.get(id1).expect("device to exist");
@@ -1382,9 +1358,8 @@ pub fn test_seal_unknown_channel_label<T: TestImpl, A: Aead>() {
 
         let (plaintext, got_seq) = {
             let mut dst = vec![0u8; ciphertext.len() - overhead(&c2)];
-            let mut open_ctx = c2.setup_open_ctx(d2_channel_id).expect("can set up ctx");
             let (_, seq) = c2
-                .open(&mut open_ctx, &mut dst[..], &ciphertext[..])
+                .open(d2_channel_id, &mut dst[..], &ciphertext[..])
                 .unwrap_or_else(|err| panic!("open({id1}, ...): {err}"));
             (dst, seq)
         };
@@ -1401,7 +1376,7 @@ pub fn test_monotonic_seq_by_one<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<LimitedAead<A, N>>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng)];
     let mut d = Aranya::<T, _>::new("test_monotonic_seq_by_one", 2 * 2 * label_ids.len(), eng);
-    let (c1, id1) = d.new_client(label_ids);
+    let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
     let d1 = d.devices.get(id1).expect("device to exist");
@@ -1434,9 +1409,8 @@ pub fn test_monotonic_seq_by_one<T: TestImpl, A: Aead>() {
             };
             let (plaintext, got_seq) = {
                 let mut dst = vec![0u8; ciphertext.len() - overhead(&c2)];
-                let mut open_ctx = c2.setup_open_ctx(d2_channel_id).expect("can set up ctx");
                 let (_, seq) = c2
-                    .open(&mut open_ctx, &mut dst[..], &ciphertext[..])
+                    .open(d2_channel_id, &mut dst[..], &ciphertext[..])
                     .unwrap_or_else(|err| panic!("open({id1}, ...): {err}"));
                 (dst, seq)
             };

--- a/crates/aranya-fast-channels/src/testing/mod.rs
+++ b/crates/aranya-fast-channels/src/testing/mod.rs
@@ -126,7 +126,7 @@ const fn overhead<S: AfcState>(_: &Client<S>) -> usize {
 pub fn test_seal_open_basic<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_seal_open_basic", label_ids.len() * 2, eng);
+    let mut d = Aranya::<T, _>::new("test_seal_open_basic", label_ids.len() as u32 * 2, eng);
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
@@ -164,7 +164,11 @@ pub fn test_seal_open_basic<T: TestImpl, A: Aead>() {
 pub fn test_seal_open_in_place_basic<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_seal_open_in_place_basic", label_ids.len() * 2, eng);
+    let mut d = Aranya::<T, _>::new(
+        "test_seal_open_in_place_basic",
+        label_ids.len() as u32 * 2,
+        eng,
+    );
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
@@ -215,7 +219,11 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
 
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_multi_client", max_nodes * label_ids.len() * 2, eng);
+    let mut d = Aranya::<T, _>::new(
+        "test_multi_client",
+        max_nodes * label_ids.len() as u32 * 2,
+        eng,
+    );
 
     let mut device_idxs = Vec::new();
     let mut clients = Vec::new();
@@ -310,7 +318,7 @@ pub fn test_multi_client<T: TestImpl, A: Aead>() {
 pub fn test_remove<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_remove", 2 * 3 * label_ids.len(), eng);
+    let mut d = Aranya::<T, _>::new("test_remove", 2 * 3 * label_ids.len() as u32, eng);
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
@@ -367,7 +375,7 @@ pub fn test_remove<T: TestImpl, A: Aead>() {
 pub fn test_remove_all<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_remove_all", 2 * 3 * label_ids.len(), eng);
+    let mut d = Aranya::<T, _>::new("test_remove_all", 2 * 3 * label_ids.len() as u32, eng);
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
@@ -433,7 +441,7 @@ pub fn test_remove_all<T: TestImpl, A: Aead>() {
 pub fn test_remove_if<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_remove_if", 2 * 3 * label_ids.len(), eng);
+    let mut d = Aranya::<T, _>::new("test_remove_if", 2 * 3 * label_ids.len() as u32, eng);
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
@@ -509,7 +517,11 @@ pub fn test_remove_if<T: TestImpl, A: Aead>() {
 pub fn test_remove_no_channels<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_remove_no_channels", 2 * 3 * label_ids.len(), eng);
+    let mut d = Aranya::<T, _>::new(
+        "test_remove_no_channels",
+        2 * 3 * label_ids.len() as u32,
+        eng,
+    );
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
@@ -577,7 +589,7 @@ pub fn test_remove_no_channels<T: TestImpl, A: Aead>() {
 pub fn test_channels_exist<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_channels_exist", 2 * 3 * label_ids.len(), eng);
+    let mut d = Aranya::<T, _>::new("test_channels_exist", 2 * 3 * label_ids.len() as u32, eng);
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
@@ -657,7 +669,11 @@ pub fn test_channels_not_exist<T: TestImpl, A: Aead>() {
         LabelId::random(&eng),
     ];
 
-    let mut d = Aranya::<T, _>::new("test_channels_not_exist", 2 * 3 * label_ids.len(), eng);
+    let mut d = Aranya::<T, _>::new(
+        "test_channels_not_exist",
+        2 * 3 * label_ids.len() as u32,
+        eng,
+    );
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
     let (c3, id3) = d.new_client(label_ids);
@@ -931,7 +947,11 @@ pub fn test_unidirectional_exhaustive<T: TestImpl, A: Aead>() {
 
     let labels = [label1, label2, label3, label4];
 
-    let mut d = Aranya::<T, _>::new("test_unidirectional_exhaustive", 2 * 5 * labels.len(), eng);
+    let mut d = Aranya::<T, _>::new(
+        "test_unidirectional_exhaustive",
+        2 * 5 * labels.len() as u32,
+        eng,
+    );
 
     let mut c1 = d.new_client_with_type([
         (label1, ChanOp::OpenOnly),
@@ -1061,7 +1081,7 @@ pub fn test_key_expiry<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<LimitedAead<A, N>>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng)];
 
-    let mut d = Aranya::<T, _>::new("test_key_expiry", 2 * 2 * label_ids.len(), eng);
+    let mut d = Aranya::<T, _>::new("test_key_expiry", 2 * 2 * label_ids.len() as u32, eng);
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
@@ -1124,7 +1144,11 @@ pub fn test_key_expiry<T: TestImpl, A: Aead>() {
 pub fn test_open_truncated_tag<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_open_truncated_tag", 2 * 2 * label_ids.len(), eng);
+    let mut d = Aranya::<T, _>::new(
+        "test_open_truncated_tag",
+        2 * 2 * label_ids.len() as u32,
+        eng,
+    );
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
@@ -1161,7 +1185,11 @@ pub fn test_open_truncated_tag<T: TestImpl, A: Aead>() {
 pub fn test_open_modified_tag<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_open_modified_tag", 2 * 2 * label_ids.len(), eng);
+    let mut d = Aranya::<T, _>::new(
+        "test_open_modified_tag",
+        2 * 2 * label_ids.len() as u32,
+        eng,
+    );
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
@@ -1197,7 +1225,11 @@ pub fn test_open_modified_tag<T: TestImpl, A: Aead>() {
 pub fn test_open_different_seq<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng), LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_open_different_seq", 2 * 2 * label_ids.len(), eng);
+    let mut d = Aranya::<T, _>::new(
+        "test_open_different_seq",
+        2 * 2 * label_ids.len() as u32,
+        eng,
+    );
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 
@@ -1253,7 +1285,7 @@ pub fn test_seal_unknown_channel_label<T: TestImpl, A: Aead>() {
     let (eng, _) = TestEngine::<A>::from_entropy(Rng);
     let mut d = Aranya::<T, _>::new(
         "test_open_unknown_channel_label",
-        2 * 2 * label_ids.len(),
+        2 * 2 * label_ids.len() as u32,
         eng,
     );
     let (mut c1, id1) = d.new_client(label_ids);
@@ -1305,7 +1337,11 @@ pub fn test_monotonic_seq_by_one<T: TestImpl, A: Aead>() {
     type N = U1;
     let (eng, _) = TestEngine::<LimitedAead<A, N>>::from_entropy(Rng);
     let label_ids = [LabelId::random(&eng)];
-    let mut d = Aranya::<T, _>::new("test_monotonic_seq_by_one", 2 * 2 * label_ids.len(), eng);
+    let mut d = Aranya::<T, _>::new(
+        "test_monotonic_seq_by_one",
+        2 * 2 * label_ids.len() as u32,
+        eng,
+    );
     let (mut c1, id1) = d.new_client(label_ids);
     let (c2, id2) = d.new_client(label_ids);
 

--- a/crates/aranya-fast-channels/src/testing/util.rs
+++ b/crates/aranya-fast-channels/src/testing/util.rs
@@ -86,7 +86,7 @@ pub trait TestImpl {
     fn new_states<CS: CipherSuite>(
         name: &str,
         id: DeviceIdx,
-        max_chans: usize,
+        max_chans: u32,
     ) -> States<Self::Afc<CS>, Self::Aranya<CS>>;
 
     /// Converts `key` into the encryption key type used by
@@ -231,7 +231,7 @@ where
     /// All peers that have `ChanOp` to the label.
     peers: Vec<(DeviceIdx, LabelId, ChanOp)>,
     /// For `T::new_states`.
-    max_chans: usize,
+    max_chans: u32,
     /// The underlying crypto engine.
     eng: E,
 }
@@ -244,14 +244,14 @@ where
     /// Creates an instance of Aranya.
     ///
     /// `name` is the name of the test using `Aranya`.
-    pub fn new(name: &str, max_chans: usize, eng: E) -> Self {
+    pub fn new(name: &str, max_chans: u32, eng: E) -> Self {
         #[cfg(feature = "unsafe_debug")]
         crate::util::init_debug_logging();
 
         Self {
             name: name.to_owned(),
-            devices: Vec::with_capacity(max_chans),
-            peers: Vec::with_capacity(max_chans),
+            devices: Vec::with_capacity(max_chans as usize),
+            peers: Vec::with_capacity(max_chans as usize),
             max_chans,
             eng,
         }
@@ -527,7 +527,7 @@ impl TestImpl for MockImpl {
     fn new_states<CS: CipherSuite>(
         _name: &str,
         _device_idx: DeviceIdx,
-        _max_chans: usize,
+        _max_chans: u32,
     ) -> States<Self::Afc<CS>, Self::Aranya<CS>> {
         let afc = memory::State::<CS>::new();
         let aranya = afc.clone();


### PR DESCRIPTION
WIP but working impl of #479.

`afc::shm::{read,write,shared}` are greatly simplified by introducing a generic arena type in `arena.rs`. This arena type implements a concurrent list with stable indices.