### PR TITLE
policy-compiler: compile ffi function args when stub_ffi is enabled

### DIFF
--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -962,7 +962,11 @@ impl<'a> CompileState<'a> {
                     f.module.name.clone(),
                     f.identifier.name.clone(),
                 )));
+
                 if self.stub_ffi {
+                    for arg_e in &f.arguments {
+                        let _arg_ty = self.compile_expression(arg_e)?;
+                    }
                     self.append_instruction(Instruction::Exit(ExitReason::Panic));
                     VType {
                         kind: TypeKind::Never,


### PR DESCRIPTION
Not compiling the args can hide errors when compiling with stub_ffi.