### PR TITLE
chore: release 2025-12-11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "aranya-afc-util"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aranya-afc-util",
  "aranya-crypto",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-codegen"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aranya-capi-macro",
  "aranya-libc",
@@ -209,7 +209,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aranya-capi-codegen",
  "proc-macro2",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-crypto-ffi"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "aranya-crypto",
  "aranya-crypto-ffi",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-device-ffi"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-envelope-ffi"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-fast-channels"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "aranya-crypto",
  "aranya-fast-channels",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-idam-ffi"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "aranya-crypto",
  "aranya-idam-ffi",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-perspective-ffi"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ast"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "aranya-policy-text",
  "rkyv",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-compiler"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-derive"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aranya-policy-lang",
  "prettyplease",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "aranya-policy-compiler",
  "aranya-policy-ifgen-build",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen-build"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-lang"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-module"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aranya-id",
  "aranya-policy-ast",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-vm"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-runtime"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "aranya-crypto",
  "aranya-libc",

--- a/crates/aranya-afc-util/CHANGELOG.md
+++ b/crates/aranya-afc-util/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0](https://github.com/aranya-project/aranya-core/compare/aranya-afc-util-v0.17.0...aranya-afc-util-v0.18.0) - 2025-12-11
+
+### Other
+
+- Pass `OpenCtx` to client methods ([#485](https://github.com/aranya-project/aranya-core/pull/485))
+
 ## [0.17.0](https://github.com/aranya-project/aranya-core/compare/aranya-afc-util-v0.16.0...aranya-afc-util-v0.17.0) - 2025-11-12
 
 ### Other

--- a/crates/aranya-afc-util/Cargo.toml
+++ b/crates/aranya-afc-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-afc-util"
 description = "Utilities for using Aranya Fast Channels"
-version = "0.17.0"
+version = "0.18.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -41,8 +41,8 @@ testing = [
 
 [dependencies]
 aranya-crypto = { version = "0.12.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "afc"] }
-aranya-fast-channels = { version = "0.16.0", path = "../aranya-fast-channels", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.15.1", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-fast-channels = { version = "0.17.0", path = "../aranya-fast-channels", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.16.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 buggy = { version = "0.1.0", default-features = false }
 postcard = { workspace = true, default-features = false, features = ["heapless"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }

--- a/crates/aranya-capi-codegen/CHANGELOG.md
+++ b/crates/aranya-capi-codegen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-capi-codegen-v0.5.0...aranya-capi-codegen-v0.6.0) - 2025-12-11
+
+### Other
+
+- expand opaque during codegen ([#503](https://github.com/aranya-project/aranya-core/pull/503))
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-capi-codegen-v0.4.0...aranya-capi-codegen-v0.5.0) - 2025-10-16
 
 ### Other

--- a/crates/aranya-capi-codegen/Cargo.toml
+++ b/crates/aranya-capi-codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-capi-codegen"
 description = "Code generation for Aranya's C API tooling"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-capi-core/CHANGELOG.md
+++ b/crates/aranya-capi-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/aranya-project/aranya-core/compare/aranya-capi-core-v0.6.0...aranya-capi-core-v0.7.0) - 2025-12-11
+
+### Other
+
+- updated the following local packages: aranya-capi-macro
+
 ## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-capi-core-v0.5.0...aranya-capi-core-v0.6.0) - 2025-10-16
 
 ### Other

--- a/crates/aranya-capi-core/Cargo.toml
+++ b/crates/aranya-capi-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-capi-core"
 description = "Aranya's C API tooling"
-version = "0.6.0"
+version = "0.7.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -31,7 +31,7 @@ std = [
 ]
 
 [dependencies]
-aranya-capi-macro = { version = "0.5.0", path = "../aranya-capi-macro", default-features = false }
+aranya-capi-macro = { version = "0.6.0", path = "../aranya-capi-macro", default-features = false }
 aranya-libc = { version = "0.4.0", path = "../aranya-libc", default-features = false }
 buggy = { version = "0.1.0", default-features = false }
 

--- a/crates/aranya-capi-macro/CHANGELOG.md
+++ b/crates/aranya-capi-macro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/aranya-project/aranya-core/compare/aranya-capi-macro-v0.5.0...aranya-capi-macro-v0.6.0) - 2025-12-11
+
+### Other
+
+- expand opaque during codegen ([#503](https://github.com/aranya-project/aranya-core/pull/503))
+
 ## [0.5.0](https://github.com/aranya-project/aranya-core/compare/aranya-capi-macro-v0.4.0...aranya-capi-macro-v0.5.0) - 2025-10-16
 
 ### Other

--- a/crates/aranya-capi-macro/Cargo.toml
+++ b/crates/aranya-capi-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-capi-macro"
 description = "Proc macros for Aranya's C API tooling"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -20,7 +20,7 @@ default = []
 debug = ["aranya-capi-codegen/debug"]
 
 [dependencies]
-aranya-capi-codegen = { version = "0.5.0", path = "../aranya-capi-codegen" }
+aranya-capi-codegen = { version = "0.6.0", path = "../aranya-capi-codegen" }
 
 proc-macro2 = { workspace = true }
 quote = { workspace = true }

--- a/crates/aranya-crypto-ffi/CHANGELOG.md
+++ b/crates/aranya-crypto-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-ffi-v0.15.1...aranya-crypto-ffi-v0.16.0) - 2025-12-11
+
+### Other
+
+- updated the following local packages: aranya-policy-vm
+
 ## [0.15.1](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-ffi-v0.15.0...aranya-crypto-ffi-v0.15.1) - 2025-11-12
 
 ### Other

--- a/crates/aranya-crypto-ffi/Cargo.toml
+++ b/crates/aranya-crypto-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-crypto-ffi"
 description = "The crypto FFI for Aranya Policy"
-version = "0.15.1"
+version = "0.16.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -44,7 +44,7 @@ testing = [
 
 [dependencies]
 aranya-crypto = { version = "0.12.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.15.1", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-policy-vm = { version = "0.16.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 postcard = { workspace = true, default-features = false, features = ["heapless"] }
 serde = { workspace = true, default-features = false, features = ["derive"], optional = true }

--- a/crates/aranya-device-ffi/CHANGELOG.md
+++ b/crates/aranya-device-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/aranya-project/aranya-core/compare/aranya-device-ffi-v0.15.1...aranya-device-ffi-v0.16.0) - 2025-12-11
+
+### Other
+
+- updated the following local packages: aranya-policy-vm
+
 ## [0.15.1](https://github.com/aranya-project/aranya-core/compare/aranya-device-ffi-v0.15.0...aranya-device-ffi-v0.15.1) - 2025-11-12
 
 ### Other

--- a/crates/aranya-device-ffi/Cargo.toml
+++ b/crates/aranya-device-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-device-ffi"
 description = "The device FFI for Aranya Policy"
-version = "0.15.1"
+version = "0.16.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -25,7 +25,7 @@ testing = []
 
 [dependencies]
 aranya-crypto = { version = "0.12.0", path = "../aranya-crypto", default-features = false }
-aranya-policy-vm = { version = "0.15.1", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-policy-vm = { version = "0.16.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 aranya-crypto = { path = "../aranya-crypto", features = ["getrandom"] }

--- a/crates/aranya-envelope-ffi/CHANGELOG.md
+++ b/crates/aranya-envelope-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/aranya-project/aranya-core/compare/aranya-envelope-ffi-v0.15.1...aranya-envelope-ffi-v0.16.0) - 2025-12-11
+
+### Other
+
+- updated the following local packages: aranya-policy-vm
+
 ## [0.15.1](https://github.com/aranya-project/aranya-core/compare/aranya-envelope-ffi-v0.15.0...aranya-envelope-ffi-v0.15.1) - 2025-11-12
 
 ### Other

--- a/crates/aranya-envelope-ffi/Cargo.toml
+++ b/crates/aranya-envelope-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-envelope-ffi"
 description = "The envelope FFI for Aranya Policy"
-version = "0.15.1"
+version = "0.16.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -29,7 +29,7 @@ std = [
 
 [dependencies]
 aranya-crypto = { version = "0.12.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.15.1", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-policy-vm = { version = "0.16.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/aranya-fast-channels/CHANGELOG.md
+++ b/crates/aranya-fast-channels/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/aranya-project/aranya-core/compare/aranya-fast-channels-v0.16.0...aranya-fast-channels-v0.17.0) - 2025-12-11
+
+### Other
+
+- clean up dev profile and some feature sets ([#507](https://github.com/aranya-project/aranya-core/pull/507))
+- Pass `OpenCtx` to client methods ([#485](https://github.com/aranya-project/aranya-core/pull/485))
+
 ## [0.16.0](https://github.com/aranya-project/aranya-core/compare/aranya-fast-channels-v0.15.0...aranya-fast-channels-v0.16.0) - 2025-11-12
 
 ### Other

--- a/crates/aranya-fast-channels/Cargo.toml
+++ b/crates/aranya-fast-channels/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-fast-channels"
 description = "High throughput, low latency encryption protected by Aranya Policy"
-version = "0.16.0"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-idam-ffi/CHANGELOG.md
+++ b/crates/aranya-idam-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/aranya-project/aranya-core/compare/aranya-idam-ffi-v0.15.1...aranya-idam-ffi-v0.16.0) - 2025-12-11
+
+### Other
+
+- updated the following local packages: aranya-policy-vm
+
 ## [0.15.1](https://github.com/aranya-project/aranya-core/compare/aranya-idam-ffi-v0.15.0...aranya-idam-ffi-v0.15.1) - 2025-11-12
 
 ### Other

--- a/crates/aranya-idam-ffi/Cargo.toml
+++ b/crates/aranya-idam-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-idam-ffi"
 description = "The IDAM FFI for Aranya Policy"
-version = "0.15.1"
+version = "0.16.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -36,7 +36,7 @@ testing = [
 
 [dependencies]
 aranya-crypto = { version = "0.12.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.15.1", path = "../aranya-policy-vm", features = ["derive"] }
+aranya-policy-vm = { version = "0.16.0", path = "../aranya-policy-vm", features = ["derive"] }
 postcard = { workspace = true, default-features = false, features = ["heapless"] }
 # For `custom_id!`
 serde = { workspace = true, default-features = false }

--- a/crates/aranya-perspective-ffi/CHANGELOG.md
+++ b/crates/aranya-perspective-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/aranya-project/aranya-core/compare/aranya-perspective-ffi-v0.15.1...aranya-perspective-ffi-v0.16.0) - 2025-12-11
+
+### Other
+
+- updated the following local packages: aranya-policy-vm
+
 ## [0.15.1](https://github.com/aranya-project/aranya-core/compare/aranya-perspective-ffi-v0.15.0...aranya-perspective-ffi-v0.15.1) - 2025-11-12
 
 ### Other

--- a/crates/aranya-perspective-ffi/Cargo.toml
+++ b/crates/aranya-perspective-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-perspective-ffi"
 description = "The perspective FFI for Aranya Policy"
-version = "0.15.1"
+version = "0.16.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -27,7 +27,7 @@ testing = []
 
 [dependencies]
 aranya-crypto = { version = "0.12.0", path = "../aranya-crypto", default-features = false }
-aranya-policy-vm = { version = "0.15.1", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-policy-vm = { version = "0.16.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 aranya-crypto = { path = "../aranya-crypto", features = ["getrandom"] }

--- a/crates/aranya-policy-ast/CHANGELOG.md
+++ b/crates/aranya-policy-ast/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ast-v0.9.0...aranya-policy-ast-v0.10.0) - 2025-12-11
+
+### Other
+
+- split type checking and instruction generation ([#500](https://github.com/aranya-project/aranya-core/pull/500))
+- add alternative parsing `option[T]` ([#499](https://github.com/aranya-project/aranya-core/pull/499))
+- switch parser snapshots to simplified debug repr ([#492](https://github.com/aranya-project/aranya-core/pull/492))
+- remove `Typeish` and `NullableVType` ([#486](https://github.com/aranya-project/aranya-core/pull/486))
+- define math as builtin functions ([#439](https://github.com/aranya-project/aranya-core/pull/439))
+
 ## [0.9.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ast-v0.8.1...aranya-policy-ast-v0.9.0) - 2025-11-05
 
 ### Other

--- a/crates/aranya-policy-ast/Cargo.toml
+++ b/crates/aranya-policy-ast/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ast"
 description = "The Aranya Policy Language AST"
-version = "0.9.0"
+version = "0.10.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-policy-compiler/CHANGELOG.md
+++ b/crates/aranya-policy-compiler/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-compiler-v0.16.0...aranya-policy-compiler-v0.17.0) - 2025-12-11
+
+### Other
+
+- allow nested option ([#502](https://github.com/aranya-project/aranya-core/pull/502))
+- split type checking and instruction generation ([#500](https://github.com/aranya-project/aranya-core/pull/500))
+- add alternative parsing `option[T]` ([#499](https://github.com/aranya-project/aranya-core/pull/499))
+- add `compile_interface` ([#496](https://github.com/aranya-project/aranya-core/pull/496))
+- compile ffi function args when stub_ffi is enabled ([#495](https://github.com/aranya-project/aranya-core/pull/495))
+- remove `Typeish` and `NullableVType` ([#486](https://github.com/aranya-project/aranya-core/pull/486))
+- define math as builtin functions ([#439](https://github.com/aranya-project/aranya-core/pull/439))
+
 ## [0.16.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-compiler-v0.15.0...aranya-policy-compiler-v0.16.0) - 2025-11-12
 
 ### Other

--- a/crates/aranya-policy-compiler/Cargo.toml
+++ b/crates/aranya-policy-compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-compiler"
 description = "The Aranya Policy Compiler"
-version = "0.16.0"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -15,9 +15,9 @@ workspace = true
 default = []
 
 [dependencies]
-aranya-policy-ast = { version = "0.9.0", path = "../aranya-policy-ast" }
-aranya-policy-lang = { version = "0.9.0", path = "../aranya-policy-lang" }
-aranya-policy-module = { version = "0.15.0", path = "../aranya-policy-module", features = ["std"] }
+aranya-policy-ast = { version = "0.10.0", path = "../aranya-policy-ast" }
+aranya-policy-lang = { version = "0.10.0", path = "../aranya-policy-lang" }
+aranya-policy-module = { version = "0.16.0", path = "../aranya-policy-module", features = ["std"] }
 buggy = { version = "0.1.0", features = ["std"] }
 
 ciborium = { version = "0.2" }

--- a/crates/aranya-policy-derive/CHANGELOG.md
+++ b/crates/aranya-policy-derive/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-derive-v0.10.0...aranya-policy-derive-v0.11.0) - 2025-12-11
+
+### Other
+
+- remove `Typeish` and `NullableVType` ([#486](https://github.com/aranya-project/aranya-core/pull/486))
+
 ## [0.10.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-derive-v0.9.0...aranya-policy-derive-v0.10.0) - 2025-11-05
 
 ### Other

--- a/crates/aranya-policy-derive/Cargo.toml
+++ b/crates/aranya-policy-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-derive"
 description = "Proc macros for generating Aranya Policy Language FFIs"
-version = "0.10.0"
+version = "0.11.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ proc-macro = true
 default = []
 
 [dependencies]
-aranya-policy-lang = { version = "0.9.0", path = "../aranya-policy-lang" }
+aranya-policy-lang = { version = "0.10.0", path = "../aranya-policy-lang" }
 
 prettyplease = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/crates/aranya-policy-ifgen-build/CHANGELOG.md
+++ b/crates/aranya-policy-ifgen-build/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-build-v0.10.0...aranya-policy-ifgen-build-v0.11.0) - 2025-12-11
+
+### Other
+
+- add `compile_interface` ([#496](https://github.com/aranya-project/aranya-core/pull/496))
+- remove `Typeish` and `NullableVType` ([#486](https://github.com/aranya-project/aranya-core/pull/486))
+
 ## [0.10.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-build-v0.9.0...aranya-policy-ifgen-build-v0.10.0) - 2025-11-12
 
 ### Other

--- a/crates/aranya-policy-ifgen-build/Cargo.toml
+++ b/crates/aranya-policy-ifgen-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ifgen-build"
 description = "Code generator for aranya-policy-ifgen"
-version = "0.10.0"
+version = "0.11.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -12,9 +12,9 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aranya-policy-ast = { version = "0.9.0", path = "../aranya-policy-ast" }
-aranya-policy-compiler = { version = "0.16.0", path = "../aranya-policy-compiler" }
-aranya-policy-lang = { version = "0.9.0", path = "../aranya-policy-lang" }
+aranya-policy-ast = { version = "0.10.0", path = "../aranya-policy-ast" }
+aranya-policy-compiler = { version = "0.17.0", path = "../aranya-policy-compiler" }
+aranya-policy-lang = { version = "0.10.0", path = "../aranya-policy-lang" }
 
 anyhow = { workspace = true }
 prettyplease = { workspace = true }

--- a/crates/aranya-policy-ifgen/CHANGELOG.md
+++ b/crates/aranya-policy-ifgen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.16.1...aranya-policy-ifgen-v0.17.0) - 2025-12-11
+
+### Other
+
+- add `compile_interface` ([#496](https://github.com/aranya-project/aranya-core/pull/496))
+
 ## [0.16.1](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.16.0...aranya-policy-ifgen-v0.16.1) - 2025-11-12
 
 ### Other

--- a/crates/aranya-policy-ifgen/Cargo.toml
+++ b/crates/aranya-policy-ifgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ifgen"
 description = "Tools for generating Rust interfaces to Aranya Policies"
-version = "0.16.1"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -19,8 +19,8 @@ serde = [
 
 [dependencies]
 aranya-policy-ifgen-macro = { version = "0.5.0", path = "../aranya-policy-ifgen-macro" }
-aranya-policy-vm = { version = "0.15.1", path = "../aranya-policy-vm" }
-aranya-runtime = { version = "0.16.1", path = "../aranya-runtime" }
+aranya-policy-vm = { version = "0.16.0", path = "../aranya-policy-vm" }
+aranya-runtime = { version = "0.17.0", path = "../aranya-runtime" }
 
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/crates/aranya-policy-lang/CHANGELOG.md
+++ b/crates/aranya-policy-lang/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-lang-v0.9.0...aranya-policy-lang-v0.10.0) - 2025-12-11
+
+### Other
+
+- add custom error for `+` and `-` ops ([#508](https://github.com/aranya-project/aranya-core/pull/508))
+- allow nested option ([#502](https://github.com/aranya-project/aranya-core/pull/502))
+- format pest grammar with leading alternates ([#509](https://github.com/aranya-project/aranya-core/pull/509))
+- improve parser testing ([#489](https://github.com/aranya-project/aranya-core/pull/489))
+- split type checking and instruction generation ([#500](https://github.com/aranya-project/aranya-core/pull/500))
+- add alternative parsing `option[T]` ([#499](https://github.com/aranya-project/aranya-core/pull/499))
+- switch parser snapshots to simplified debug repr ([#492](https://github.com/aranya-project/aranya-core/pull/492))
+- define math as builtin functions ([#439](https://github.com/aranya-project/aranya-core/pull/439))
+
 ## [0.9.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-lang-v0.8.1...aranya-policy-lang-v0.9.0) - 2025-11-05
 
 ### Other

--- a/crates/aranya-policy-lang/Cargo.toml
+++ b/crates/aranya-policy-lang/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-lang"
 description = "The Aranya Policy Language parser"
-version = "0.9.0"
+version = "0.10.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ default = []
 buggy = { version = "0.1.0", features = ["std"] }
 # `std` is required because bin/parser-explorer uses `clap` which
 # requires it for arg parsing.
-aranya-policy-ast = { version = "0.9.0", path = "../aranya-policy-ast", features = ["std"] }
+aranya-policy-ast = { version = "0.10.0", path = "../aranya-policy-ast", features = ["std"] }
 
 anyhow = { workspace = true }
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/aranya-policy-module/CHANGELOG.md
+++ b/crates/aranya-policy-module/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-module-v0.15.0...aranya-policy-module-v0.16.0) - 2025-12-11
+
+### Other
+
+- allow nested option ([#502](https://github.com/aranya-project/aranya-core/pull/502))
+- remove `Typeish` and `NullableVType` ([#486](https://github.com/aranya-project/aranya-core/pull/486))
+
 ## [0.15.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-module-v0.14.0...aranya-policy-module-v0.15.0) - 2025-11-05
 
 ### Other

--- a/crates/aranya-policy-module/Cargo.toml
+++ b/crates/aranya-policy-module/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-module"
 description = "The Aranya Policy module format"
-version = "0.15.0"
+version = "0.16.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -10,7 +10,7 @@ rust-version.workspace = true
 
 [dependencies]
 aranya-id = { version = "0.2.0", path = "../aranya-id" }
-aranya-policy-ast = { version = "0.9.0", path = "../aranya-policy-ast" }
+aranya-policy-ast = { version = "0.10.0", path = "../aranya-policy-ast" }
 
 fnv = { workspace = true, default-features = false }
 indexmap = { workspace = true, default-features = false, features = ["serde"] }

--- a/crates/aranya-policy-vm/CHANGELOG.md
+++ b/crates/aranya-policy-vm/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.15.1...aranya-policy-vm-v0.16.0) - 2025-12-11
+
+### Other
+
+- allow nested option ([#502](https://github.com/aranya-project/aranya-core/pull/502))
+- clean up dev profile and some feature sets ([#507](https://github.com/aranya-project/aranya-core/pull/507))
+- split type checking and instruction generation ([#500](https://github.com/aranya-project/aranya-core/pull/500))
+- add alternative parsing `option[T]` ([#499](https://github.com/aranya-project/aranya-core/pull/499))
+
 ## [0.15.1](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.15.0...aranya-policy-vm-v0.15.1) - 2025-11-12
 
 ### Other

--- a/crates/aranya-policy-vm/Cargo.toml
+++ b/crates/aranya-policy-vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-vm"
 description = "The Aranya Policy Virtual Machine"
-version = "0.15.1"
+version = "0.16.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -31,9 +31,9 @@ bench = ["dep:table_formatter", "std"]
 
 [dependencies]
 aranya-crypto = { version = "0.12.0", path = "../aranya-crypto", default-features = false }
-aranya-policy-ast = { version = "0.9.0", path = "../aranya-policy-ast" }
-aranya-policy-derive = { version = "0.10.0", path = "../aranya-policy-derive" }
-aranya-policy-module = { version = "0.15.0", path = "../aranya-policy-module" }
+aranya-policy-ast = { version = "0.10.0", path = "../aranya-policy-ast" }
+aranya-policy-derive = { version = "0.11.0", path = "../aranya-policy-derive" }
+aranya-policy-module = { version = "0.16.0", path = "../aranya-policy-module" }
 buggy = { version = "0.1.0", features = ["alloc"] }
 
 heapless = { workspace = true }

--- a/crates/aranya-runtime/CHANGELOG.md
+++ b/crates/aranya-runtime/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/aranya-project/aranya-core/compare/aranya-runtime-v0.16.1...aranya-runtime-v0.17.0) - 2025-12-11
+
+### Other
+
+- 473 sync failures ([#511](https://github.com/aranya-project/aranya-core/pull/511))
+- Low mem ([#491](https://github.com/aranya-project/aranya-core/pull/491))
+
 ## [0.16.1](https://github.com/aranya-project/aranya-core/compare/aranya-runtime-v0.16.0...aranya-runtime-v0.16.1) - 2025-11-12
 
 ### Other

--- a/crates/aranya-runtime/Cargo.toml
+++ b/crates/aranya-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-runtime"
 description = "The Aranya core runtime"
-version = "0.16.1"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -16,7 +16,7 @@ buggy = { version = "0.1.0", features = ["alloc"] }
 # `aranya-crypto` enables `getrandom` by default.
 aranya-crypto = { version = "0.12.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "rand_compat"] }
 aranya-libc = { version = "0.4.0", path = "../aranya-libc", default-features = false, optional = true }
-aranya-policy-vm = { version = "0.15.1", path = "../aranya-policy-vm" }
+aranya-policy-vm = { version = "0.16.0", path = "../aranya-policy-vm" }
 
 heapless = { workspace = true, features = ["serde"] }
 postcard = { workspace = true, features = ["alloc"] }
@@ -29,7 +29,7 @@ vec1 = { version = "1.10.1", default-features = false, features = ["serde"] }
 yoke = { version = "0.8", features = ["derive"] }
 
 # Used by `testing`.
-aranya-policy-module = { version = "0.15.0", path = "../aranya-policy-module", optional = true }
+aranya-policy-module = { version = "0.16.0", path = "../aranya-policy-module", optional = true }
 serde_json = { version = "1.0.117", default-features = false, features = ["alloc"], optional = true }
 
 # graphviz


### PR DESCRIPTION
```
aranya-crypto-ffi@0.16.0
aranya-policy-vm@0.16.0
aranya-policy-ast@0.10.0
aranya-policy-derive@0.11.0
aranya-policy-lang@0.10.0
aranya-policy-module@0.16.0
aranya-policy-compiler@0.17.0
aranya-device-ffi@0.16.0
aranya-envelope-ffi@0.16.0
aranya-idam-ffi@0.16.0
aranya-perspective-ffi@0.16.0
aranya-runtime@0.17.0
aranya-afc-util@0.18.0
aranya-fast-channels@0.17.0
aranya-capi-codegen@0.6.0
aranya-capi-core@0.7.0
aranya-capi-macro@0.6.0
aranya-policy-ifgen@0.17.0
aranya-policy-ifgen-build@0.11.0
```