### PR TITLE
chore: rename `storage_id` to `graph_id`

### DIFF
--- a/crates/aranya-quic-syncer/benches/quic_syncer.rs
+++ b/crates/aranya-quic-syncer/benches/quic_syncer.rs
@@ -79,13 +79,13 @@ fn new_graph(
 
 fn add_commands(
     client: &mut ClientState<TestPolicyStore, MemStorageProvider>,
-    storage_id: GraphId,
+    graph_id: GraphId,
     sink: &mut CountSink,
     n: u64,
 ) {
     for x in 0..n {
         client
-            .action(storage_id, sink, TestActions::SetValue(0, x))
+            .action(graph_id, sink, TestActions::SetValue(0, x))
             .expect("unable to add command");
     }
 }
@@ -140,7 +140,7 @@ fn sync_bench(c: &mut Criterion) {
                 .expect("Syncer creation must succeed"),
             ));
 
-            let storage_id = new_graph(
+            let graph_id = new_graph(
                 response_client.lock().await.deref_mut(),
                 response_sink.lock().await.deref_mut(),
             )
@@ -149,7 +149,7 @@ fn sync_bench(c: &mut Criterion) {
             let task = tokio::spawn(run_syncer(Arc::clone(&syncer2), server2, rx2));
             add_commands(
                 response_client.lock().await.deref_mut(),
-                storage_id,
+                graph_id,
                 response_sink.lock().await.deref_mut(),
                 iters,
             );
@@ -157,7 +157,7 @@ fn sync_bench(c: &mut Criterion) {
             // Start timing for benchmark
             let start = Instant::now();
             while request_sink.lock().await.count() < iters.try_into().unwrap() {
-                let sync_requester = SyncRequester::new(storage_id, &mut Rng::new());
+                let sync_requester = SyncRequester::new(graph_id, &mut Rng::new());
                 if let Err(e) = syncer1
                     .lock()
                     .await
@@ -166,7 +166,7 @@ fn sync_bench(c: &mut Criterion) {
                         server2_addr,
                         sync_requester,
                         request_sink.lock().await.deref_mut(),
-                        storage_id,
+                        graph_id,
                     )
                     .await
                 {

--- a/crates/aranya-runtime/benches/vm.rs
+++ b/crates/aranya-runtime/benches/vm.rs
@@ -20,18 +20,18 @@ fn benchmark_1() {
     let mut cs = ClientState::new(policy_store, provider);
 
     let mut sink = TestSink::new();
-    let storage_id = cs
+    let graph_id = cs
         .new_graph(&[0u8], vm_action!(init(0)), &mut sink)
         .expect("could not create graph");
 
     sink.add_expectation(vm_effect!(StuffHappened { x: 1, y: 3 }));
 
-    cs.action(storage_id, &mut sink, vm_action!(create_action(3)))
+    cs.action(graph_id, &mut sink, vm_action!(create_action(3)))
         .expect("could not call action");
 
     sink.add_expectation(vm_effect!(StuffHappened { x: 1, y: 4 }));
 
-    cs.action(storage_id, &mut sink, vm_action!(increment()))
+    cs.action(graph_id, &mut sink, vm_action!(increment()))
         .expect("should call increment");
 
     bench_measurements().print_stats();
@@ -115,16 +115,16 @@ policy-version: 1
     let mut cs = ClientState::new(policy_store, provider);
 
     let mut sink = TestSink::new();
-    let storage_id = cs
+    let graph_id = cs
         .new_graph(&[0u8], vm_action!(init()), &mut sink)
         .expect("could not create graph");
 
     for i in 1..10 {
         let text: Text = i.to_string().parse().expect("valid text");
-        cs.action(storage_id, &mut sink, vm_action!(insert(i, text)))
+        cs.action(graph_id, &mut sink, vm_action!(insert(i, text)))
             .expect("action `insert` failed");
     }
-    cs.action(storage_id, &mut sink, vm_action!(run()))
+    cs.action(graph_id, &mut sink, vm_action!(run()))
         .expect("action `run` failed");
 
     bench_measurements().print_stats();

--- a/crates/aranya-runtime/src/client.rs
+++ b/crates/aranya-runtime/src/client.rs
@@ -137,7 +137,7 @@ where
 
     pub fn update_heads<I>(
         &mut self,
-        storage_id: GraphId,
+        graph_id: GraphId,
         addrs: I,
         request_heads: &mut PeerCache,
     ) -> Result<(), ClientError>
@@ -145,7 +145,7 @@ where
         I: IntoIterator<Item = Address>,
         I::IntoIter: DoubleEndedIterator,
     {
-        let storage = self.provider.get_storage(storage_id)?;
+        let storage = self.provider.get_storage(graph_id)?;
 
         // Commands in sync messages are always ancestor-first (lower max_cut to higher max_cut).
         // Reverse the iterator to process highest max_cut first, which allows us to skip ancestors
@@ -165,8 +165,8 @@ where
     }
 
     /// Returns the address of the head of the graph.
-    pub fn head_address(&mut self, storage_id: GraphId) -> Result<Address, ClientError> {
-        let storage = self.provider.get_storage(storage_id)?;
+    pub fn head_address(&mut self, graph_id: GraphId) -> Result<Address, ClientError> {
+        let storage = self.provider.get_storage(graph_id)?;
         let address = storage.get_head_address()?;
         Ok(address)
     }
@@ -174,11 +174,11 @@ where
     /// Performs an `action`, writing the results to `sink`.
     pub fn action(
         &mut self,
-        storage_id: GraphId,
+        graph_id: GraphId,
         sink: &mut impl Sink<PS::Effect>,
         action: <PS::Policy as Policy>::Action<'_>,
     ) -> Result<(), ClientError> {
-        let storage = self.provider.get_storage(storage_id)?;
+        let storage = self.provider.get_storage(graph_id)?;
 
         let head = storage.get_head()?;
 
@@ -211,21 +211,21 @@ where
     SP: StorageProvider,
 {
     /// Create a new [`Transaction`], used to receive [`Command`]s when syncing.
-    pub fn transaction(&mut self, storage_id: GraphId) -> Transaction<SP, PS> {
-        Transaction::new(storage_id)
+    pub fn transaction(&mut self, graph_id: GraphId) -> Transaction<SP, PS> {
+        Transaction::new(graph_id)
     }
 
     /// Create an ephemeral [`Session`] associated with this client.
-    pub fn session(&mut self, storage_id: GraphId) -> Result<Session<SP, PS>, ClientError> {
-        Session::new(&mut self.provider, storage_id)
+    pub fn session(&mut self, graph_id: GraphId) -> Result<Session<SP, PS>, ClientError> {
+        Session::new(&mut self.provider, graph_id)
     }
 
     /// Checks if a command with the given address exists in the specified graph.
     ///
     /// Returns `true` if the command exists, `false` if it doesn't exist or the graph doesn't exist.
     /// This method is used to determine if we need to sync when a hello message is received.
-    pub fn command_exists(&mut self, storage_id: GraphId, address: Address) -> bool {
-        let Ok(storage) = self.provider.get_storage(storage_id) else {
+    pub fn command_exists(&mut self, graph_id: GraphId, address: Address) -> bool {
+        let Ok(storage) = self.provider.get_storage(graph_id) else {
             // Graph doesn't exist
             return false;
         };

--- a/crates/aranya-runtime/src/sync/responder.rs
+++ b/crates/aranya-runtime/src/sync/responder.rs
@@ -470,7 +470,7 @@ impl SyncResponder {
                     response_index: self.message_index as u64,
                     commands,
                 },
-                graph_id: self.graph_id.assume("storage id must exist")?,
+                graph_id: self.graph_id.assume("graph id must exist")?,
             };
             self.message_index = self
                 .message_index

--- a/crates/aranya-runtime/src/testing/dsl.rs
+++ b/crates/aranya-runtime/src/testing/dsl.rs
@@ -551,13 +551,13 @@ where
                     .ok_or(TestError::MissingClient)?
                     .get_mut();
                 let policy_data = policy.to_be_bytes();
-                let storage_id = state.new_graph(
+                let graph_id = state.new_graph(
                     policy_data.as_slice(),
                     TestActions::Init(policy),
                     &mut sink,
                 )?;
 
-                graphs.insert(id, storage_id);
+                graphs.insert(id, graph_id);
 
                 assert_eq!(0, sink.count());
             }
@@ -566,8 +566,8 @@ where
                     .get_mut(&client)
                     .ok_or(TestError::MissingClient)?
                     .get_mut();
-                let storage_id = graphs.get(&id).ok_or(TestError::MissingGraph(id))?;
-                state.remove_graph(*storage_id)?;
+                let graph_id = graphs.get(&id).ok_or(TestError::MissingGraph(id))?;
+                state.remove_graph(*graph_id)?;
 
                 assert_eq!(0, sink.count());
             }
@@ -579,7 +579,7 @@ where
                 must_receive,
                 max_syncs,
             } => {
-                let storage_id = graphs.get(&graph).ok_or(TestError::MissingGraph(graph))?;
+                let graph_id = graphs.get(&graph).ok_or(TestError::MissingGraph(graph))?;
 
                 let mut request_client = clients
                     .get(&client)
@@ -609,7 +609,7 @@ where
                         &mut request_client,
                         &mut response_client,
                         &mut sink,
-                        *storage_id,
+                        *graph_id,
                     )?;
                     total_received += received;
                     total_sent += sent;
@@ -655,11 +655,11 @@ where
                     .ok_or(TestError::MissingClient)?
                     .get_mut();
 
-                let storage_id = graphs.get(&graph).ok_or(TestError::MissingGraph(graph))?;
+                let graph_id = graphs.get(&graph).ok_or(TestError::MissingGraph(graph))?;
 
                 for _ in 0..repeat {
                     let set = TestActions::SetValue(key, value);
-                    state.action(*storage_id, &mut sink, set)?;
+                    state.action(*graph_id, &mut sink, set)?;
                 }
 
                 assert_eq!(0, sink.count());
@@ -671,8 +671,8 @@ where
                     .ok_or(TestError::MissingClient)?
                     .get_mut();
 
-                let storage_id = graphs.get(&graph).ok_or(TestError::MissingGraph(graph))?;
-                let storage = state.provider().get_storage(*storage_id)?;
+                let graph_id = graphs.get(&graph).ok_or(TestError::MissingGraph(graph))?;
+                let storage = state.provider().get_storage(*graph_id)?;
                 let head = storage.get_head()?;
                 print_graph(storage, head)?;
             }
@@ -693,10 +693,10 @@ where
                     .ok_or(TestError::MissingClient)?
                     .borrow_mut();
 
-                let storage_id = graphs.get(&graph).ok_or(TestError::MissingGraph(graph))?;
+                let graph_id = graphs.get(&graph).ok_or(TestError::MissingGraph(graph))?;
 
-                let storage_a = state_a.provider().get_storage(*storage_id)?;
-                let storage_b = state_b.provider().get_storage(*storage_id)?;
+                let storage_a = state_a.provider().get_storage(*graph_id)?;
+                let storage_b = state_b.provider().get_storage(*graph_id)?;
 
                 let same = graph_eq(storage_a, storage_b);
                 if same != equal {
@@ -731,8 +731,8 @@ where
                     .get(&client)
                     .ok_or(TestError::MissingClient)?
                     .borrow_mut();
-                let storage_id = graphs.get(&graph).ok_or(TestError::MissingGraph(graph))?;
-                let storage = state.provider().get_storage(*storage_id)?;
+                let graph_id = graphs.get(&graph).ok_or(TestError::MissingGraph(graph))?;
+                let storage = state.provider().get_storage(*graph_id)?;
                 let head = storage.get_head()?;
                 let seg = storage.get_segment(head)?;
                 let command = seg.get_command(head).assume("command must exist")?;
@@ -930,12 +930,12 @@ fn sync<SP: StorageProvider>(
     request_state: &mut ClientState<TestPolicyStore, SP>,
     response_state: &mut ClientState<TestPolicyStore, SP>,
     sink: &mut TestSink,
-    storage_id: GraphId,
+    graph_id: GraphId,
 ) -> Result<(usize, usize), TestError> {
-    let mut request_syncer = SyncRequester::new(storage_id, &mut Rng);
+    let mut request_syncer = SyncRequester::new(graph_id, &mut Rng);
     assert!(request_syncer.ready());
 
-    let mut request_trx = request_state.transaction(storage_id);
+    let mut request_trx = request_state.transaction(graph_id);
 
     let mut buffer = [0u8; MAX_SYNC_MESSAGE_SIZE];
     let (len, sent) = request_syncer.poll(&mut buffer, request_state.provider(), request_cache)?;
@@ -957,7 +957,7 @@ fn sync<SP: StorageProvider>(
         received = request_state.add_commands(&mut request_trx, sink, &cmds)?;
         request_state.commit(&mut request_trx, sink)?;
         request_state.update_heads(
-            storage_id,
+            graph_id,
             cmds.iter().filter_map(|cmd| cmd.address().ok()),
             request_cache,
         )?;

--- a/crates/aranya-runtime/src/vm_policy.rs
+++ b/crates/aranya-runtime/src/vm_policy.rs
@@ -83,12 +83,12 @@
 //! let mut cs = ClientState::new(policy_store, provider);
 //! let mut sink = MySink::new();
 //!
-//! let storage_id = cs
+//! let graph_id = cs
 //!     .new_graph(&[0u8], vm_action!(init(0)), &mut sink)
 //!     .expect("could not create graph");
 //! ```
 //!
-//! Because the ID of this initial command is also the storage ID of the resulting graph,
+//! Because the ID of this initial command is also the ID of the resulting graph,
 //! some data within the command must be present to ensure that multiple initial commands
 //! create distinct IDs for each graph. If no other suitable data exists, it is good
 //! practice to add a nonce field that is distinct for each graph.
@@ -154,7 +154,7 @@ pub use protocol::*;
 /// ```ignore
 /// let x = 42;
 /// let y = text!("asdf");
-/// client.action(storage_id, sink, vm_action!(foobar(x, y)))
+/// client.action(graph_id, sink, vm_action!(foobar(x, y)))
 /// ```
 #[macro_export]
 macro_rules! vm_action {
@@ -177,7 +177,7 @@ macro_rules! vm_action {
 /// let val = 3;
 /// sink.add_expectation(vm_effect!(StuffHappened { x: 1, y: val }));
 ///
-/// client.action(storage_id, sink, vm_action!(create(val)))
+/// client.action(graph_id, sink, vm_action!(create(val)))
 /// ```
 #[macro_export]
 macro_rules! vm_effect {


### PR DESCRIPTION
This is more accurate. We don't have storage IDs. The graph itself has an ID globally, and you can fetch the local storage for a graph by it's graph ID.