### PR TITLE
runtime: remove `many_clients` dsl test

### DIFF
--- a/crates/aranya-runtime/src/testing/dsl.rs
+++ b/crates/aranya-runtime/src/testing/dsl.rs
@@ -1141,7 +1141,6 @@ test_vectors! {
     large_sync,
     list_multiple_graph_ids,
     many_branches,
-    many_clients,
     max_cut,
     missing_parent_after_sync,
     remove_graph,

--- a/crates/aranya-runtime/src/testing/testdata/many_clients.test
+++ b/crates/aranya-runtime/src/testing/testdata/many_clients.test
@@ -1,9 +1,0 @@
-[
-  { 
-    "SetupClientsAndGraph": {
-      "clients": 1000, 
-      "graph": 0, 
-      "policy": 0
-    }
-  } 
-]


### PR DESCRIPTION
This doesn't really test much since it just syncs the same init command many times.