### PR TITLE
aranya-crypto: remove bearssl re-export and feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,17 +146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aranya-bearssl-sys"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c84dcd0c2e09e4dfd3a9d913719d89e6982056cfdc6d78d7c9fc8ca097c642"
-dependencies = [
- "bindgen 0.70.1",
- "cc",
- "glob",
-]
-
-[[package]]
 name = "aranya-capi-codegen"
 version = "0.7.0"
 dependencies = [
@@ -625,7 +614,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -693,24 +682,6 @@ dependencies = [
  "shlex",
  "syn",
  "which",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
 ]
 
 [[package]]
@@ -3133,7 +3104,6 @@ checksum = "c901b44b1697abe85dc4797e0689fe0ae0c24a2318d4996ae0421df9df71665a"
 dependencies = [
  "aes",
  "aes-gcm",
- "aranya-bearssl-sys",
  "buggy",
  "cfg-if",
  "crypto-common",

--- a/crates/aranya-crypto/Cargo.toml
+++ b/crates/aranya-crypto/Cargo.toml
@@ -36,9 +36,6 @@ alloc = [
 	"spideroak-crypto/alloc",
 ]
 
-# Enable BearSSL.
-bearssl = ["spideroak-crypto/bearssl"]
-
 # Enable committing AEAD implementations.
 committing-aead = ["spideroak-crypto/committing-aead"]
 
@@ -194,7 +191,6 @@ always_include_features = [
 	"afc",
 	"alloc",
 	"apq",
-	"bearssl",
 	"clone-aead",
 	"committing-aead",
 	"ed25519_batch",

--- a/crates/aranya-crypto/src/ciphersuite/mod.rs
+++ b/crates/aranya-crypto/src/ciphersuite/mod.rs
@@ -100,57 +100,6 @@ pub trait CipherSuite {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "bearssl")]
-    mod bearssl {
-        use spideroak_crypto::oid::consts::{DHKEM_P256_HKDF_SHA256, DHKEM_P521_HKDF_SHA512};
-
-        use crate::{
-            bearssl::{
-                self, Aes256Gcm, HkdfSha256, HkdfSha384, HkdfSha512, HmacSha512, P256, P384, P521,
-                Sha256,
-            },
-            kem_with_oid,
-            test_util::{TestCs, test_ciphersuite},
-        };
-
-        kem_with_oid! {
-            /// DHKEM(P256, HKDF-SHA256).
-            #[derive(Debug)]
-            struct DhKemP256HkdfSha256(bearssl::DhKemP256HkdfSha256) => DHKEM_P256_HKDF_SHA256
-        }
-
-        kem_with_oid! {
-            /// DHKEM(P521, HKDF-SHA512).
-            #[derive(Debug)]
-            struct DhKemP521HkdfSha512(bearssl::DhKemP521HkdfSha512) => DHKEM_P521_HKDF_SHA512
-        }
-
-        test_ciphersuite!(p256, TestCs<
-            Aes256Gcm,
-            Sha256,
-            HkdfSha256,
-            DhKemP256HkdfSha256,
-            HmacSha512,
-            P256,
-        >);
-        test_ciphersuite!(p384, TestCs<
-            Aes256Gcm,
-            Sha256,
-            HkdfSha384,
-            DhKemP256HkdfSha256, // DhKemP384HkdfSha384 does not exist
-            HmacSha512,
-            P384,
-        >);
-        test_ciphersuite!(p521, TestCs<
-            Aes256Gcm,
-            Sha256,
-            HkdfSha512,
-            DhKemP521HkdfSha512,
-            HmacSha512,
-            P521,
-        >);
-    }
-
     mod rust {
         use spideroak_crypto::{
             oid::consts::DHKEM_P256_HKDF_SHA256,

--- a/crates/aranya-crypto/src/lib.rs
+++ b/crates/aranya-crypto/src/lib.rs
@@ -73,10 +73,6 @@ pub use keystore::{KeyStore, KeyStoreExt};
 // These were already exported in the root of the crate, so keep
 // them even though `policy` is a public module now.
 pub use policy::{Cmd, CmdId, PolicyId, merge_cmd_id};
-#[doc(no_inline)]
-#[cfg(feature = "bearssl")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bearssl")))]
-pub use spideroak_crypto::bearssl;
 /// Constant time cryptographic operations.
 #[doc(inline)]
 pub use spideroak_crypto::subtle;

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -248,12 +248,6 @@ user-id = 293722 # aranya-project-bot
 start = "2024-10-16"
 end = "2025-12-19"
 
-[[trusted.aranya-bearssl-sys]]
-criteria = "safe-to-deploy"
-user-id = 293722 # aranya-project-bot
-start = "2024-10-15"
-end = "2025-12-19"
-
 [[trusted.aranya-capi-codegen]]
 criteria = "safe-to-deploy"
 user-id = 293722 # aranya-project-bot

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -36,12 +36,6 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
-[[publisher.aranya-bearssl-sys]]
-version = "0.1.0"
-when = "2024-10-15"
-user-id = 293722
-user-login = "aranya-project-bot"
-
 [[publisher.buggy]]
 version = "0.1.0"
 when = "2025-01-24"


### PR DESCRIPTION
The `aranya-crypto` bearssl feature just re-exports `spideroak_crypto::bearssl`. If we or someone else wants to use it for something we can still just use it from `spideroak_crypto`. Removing it here means that `aranya-core` CI doesn't need to build it and run tests for it.