### PR TITLE
policy-module: make `ConstValue::vtype` infallible

### DIFF
--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1137,7 +1137,7 @@ impl<'a> CompileState<'a> {
         let expression = &global_let.expression;
 
         let value = self.expression_value(expression)?;
-        let vt = value.vtype().expect("global let expression has weird type");
+        let vt = value.vtype();
 
         match self.m.interface.globals.entry(identifier.name.clone()) {
             Entry::Vacant(e) => {

--- a/crates/aranya-policy-module/src/data.rs
+++ b/crates/aranya-policy-module/src/data.rs
@@ -49,28 +49,28 @@ impl ConstValue {
     pub const NONE: Self = Self::Option(None);
 
     /// Get the associated [`TypeKind`].
-    pub fn vtype(&self) -> Option<TypeKind> {
+    pub fn vtype(&self) -> TypeKind {
         match self {
-            Self::Int(_) => Some(TypeKind::Int),
-            Self::Bool(_) => Some(TypeKind::Bool),
-            Self::String(_) => Some(TypeKind::String),
-            Self::Enum(name, _) => Some(TypeKind::Enum(Ident {
+            Self::Int(_) => TypeKind::Int,
+            Self::Bool(_) => TypeKind::Bool,
+            Self::String(_) => TypeKind::String,
+            Self::Enum(name, _) => TypeKind::Enum(Ident {
                 name: name.to_owned(),
                 span: Span::empty(),
-            })),
-            Self::Struct(s) => Some(TypeKind::Struct(Ident {
+            }),
+            Self::Struct(s) => TypeKind::Struct(Ident {
                 name: s.name.clone(),
                 span: Span::empty(),
-            })),
+            }),
             Self::Option(o) => {
                 let inner_kind = match o {
-                    Some(inner_value) => inner_value.vtype()?,
+                    Some(inner_value) => inner_value.vtype(),
                     None => TypeKind::Never,
                 };
-                Some(TypeKind::Optional(Box::new(VType {
+                TypeKind::Optional(Box::new(VType {
                     kind: inner_kind,
                     span: Span::empty(),
-                })))
+                }))
             }
         }
     }


### PR DESCRIPTION
I forgot to do this in #584, this was part of the motivation.