### PR TITLE
clean up lifetimes

### DIFF
--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -1731,9 +1731,9 @@ fn parse_policy_chunk(
     parse_policy_chunk_inner(chunk, &p, policy).map_err(|e| e.with_source(policy.text.clone()))
 }
 
-fn parse_policy_chunk_inner<'a>(
-    chunk: Pairs<'a, Rule>,
-    p: &ChunkParser<'a>,
+fn parse_policy_chunk_inner(
+    chunk: Pairs<'_, Rule>,
+    p: &ChunkParser<'_>,
     policy: &mut ast::Policy,
 ) -> Result<(), ParseError> {
     for item in chunk {


### PR DESCRIPTION
Targeting #524. Many of the lifetimes were more restrictive than they needed to be.