### PR TITLE
Ignore advisory RUSTSEC-2026-0097

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -77,6 +77,7 @@ yanked = "warn"
 # output a note when they are encountered.
 ignore = [
     { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but shouldn't need any, and we don't use it directly" },
+    { id = "RUSTSEC-2026-0097", reason = "we don't use the features required to hit the bug" },
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish


### PR DESCRIPTION
We aren't using the `log` or `thread_rng` features of `rand`, so this advisory doesn't apply to us.