### PR TITLE
core: reexport aranya_crypto and keystore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
 name = "canary-std"
 version = "0.0.0"
 dependencies = [
+ "aranya-core",
  "aranya-crypto",
  "aranya-crypto-ffi",
  "aranya-device-ffi",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -46,7 +46,7 @@ dependencies = ["install-cargo-all-features"]
 category = "test"
 description = "Run aranya-core example"
 command = "cargo"
-args = ["run", "-p", "aranya-core", "--example", "simple", "--features", "std,libc"]
+args = ["run", "-p", "aranya-core", "--example", "simple", "--features", "std,libc,memstore"]
 
 
 # Security

--- a/canaries/canary-std/Cargo.toml
+++ b/canaries/canary-std/Cargo.toml
@@ -8,6 +8,10 @@ rust-version.workspace = true
 
 [dependencies]
 # aranya-afc-util = { path = "../../crates/aranya-afc-util", features = ["alloc"] }
+aranya-core = { path = "../../crates/aranya-core", default-features = false, features = [
+	"custom-engine",
+	"memstore",
+] }
 # `aranya-crypto` enables `getrandom` by default.
 aranya-crypto = { path = "../../crates/aranya-crypto", default-features = false, features = [
 	"alloc",

--- a/canaries/canary-std/src/main.rs
+++ b/canaries/canary-std/src/main.rs
@@ -2,6 +2,7 @@
 #![no_std]
 #![no_main]
 
+extern crate aranya_core;
 extern crate aranya_crypto;
 extern crate aranya_crypto_ffi;
 extern crate aranya_device_ffi;

--- a/crates/aranya-core/Cargo.toml
+++ b/crates/aranya-core/Cargo.toml
@@ -21,11 +21,16 @@ default = []
 libc = ["aranya-runtime/libc"]
 
 std = [
+	"aranya-crypto/getrandom",
 	"aranya-crypto/std",
 	"aranya-runtime/std",
 ]
 
 low-mem-usage = ["aranya-runtime/low-mem-usage"]
+
+custom-engine = []
+
+memstore = ["aranya-crypto/memstore"]
 
 [dev-dependencies]
 anyhow = "1"
@@ -46,4 +51,4 @@ aranya-policy-vm = { path = "../aranya-policy-vm" }
 [[example]]
 name = "simple"
 path = "examples/simple.rs"
-required-features = ["std", "libc"]
+required-features = ["std", "libc", "memstore"]

--- a/crates/aranya-core/examples/simple.rs
+++ b/crates/aranya-core/examples/simple.rs
@@ -9,14 +9,13 @@ use std::fs;
 use anyhow::{Context as _, Result};
 use aranya_core::{
     ClientState, Command as _, GraphId, Sink, TraversalBuffer, TraversalBuffers,
+    crypto::{DefaultCipherSuite, DefaultEngine, Rng},
+    keystore::{
+        DeviceId, EncryptionKey, Identified, IdentityKey, KeyStoreExt as _, MemStore, SigningKey,
+    },
     policy::{FfiCallable, VmEffect, VmPolicy, VmPolicyStore},
     storage::{FileManager, LinearStorageProvider},
     sync::{MAX_SYNC_MESSAGE_SIZE, PeerCache, SyncRequester, SyncResponder, SyncType},
-};
-use aranya_crypto::{
-    DeviceId, EncryptionKey, IdentityKey, Rng, SigningKey,
-    default::{DefaultCipherSuite, DefaultEngine},
-    keystore::{KeyStoreExt as _, memstore::MemStore},
 };
 use aranya_crypto_ffi::Ffi as CryptoFfi;
 use aranya_device_ffi::FfiDevice as DeviceFfi;
@@ -73,8 +72,8 @@ struct DeviceKeys {
     engine: CE,
     store: MemStore,
     device_id: DeviceId,
-    sign_id: <SigningKey<CS> as aranya_crypto::Identified>::Id,
-    enc_id: <EncryptionKey<CS> as aranya_crypto::Identified>::Id,
+    sign_id: <SigningKey<CS> as Identified>::Id,
+    enc_id: <EncryptionKey<CS> as Identified>::Id,
     ident_pk_bytes: Vec<u8>,
     sign_pk_bytes: Vec<u8>,
     enc_pk_bytes: Vec<u8>,

--- a/crates/aranya-core/src/lib.rs
+++ b/crates/aranya-core/src/lib.rs
@@ -6,6 +6,8 @@
 //!
 //! # Modules
 //!
+//! - [`crypto`] — cryptography engine and cipher suite.
+//! - [`keystore`] — device key material and keystore plumbing.
 //! - [`storage`] — storage providers and I/O plumbing for the graph.
 //! - [`policy`] — VM-backed policy execution (actions, effects, FFI).
 //! - [`sync`] — peer-to-peer sync protocol for replicating graph state.
@@ -65,6 +67,68 @@ pub mod policy {
 
     #[doc(inline)]
     pub use crate::VmPolicyStore;
+}
+
+pub mod crypto {
+    //! Cryptography engine and cipher suite.
+    //!
+    //! Most consumers should use [`DefaultEngine`] parameterized on
+    //! [`DefaultCipherSuite`] and [`Rng`]:
+    //!
+    //! ```ignore
+    //! use aranya_core::crypto::{DefaultCipherSuite, DefaultEngine, Rng};
+    //!
+    //! let (engine, key) =
+    //!     DefaultEngine::<Rng, DefaultCipherSuite>::from_entropy(Rng);
+    //! ```
+    //!
+    //! The returned AEAD key is the root of trust for wrapped keys and
+    //! must be persisted securely.
+    //!
+    //! To implement a custom [`Engine`], enable the `custom-engine`
+    //! feature. This exposes the low-level trait surface
+    //! ([`RawSecretWrap`], [`UnwrappedKey`], [`WrappedKey`], etc.) needed
+    //! to write a conforming engine. Custom engines are security-critical
+    //! and should be reviewed by cryptographers.
+
+    #[doc(inline)]
+    pub use aranya_crypto::{
+        CipherSuite, Engine, Rng, UnwrapError, WrapError,
+        default::{DefaultCipherSuite, DefaultEngine},
+    };
+    #[cfg(feature = "custom-engine")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "custom-engine")))]
+    #[doc(inline)]
+    pub use aranya_crypto::{
+        Csprng, Random,
+        engine::{
+            AlgId, RawSecret, RawSecretWrap, Secret, UnwrappedKey, UnwrappedSecret, WrappedKey,
+            WrongKeyType,
+        },
+    };
+}
+
+pub mod keystore {
+    //! Device key material and keystore plumbing.
+    //!
+    //! Device keys — [`IdentityKey`], [`SigningKey`], and [`EncryptionKey`] —
+    //! are stored as wrapped secrets in a [`KeyStore`]. [`KeyStoreExt`] is a
+    //! blanket-impl convenience trait layered over [`KeyStore`] that adds
+    //! `insert_key`/`get_key`/`remove_key` using the
+    //! [`Engine`](crate::crypto::Engine)-based wrap/unwrap path. [`Identified`]
+    //! is the trait that ties each key to its stable [`Identified::Id`].
+    //!
+    //! [`MemStore`] is an in-memory [`KeyStore`] suitable for tests and
+    //! short-lived sessions; enable the `memstore` feature to use it.
+
+    #[cfg(feature = "memstore")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "memstore")))]
+    #[doc(inline)]
+    pub use aranya_crypto::keystore::memstore::MemStore;
+    #[doc(inline)]
+    pub use aranya_crypto::{
+        DeviceId, EncryptionKey, Identified, IdentityKey, KeyStore, KeyStoreExt, SigningKey,
+    };
 }
 
 pub mod sync {

--- a/crates/aranya-core/src/lib.rs
+++ b/crates/aranya-core/src/lib.rs
@@ -91,18 +91,15 @@ pub mod crypto {
 
     #[doc(inline)]
     pub use aranya_crypto::{
-        CipherSuite, Engine, Rng, UnwrapError, WrapError,
+        CipherSuite, Csprng, Engine, Random, Rng, UnwrapError, WrapError,
         default::{DefaultCipherSuite, DefaultEngine},
     };
     #[cfg(feature = "custom-engine")]
     #[cfg_attr(docsrs, doc(cfg(feature = "custom-engine")))]
     #[doc(inline)]
-    pub use aranya_crypto::{
-        Csprng, Random,
-        engine::{
-            AlgId, RawSecret, RawSecretWrap, Secret, UnwrappedKey, UnwrappedSecret, WrappedKey,
-            WrongKeyType,
-        },
+    pub use aranya_crypto::engine::{
+        AlgId, RawSecret, RawSecretWrap, Secret, UnwrappedKey, UnwrappedSecret, WrappedKey,
+        WrongKeyType,
     };
 }
 

--- a/crates/aranya-core/src/lib.rs
+++ b/crates/aranya-core/src/lib.rs
@@ -26,8 +26,6 @@ pub use aranya_runtime::{
     Address, ClientError, ClientState, CmdId, Command, GraphId, Session, Sink, Transaction,
     TraversalBuffer, TraversalBuffers,
 };
-#[doc(inline)]
-pub use client::VmPolicyStore;
 
 pub mod storage {
     //! Storage providers and low-level I/O for the graph.
@@ -66,7 +64,7 @@ pub mod policy {
     };
 
     #[doc(inline)]
-    pub use crate::VmPolicyStore;
+    pub use crate::client::VmPolicyStore;
 }
 
 pub mod crypto {

--- a/crates/aranya-core/src/lib.rs
+++ b/crates/aranya-core/src/lib.rs
@@ -89,17 +89,17 @@ pub mod crypto {
     //! to write a conforming engine. Custom engines are security-critical
     //! and should be reviewed by cryptographers.
 
-    #[doc(inline)]
-    pub use aranya_crypto::{
-        CipherSuite, Csprng, Engine, Random, Rng, UnwrapError, WrapError,
-        default::{DefaultCipherSuite, DefaultEngine},
-    };
     #[cfg(feature = "custom-engine")]
     #[cfg_attr(docsrs, doc(cfg(feature = "custom-engine")))]
     #[doc(inline)]
     pub use aranya_crypto::engine::{
         AlgId, RawSecret, RawSecretWrap, Secret, UnwrappedKey, UnwrappedSecret, WrappedKey,
         WrongKeyType,
+    };
+    #[doc(inline)]
+    pub use aranya_crypto::{
+        CipherSuite, Csprng, Engine, Random, Rng, UnwrapError, WrapError,
+        default::{DefaultCipherSuite, DefaultEngine},
     };
 }
 

--- a/crates/aranya-crypto/src/default.rs
+++ b/crates/aranya-crypto/src/default.rs
@@ -61,6 +61,11 @@ mod __private {
 pub(crate) use __private::DhKemP256HkdfSha256;
 
 /// A basic [`Engine`] implementation that wraps keys with its [`Aead`].
+///
+/// `R` is the CSPRNG used for key and nonce generation; it defaults to
+/// [`Rng`], the system CSPRNG. `S` is the [`CipherSuite`]; it defaults
+/// to [`DefaultCipherSuite`]. Most callers should keep both defaults
+/// and construct the engine via [`DefaultEngine::from_entropy`].
 pub struct DefaultEngine<R: Csprng = Rng, S: CipherSuite = DefaultCipherSuite> {
     aead: S::Aead,
     rng: R,
@@ -88,7 +93,11 @@ impl<R: Csprng, S: CipherSuite> DefaultEngine<R, S> {
     }
 
     /// Creates an [`Engine`] using entropy from `rng` and
-    /// returns it and the generated key.
+    /// returns it alongside the generated AEAD key.
+    ///
+    /// The returned key is the root of trust for every key this
+    /// engine wraps; persist it securely. Losing it means losing
+    /// access to all wrapped keys; leaking it compromises them.
     pub fn from_entropy(rng: R) -> (Self, <S::Aead as Aead>::Key) {
         let key = <S::Aead as Aead>::Key::random(&rng);
         let eng = Self::new(&key, rng);

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -46,6 +46,9 @@ audit-as-crates-io = false
 [policy.aranya-capi-macro]
 audit-as-crates-io = false
 
+[policy.aranya-core]
+audit-as-crates-io = false
+
 [policy.aranya-crypto]
 audit-as-crates-io = false
 


### PR DESCRIPTION
Reexport the Engine, DefaultCipherSuite, and keystore + related members. 