### PR TITLE
policy-ast: add `WithSpan` wrapper and `WithSpanExt` helpers

### DIFF
--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -11,14 +11,14 @@ use crate::{Identifier, Span, Spanned, Text, span::spanned};
 )]
 pub struct Ident {
     /// The identifier name
-    pub name: Identifier,
+    pub inner: Identifier,
     /// The source location of this identifier
     pub span: Span,
 }
 
 impl fmt::Debug for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.name.fmt(f)?;
+        self.inner.fmt(f)?;
         write!(f, " @ {:?}", self.span)?;
         Ok(())
     }
@@ -28,7 +28,7 @@ impl Ident {
     /// Reports whether the identifiers are the same, ignoring
     /// spans.
     pub fn matches(&self, other: &Self) -> bool {
-        self.name == other.name
+        self.inner == other.inner
     }
 }
 
@@ -36,13 +36,13 @@ impl Deref for Ident {
     type Target = Identifier;
 
     fn deref(&self) -> &Self::Target {
-        &self.name
+        &self.inner
     }
 }
 
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.name.fmt(f)
+        self.inner.fmt(f)
     }
 }
 
@@ -51,7 +51,7 @@ where
     T: AsRef<str> + ?Sized,
 {
     fn eq(&self, other: &T) -> bool {
-        self.name == other.as_ref()
+        self.inner == other.as_ref()
     }
 }
 
@@ -177,14 +177,14 @@ impl fmt::Display for Persistence {
 )]
 pub struct VType {
     /// The type kind
-    pub kind: TypeKind,
+    pub inner: TypeKind,
     /// The source location of this type
     pub span: Span,
 }
 
 impl fmt::Debug for VType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.kind.fmt(f)?;
+        self.inner.fmt(f)?;
         write!(f, " @ {:?}", self.span)?;
         Ok(())
     }
@@ -193,17 +193,17 @@ impl fmt::Debug for VType {
 impl VType {
     /// Reports whether the types are the same, ignoring spans.
     pub fn matches(&self, other: &Self) -> bool {
-        self.kind.matches(&other.kind)
+        self.inner.matches(&other.inner)
     }
 
     /// Checks if two types fit, where `Never` matches with any type.
     pub fn fits_type(&self, other: &Self) -> bool {
-        self.kind.fits_type(&other.kind)
+        self.inner.fits_type(&other.inner)
     }
 
     /// Gets the struct name if this type is a struct.
     pub fn as_struct(&self) -> Option<&Ident> {
-        if let TypeKind::Struct(name) = &self.kind {
+        if let TypeKind::Struct(name) = &self.inner {
             Some(name)
         } else {
             None
@@ -213,7 +213,7 @@ impl VType {
 
 impl fmt::Display for VType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.kind.fmt(f)
+        self.inner.fmt(f)
     }
 }
 
@@ -310,11 +310,11 @@ impl TypeKind {
             | (Self::Bool, Self::Bool)
             | (Self::Id, Self::Id)
             | (Self::Never, Self::Never) => true,
-            (Self::Struct(lhs), Self::Struct(rhs)) => lhs.name == rhs.name,
-            (Self::Enum(lhs), Self::Enum(rhs)) => lhs.name == rhs.name,
-            (Self::Optional(lhs), Self::Optional(rhs)) => lhs.kind.matches(&rhs.kind),
+            (Self::Struct(lhs), Self::Struct(rhs)) => lhs.inner == rhs.inner,
+            (Self::Enum(lhs), Self::Enum(rhs)) => lhs.inner == rhs.inner,
+            (Self::Optional(lhs), Self::Optional(rhs)) => lhs.inner.matches(&rhs.inner),
             (Self::Result(lhs), Self::Result(rhs)) => {
-                lhs.ok.kind.matches(&rhs.ok.kind) && lhs.err.kind.matches(&rhs.err.kind)
+                lhs.ok.inner.matches(&rhs.ok.inner) && lhs.err.inner.matches(&rhs.err.inner)
             }
             _ => false,
         }
@@ -329,9 +329,9 @@ impl TypeKind {
             | (Self::Int, Self::Int)
             | (Self::Bool, Self::Bool)
             | (Self::Id, Self::Id) => true,
-            (Self::Struct(lhs), Self::Struct(rhs)) => lhs.name == rhs.name,
-            (Self::Enum(lhs), Self::Enum(rhs)) => lhs.name == rhs.name,
-            (Self::Optional(lhs), Self::Optional(rhs)) => lhs.kind.fits_type(&rhs.kind),
+            (Self::Struct(lhs), Self::Struct(rhs)) => lhs.inner == rhs.inner,
+            (Self::Enum(lhs), Self::Enum(rhs)) => lhs.inner == rhs.inner,
+            (Self::Optional(lhs), Self::Optional(rhs)) => lhs.inner.fits_type(&rhs.inner),
             (Self::Result(lhs), Self::Result(rhs)) => {
                 lhs.ok.fits_type(&rhs.ok) && lhs.err.fits_type(&rhs.err)
             }
@@ -604,14 +604,14 @@ pub struct ForeignFunctionCall {
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Expression {
     /// The expression kind
-    pub kind: ExprKind,
+    pub inner: ExprKind,
     /// The source location of this expression
     pub span: Span,
 }
 
 impl fmt::Debug for Expression {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.kind.fmt(f)?;
+        self.inner.fmt(f)?;
         write!(f, " @ {:?}", self.span)?;
         Ok(())
     }
@@ -699,11 +699,11 @@ impl ExprKind {
 
             // Optional types
             (Self::Optional(None), Self::Optional(None)) => true,
-            (Self::Optional(Some(a)), Self::Optional(Some(b))) => a.kind.matches(&b.kind),
+            (Self::Optional(Some(a)), Self::Optional(Some(b))) => a.inner.matches(&b.inner),
 
             // Result types
-            (Self::Ok(a), Self::Ok(b)) => a.kind.matches(&b.kind),
-            (Self::Err(a), Self::Err(b)) => a.kind.matches(&b.kind),
+            (Self::Ok(a), Self::Ok(b)) => a.inner.matches(&b.inner),
+            (Self::Err(a), Self::Err(b)) => a.inner.matches(&b.inner),
 
             // Identifier
             (Self::Identifier(a), Self::Identifier(b)) => a.matches(b),
@@ -715,7 +715,7 @@ impl ExprKind {
                     && a.fields
                         .iter()
                         .zip(&b.fields)
-                        .all(|((k1, v1), (k2, v2))| k1.matches(k2) && v1.kind.matches(&v2.kind))
+                        .all(|((k1, v1), (k2, v2))| k1.matches(k2) && v1.inner.matches(&v2.inner))
                     && a.sources.len() == b.sources.len()
                     && a.sources
                         .iter()
@@ -735,7 +735,7 @@ impl ExprKind {
                     && a.arguments
                         .iter()
                         .zip(&b.arguments)
-                        .all(|(e1, e2)| e1.kind.matches(&e2.kind))
+                        .all(|(e1, e2)| e1.inner.matches(&e2.inner))
             }
 
             // Foreign function call
@@ -746,7 +746,7 @@ impl ExprKind {
                     && a.arguments
                         .iter()
                         .zip(&b.arguments)
-                        .all(|(e1, e2)| e1.kind.matches(&e2.kind))
+                        .all(|(e1, e2)| e1.inner.matches(&e2.inner))
             }
 
             // Internal functions
@@ -793,13 +793,13 @@ impl ExprKind {
                             }
                     }
                     (InternalFunction::If(c1, t1, e1), InternalFunction::If(c2, t2, e2)) => {
-                        c1.kind.matches(&c2.kind)
-                            && t1.kind.matches(&t2.kind)
-                            && e1.kind.matches(&e2.kind)
+                        c1.inner.matches(&c2.inner)
+                            && t1.inner.matches(&t2.inner)
+                            && e1.inner.matches(&e2.inner)
                     }
                     (InternalFunction::Serialize(e1), InternalFunction::Serialize(e2))
                     | (InternalFunction::Deserialize(e1), InternalFunction::Deserialize(e2)) => {
-                        e1.kind.matches(&e2.kind)
+                        e1.inner.matches(&e2.inner)
                     }
                     (InternalFunction::Todo(_), InternalFunction::Todo(_)) => true,
                     _ => false,
@@ -810,7 +810,7 @@ impl ExprKind {
             (Self::Return(a), Self::Return(b))
             | (Self::Not(a), Self::Not(b))
             | (Self::Unwrap(a), Self::Unwrap(b))
-            | (Self::CheckUnwrap(a), Self::CheckUnwrap(b)) => a.kind.matches(&b.kind),
+            | (Self::CheckUnwrap(a), Self::CheckUnwrap(b)) => a.inner.matches(&b.inner),
 
             // Two expression variants
             (Self::And(a1, a2), Self::And(b1, b2))
@@ -821,18 +821,18 @@ impl ExprKind {
             | (Self::LessThan(a1, a2), Self::LessThan(b1, b2))
             | (Self::GreaterThanOrEqual(a1, a2), Self::GreaterThanOrEqual(b1, b2))
             | (Self::LessThanOrEqual(a1, a2), Self::LessThanOrEqual(b1, b2)) => {
-                a1.kind.matches(&b1.kind) && a2.kind.matches(&b2.kind)
+                a1.inner.matches(&b1.inner) && a2.inner.matches(&b2.inner)
             }
 
             // Expression with Ident
             (Self::Dot(e1, i1), Self::Dot(e2, i2))
             | (Self::Cast(e1, i1), Self::Cast(e2, i2))
             | (Self::Substruct(e1, i1), Self::Substruct(e2, i2)) => {
-                e1.kind.matches(&e2.kind) && i1.matches(i2)
+                e1.inner.matches(&e2.inner) && i1.matches(i2)
             }
 
             // Is expression
-            (Self::Is(e1, b1), Self::Is(e2, b2)) => e1.kind.matches(&e2.kind) && b1 == b2,
+            (Self::Is(e1, b1), Self::Is(e2, b2)) => e1.inner.matches(&e2.inner) && b1 == b2,
 
             // Block expression
             (Self::Block(stmts1, expr1), Self::Block(stmts2, expr2)) => {
@@ -841,7 +841,7 @@ impl ExprKind {
                         .iter()
                         .zip(stmts2)
                         .all(|(s1, s2)| matches_statement(s1, s2))
-                    && expr1.kind.matches(&expr2.kind)
+                    && expr1.inner.matches(&expr2.inner)
             }
 
             // Match expression
@@ -856,7 +856,7 @@ impl ExprKind {
 /// Helper function to compare FactField instances, ignoring spans.
 fn matches_fact_field(a: &FactField, b: &FactField) -> bool {
     match (a, b) {
-        (FactField::Expression(e1), FactField::Expression(e2)) => e1.kind.matches(&e2.kind),
+        (FactField::Expression(e1), FactField::Expression(e2)) => e1.inner.matches(&e2.inner),
         (FactField::Bind(_), FactField::Bind(_)) => true,
         _ => false,
     }
@@ -865,13 +865,14 @@ fn matches_fact_field(a: &FactField, b: &FactField) -> bool {
 /// Helper function to compare Statement instances, ignoring spans.
 fn matches_statement(a: &Statement, b: &Statement) -> bool {
     use StmtKind::*;
-    match (&a.kind, &b.kind) {
+    match (&a.inner, &b.inner) {
         (Let(l1), Let(l2)) => {
-            l1.identifier.matches(&l2.identifier) && l1.expression.kind.matches(&l2.expression.kind)
+            l1.identifier.matches(&l2.identifier)
+                && l1.expression.inner.matches(&l2.expression.inner)
         }
-        (Check(c1), Check(c2)) => c1.expression.kind.matches(&c2.expression.kind),
+        (Check(c1), Check(c2)) => c1.expression.inner.matches(&c2.expression.inner),
         (Match(m1), Match(m2)) => {
-            m1.expression.kind.matches(&m2.expression.kind)
+            m1.expression.inner.matches(&m2.expression.inner)
                 && m1.arms.len() == m2.arms.len()
                 && m1.arms.iter().zip(&m2.arms).all(|(a1, a2)| {
                     matches_match_pattern(&a1.pattern, &a2.pattern)
@@ -890,7 +891,7 @@ fn matches_statement(a: &Statement, b: &Statement) -> bool {
                     .iter()
                     .zip(&i2.branches)
                     .all(|((cond1, stmts1), (cond2, stmts2))| {
-                        cond1.kind.matches(&cond2.kind)
+                        cond1.inner.matches(&cond2.inner)
                             && stmts1.len() == stmts2.len()
                             && stmts1
                                 .iter()
@@ -919,7 +920,7 @@ fn matches_statement(a: &Statement, b: &Statement) -> bool {
                     .zip(&m2.statements)
                     .all(|(s1, s2)| matches_statement(s1, s2))
         }
-        (Return(r1), Return(r2)) => r1.expression.kind.matches(&r2.expression.kind),
+        (Return(r1), Return(r2)) => r1.expression.inner.matches(&r2.expression.inner),
         (ActionCall(c1), ActionCall(c2)) | (FunctionCall(c1), FunctionCall(c2)) => {
             c1.identifier.matches(&c2.identifier)
                 && c1.arguments.len() == c2.arguments.len()
@@ -927,10 +928,10 @@ fn matches_statement(a: &Statement, b: &Statement) -> bool {
                     .arguments
                     .iter()
                     .zip(&c2.arguments)
-                    .all(|(e1, e2)| e1.kind.matches(&e2.kind))
+                    .all(|(e1, e2)| e1.inner.matches(&e2.inner))
         }
         (Publish(e1), Publish(e2)) | (Emit(e1), Emit(e2)) | (DebugAssert(e1), DebugAssert(e2)) => {
-            e1.kind.matches(&e2.kind)
+            e1.inner.matches(&e2.inner)
         }
         (Create(c1), Create(c2)) => matches_fact_literal(&c1.fact, &c2.fact),
         (Delete(d1), Delete(d2)) => matches_fact_literal(&d1.fact, &d2.fact),
@@ -973,7 +974,11 @@ fn matches_match_pattern(a: &MatchPattern, b: &MatchPattern) -> bool {
     match (a, b) {
         (MatchPattern::Default(_), MatchPattern::Default(_)) => true,
         (MatchPattern::Values(v1), MatchPattern::Values(v2)) => {
-            v1.len() == v2.len() && v1.iter().zip(v2).all(|(e1, e2)| e1.kind.matches(&e2.kind))
+            v1.len() == v2.len()
+                && v1
+                    .iter()
+                    .zip(v2)
+                    .all(|(e1, e2)| e1.inner.matches(&e2.inner))
         }
         _ => false,
     }
@@ -981,11 +986,11 @@ fn matches_match_pattern(a: &MatchPattern, b: &MatchPattern) -> bool {
 
 /// Helper function to compare MatchExpression instances, ignoring spans.
 fn matches_match_expression(a: &MatchExpression, b: &MatchExpression) -> bool {
-    a.scrutinee.kind.matches(&b.scrutinee.kind)
+    a.scrutinee.inner.matches(&b.scrutinee.inner)
         && a.arms.len() == b.arms.len()
         && a.arms.iter().zip(&b.arms).all(|(a1, a2)| {
             matches_match_pattern(&a1.pattern, &a2.pattern)
-                && a1.expression.kind.matches(&a2.expression.kind)
+                && a1.expression.inner.matches(&a2.expression.inner)
         })
 }
 
@@ -1187,14 +1192,14 @@ pub struct ReturnStatement {
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Statement {
     /// The statement kind
-    pub kind: StmtKind,
+    pub inner: StmtKind,
     /// The source location of this statement
     pub span: Span,
 }
 
 impl fmt::Debug for Statement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.kind.fmt(f)?;
+        self.inner.fmt(f)?;
         write!(f, " @ {:?}", self.span)?;
         Ok(())
     }

--- a/crates/aranya-policy-ast/src/ast.rs
+++ b/crates/aranya-policy-ast/src/ast.rs
@@ -1,28 +1,15 @@
 use alloc::{borrow::ToOwned as _, boxed::Box, string::String, vec::Vec};
-use core::{fmt, ops::Deref, str::FromStr};
+use core::{fmt, str::FromStr};
 
 use serde_derive::{Deserialize, Serialize};
 
-use crate::{Identifier, Span, Spanned, Text, span::spanned};
+use crate::{
+    Identifier, Span, Spanned, Text,
+    span::{WithSpan, spanned},
+};
 
 /// An identifier.
-#[derive(
-    Clone, Eq, PartialEq, Serialize, Deserialize, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
-)]
-pub struct Ident {
-    /// The identifier name
-    pub inner: Identifier,
-    /// The source location of this identifier
-    pub span: Span,
-}
-
-impl fmt::Debug for Ident {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)?;
-        write!(f, " @ {:?}", self.span)?;
-        Ok(())
-    }
-}
+pub type Ident = WithSpan<Identifier>;
 
 impl Ident {
     /// Reports whether the identifiers are the same, ignoring
@@ -32,32 +19,12 @@ impl Ident {
     }
 }
 
-impl Deref for Ident {
-    type Target = Identifier;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl fmt::Display for Ident {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
 impl<T> PartialEq<T> for Ident
 where
     T: AsRef<str> + ?Sized,
 {
     fn eq(&self, other: &T) -> bool {
         self.inner == other.as_ref()
-    }
-}
-
-impl Spanned for Ident {
-    fn span(&self) -> Span {
-        self.span
     }
 }
 
@@ -171,24 +138,7 @@ impl fmt::Display for Persistence {
 /// The type of a value
 ///
 /// It is not called `Type` because that conflicts with reserved keywords.
-#[must_use]
-#[derive(
-    Clone, Eq, PartialEq, Serialize, Deserialize, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
-)]
-pub struct VType {
-    /// The type kind
-    pub inner: TypeKind,
-    /// The source location of this type
-    pub span: Span,
-}
-
-impl fmt::Debug for VType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)?;
-        write!(f, " @ {:?}", self.span)?;
-        Ok(())
-    }
-}
+pub type VType = WithSpan<TypeKind>;
 
 impl VType {
     /// Reports whether the types are the same, ignoring spans.
@@ -208,18 +158,6 @@ impl VType {
         } else {
             None
         }
-    }
-}
-
-impl fmt::Display for VType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
-impl Spanned for VType {
-    fn span(&self) -> Span {
-        self.span
     }
 }
 
@@ -601,27 +539,7 @@ pub struct ForeignFunctionCall {
 }
 
 /// All of the things which can be in an expression.
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
-pub struct Expression {
-    /// The expression kind
-    pub inner: ExprKind,
-    /// The source location of this expression
-    pub span: Span,
-}
-
-impl fmt::Debug for Expression {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)?;
-        write!(f, " @ {:?}", self.span)?;
-        Ok(())
-    }
-}
-
-impl Spanned for Expression {
-    fn span(&self) -> Span {
-        self.span
-    }
-}
+pub type Expression = WithSpan<ExprKind>;
 
 /// The kind of [`Expression`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1188,28 +1106,9 @@ pub struct ReturnStatement {
 }
 
 /// Statements in the policy language.
+///
 /// Not all statements are valid in all contexts.
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
-pub struct Statement {
-    /// The statement kind
-    pub inner: StmtKind,
-    /// The source location of this statement
-    pub span: Span,
-}
-
-impl fmt::Debug for Statement {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)?;
-        write!(f, " @ {:?}", self.span)?;
-        Ok(())
-    }
-}
-
-impl Spanned for Statement {
-    fn span(&self) -> Span {
-        self.span
-    }
-}
+pub type Statement = WithSpan<StmtKind>;
 
 /// The kind of [`Statement`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/aranya-policy-ast/src/lib.rs
+++ b/crates/aranya-policy-ast/src/lib.rs
@@ -20,4 +20,4 @@ mod tests;
 
 pub use aranya_policy_text::*;
 pub use ast::*;
-pub use span::{Span, Spanned};
+pub use span::{Span, Spanned, WithSpan, WithSpanExt};

--- a/crates/aranya-policy-ast/src/span.rs
+++ b/crates/aranya-policy-ast/src/span.rs
@@ -18,6 +18,7 @@ use serde_derive::{Deserialize, Serialize};
     rkyv::Deserialize,
     rkyv::Serialize,
 )]
+#[must_use]
 pub struct WithSpan<T> {
     pub inner: T,
     pub span: Span,
@@ -26,6 +27,11 @@ pub struct WithSpan<T> {
 impl<T> WithSpan<T> {
     pub fn new(inner: T, span: Span) -> Self {
         Self { inner, span }
+    }
+
+    pub fn with_no_span(mut self) -> Self {
+        self.span = Span::empty();
+        self
     }
 }
 
@@ -55,6 +61,17 @@ impl<T: fmt::Display> fmt::Display for WithSpan<T> {
         self.inner.fmt(f)
     }
 }
+
+pub trait WithSpanExt: Sized {
+    fn at(self, span: impl Into<Span>) -> WithSpan<Self> {
+        WithSpan::new(self, span.into())
+    }
+
+    fn nowhere(self) -> WithSpan<Self> {
+        WithSpan::new(self, Span::empty())
+    }
+}
+impl<T> WithSpanExt for T {}
 
 /// A range in the source text.
 #[derive(

--- a/crates/aranya-policy-ast/src/span.rs
+++ b/crates/aranya-policy-ast/src/span.rs
@@ -6,6 +6,7 @@ use core::{
 
 use serde_derive::{Deserialize, Serialize};
 
+/// Wraps a type to add a [`Span`].
 #[derive(
     Clone,
     Copy,
@@ -20,15 +21,21 @@ use serde_derive::{Deserialize, Serialize};
 )]
 #[must_use]
 pub struct WithSpan<T> {
+    /// The inner value.
     pub inner: T,
+    /// The span.
     pub span: Span,
 }
 
 impl<T> WithSpan<T> {
+    /// Create a new `WithSpan`.
+    ///
+    /// See also [`WithSpanExt::at`].
     pub fn new(inner: T, span: Span) -> Self {
         Self { inner, span }
     }
 
+    /// Erase this `WithSpan`'s span.
     pub fn with_no_span(mut self) -> Self {
         self.span = Span::empty();
         self
@@ -62,11 +69,26 @@ impl<T: fmt::Display> fmt::Display for WithSpan<T> {
     }
 }
 
+/// Extension trait to wrap `T` into [`WithSpan<T>`].
 pub trait WithSpanExt: Sized {
+    /// Wrap with the given span.
+    ///
+    /// ```
+    /// use aranya_policy_ast::{TypeKind, VType, WithSpanExt};
+    ///
+    /// let vtype: VType = TypeKind::Int.at(10..13);
+    /// ```
     fn at(self, span: impl Into<Span>) -> WithSpan<Self> {
         WithSpan::new(self, span.into())
     }
 
+    /// Wrap with an empty span.
+    ///
+    /// ```
+    /// use aranya_policy_ast::{TypeKind, VType, WithSpanExt};
+    ///
+    /// let vtype: VType = TypeKind::Int.nowhere();
+    /// ```
     fn nowhere(self) -> WithSpan<Self> {
         WithSpan::new(self, Span::empty())
     }

--- a/crates/aranya-policy-ast/src/span.rs
+++ b/crates/aranya-policy-ast/src/span.rs
@@ -6,6 +6,56 @@ use core::{
 
 use serde_derive::{Deserialize, Serialize};
 
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+pub struct WithSpan<T> {
+    pub inner: T,
+    pub span: Span,
+}
+
+impl<T> WithSpan<T> {
+    pub fn new(inner: T, span: Span) -> Self {
+        Self { inner, span }
+    }
+}
+
+impl<T> Spanned for WithSpan<T> {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl<T> core::ops::Deref for WithSpan<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for WithSpan<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)?;
+        write!(f, " @ {:?}", self.span)?;
+        Ok(())
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for WithSpan<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
 /// A range in the source text.
 #[derive(
     Clone,

--- a/crates/aranya-policy-ast/src/tests.rs
+++ b/crates/aranya-policy-ast/src/tests.rs
@@ -8,7 +8,7 @@ use crate::{
 macro_rules! ident_at {
     ($name:expr, $start:expr, $end:expr) => {
         Ident {
-            name: ident!($name),
+            inner: ident!($name),
             span: Span::new($start, $end),
         }
     };
@@ -17,7 +17,7 @@ macro_rules! ident_at {
 macro_rules! expr {
     ($kind:expr, $start:expr, $end:expr) => {
         Expression {
-            kind: $kind,
+            inner: $kind,
             span: Span::new($start, $end),
         }
     };
@@ -77,11 +77,11 @@ macro_rules! result_type {
     ($ok_t:expr, $start1:expr, $end1:expr, $err_t:expr, $start2:expr, $end2:expr) => {
         TypeKind::Result(Box::new(ResultTypeKind {
             ok: VType {
-                kind: $ok_t,
+                inner: $ok_t,
                 span: Span::new($start1, $end1),
             },
             err: VType {
-                kind: $err_t,
+                inner: $err_t,
                 span: Span::new($start2, $end2),
             },
         }))

--- a/crates/aranya-policy-ast/src/tests.rs
+++ b/crates/aranya-policy-ast/src/tests.rs
@@ -1,124 +1,65 @@
 use crate::{
-    EnumReference, ExprKind, Expression, Ident, NamedStruct, ResultTypeKind, Span, TypeKind, VType,
-    ident,
+    EnumReference, ExprKind, Expression, Ident, NamedStruct, ResultTypeKind, TypeKind, VType,
+    WithSpanExt as _, ident,
 };
 
-// ExprKind macros to reduce boilerplate
+// Helper functions to reduce boilerplate
 
-macro_rules! ident_at {
-    ($name:expr, $start:expr, $end:expr) => {
-        Ident {
-            inner: ident!($name),
-            span: Span::new($start, $end),
-        }
-    };
+fn enum_ref(identifier: Ident, value: Ident) -> ExprKind {
+    ExprKind::EnumReference(EnumReference { identifier, value })
 }
 
-macro_rules! expr {
-    ($kind:expr, $start:expr, $end:expr) => {
-        Expression {
-            inner: $kind,
-            span: Span::new($start, $end),
-        }
-    };
+fn named_struct(name: Ident, fields: impl IntoIterator<Item = (Ident, Expression)>) -> ExprKind {
+    ExprKind::NamedStruct(NamedStruct {
+        identifier: name,
+        fields: fields.into_iter().collect(),
+        sources: Vec::new(),
+    })
 }
 
-macro_rules! enum_ref {
-    ($enum_name:expr, $variant:expr, $e_start:expr, $e_end:expr, $v_start:expr, $v_end:expr) => {
-        ExprKind::EnumReference(EnumReference {
-            identifier: ident_at!($enum_name, $e_start, $e_end),
-            value: ident_at!($variant, $v_start, $v_end),
-        })
-    };
+fn some_expr(expr: Expression) -> ExprKind {
+    ExprKind::Optional(Some(Box::new(expr)))
 }
 
-macro_rules! named_struct {
-    ($name:expr, $s_start:expr, $s_end:expr, $field:expr, $f_start:expr, $f_end:expr, $val_kind:expr, $v_start:expr, $v_end:expr) => {
-        ExprKind::NamedStruct(NamedStruct {
-            identifier: ident_at!($name, $s_start, $s_end),
-            fields: vec![(
-                ident_at!($field, $f_start, $f_end),
-                expr!($val_kind, $v_start, $v_end),
-            )],
-            sources: vec![],
-        })
-    };
+fn ok_expr(expr: Expression) -> ExprKind {
+    ExprKind::Ok(Box::new(expr))
 }
 
-macro_rules! some_expr {
-    ($kind:expr, $start:expr, $end:expr) => {
-        ExprKind::Optional(Some(Box::new(expr!($kind, $start, $end))))
-    };
+fn err_expr(expr: Expression) -> ExprKind {
+    ExprKind::Err(Box::new(expr))
 }
 
-macro_rules! ok_expr {
-    ($kind:expr, $start:expr, $end:expr) => {
-        ExprKind::Ok(Box::new(expr!($kind, $start, $end)))
-    };
-}
-
-macro_rules! err_expr {
-    ($kind:expr, $start:expr, $end:expr) => {
-        ExprKind::Err(Box::new(expr!($kind, $start, $end)))
-    };
-}
-
-/// Unified result macro - create Ok or Err expressions
-macro_rules! result {
-    (Ok: $kind:expr, $start:expr, $end:expr) => {
-        ok_expr!($kind, $start, $end)
-    };
-    (Err: $kind:expr, $start:expr, $end:expr) => {
-        err_expr!($kind, $start, $end)
-    };
-}
-
-macro_rules! result_type {
-    ($ok_t:expr, $start1:expr, $end1:expr, $err_t:expr, $start2:expr, $end2:expr) => {
-        TypeKind::Result(Box::new(ResultTypeKind {
-            ok: VType {
-                inner: $ok_t,
-                span: Span::new($start1, $end1),
-            },
-            err: VType {
-                inner: $err_t,
-                span: Span::new($start2, $end2),
-            },
-        }))
-    };
+pub fn result_type(ok: VType, err: VType) -> TypeKind {
+    TypeKind::Result(Box::new(ResultTypeKind { ok, err }))
 }
 
 #[test]
 fn test_result_type_matches() {
-    let result1 = result_type!(TypeKind::Int, 5, 10, TypeKind::String, 15, 20);
-    let result2 = result_type!(TypeKind::Int, 6, 11, TypeKind::String, 16, 21);
+    let result1 = result_type(TypeKind::Int.at(5..10), TypeKind::String.at(15..20));
+    let result2 = result_type(TypeKind::Int.at(6..11), TypeKind::String.at(16..21));
 
     // Same types should match
     assert!(result1.matches(&result2));
 
     // Different ok types should not match
-    let result3 = result_type!(TypeKind::Bool, 10, 20, TypeKind::String, 30, 40);
+    let result3 = result_type(TypeKind::Bool.at(10..20), TypeKind::String.at(30..40));
     assert!(!result1.matches(&result3));
 
     // Different err types should not match
-    let result4 = result_type!(TypeKind::Int, 50, 60, TypeKind::Bool, 70, 80);
+    let result4 = result_type(TypeKind::Int.at(50..60), TypeKind::Bool.at(70..80));
     assert!(!result1.matches(&result4));
 }
 
 #[test]
 fn test_expr_matches_named_struct() {
     // Two identical NamedStruct expressions with different spans should match
-    let struct1 = named_struct!("MyStruct", 0, 8, "field", 9, 14, ExprKind::Int(42), 16, 18);
-    let struct2 = named_struct!(
-        "MyStruct",
-        100,
-        108,
-        "field",
-        109,
-        114,
-        ExprKind::Int(42),
-        116,
-        118
+    let struct1 = named_struct(
+        ident!("MyStruct").at(0..8),
+        [(ident!("field").at(9..14), ExprKind::Int(42).at(16..18))],
+    );
+    let struct2 = named_struct(
+        ident!("MyStruct").at(100..108),
+        [(ident!("field").at(109..114), ExprKind::Int(42).at(116..118))],
     );
 
     assert!(
@@ -129,8 +70,8 @@ fn test_expr_matches_named_struct() {
 
 #[test]
 fn test_expr_matches_enum_reference() {
-    let enum1 = enum_ref!("Color", "Red", 0, 5, 7, 10);
-    let enum2 = enum_ref!("Color", "Red", 50, 55, 57, 60);
+    let enum1 = enum_ref(ident!("Color").at(0..5), ident!("Red").at(7..10));
+    let enum2 = enum_ref(ident!("Color").at(50..55), ident!("Red").at(57..60));
 
     assert!(
         enum1.matches(&enum2),
@@ -141,35 +82,19 @@ fn test_expr_matches_enum_reference() {
 #[test]
 fn test_expr_matches_result_with_struct() {
     // Ok(MyStruct { field: 42 }) with different spans
-    let ok1 = ok_expr!(
-        named_struct!(
-            "MyStruct",
-            3,
-            11,
-            "field",
-            14,
-            19,
-            ExprKind::Int(42),
-            21,
-            23
-        ),
-        3,
-        24
+    let ok1 = ok_expr(
+        named_struct(
+            ident!("MyStruct").at(3..11),
+            [(ident!("field").at(14..19), ExprKind::Int(42).at(21..23))],
+        )
+        .at(3..24),
     );
-    let ok2 = ok_expr!(
-        named_struct!(
-            "MyStruct",
-            200,
-            208,
-            "field",
-            211,
-            216,
-            ExprKind::Int(42),
-            218,
-            220
-        ),
-        200,
-        221
+    let ok2 = ok_expr(
+        named_struct(
+            ident!("MyStruct").at(200..208),
+            [(ident!("field").at(211..216), ExprKind::Int(42).at(218..220))],
+        )
+        .at(200..221),
     );
 
     assert!(
@@ -181,8 +106,9 @@ fn test_expr_matches_result_with_struct() {
 #[test]
 fn test_expr_matches_result_with_enum_ok() {
     // Ok(Color::Red) with different spans
-    let ok1 = result!(Ok: enum_ref!("Color", "Red", 3, 8, 10, 13), 3, 13);
-    let ok2 = result!(Ok: enum_ref!("Color", "Red", 100, 105, 107, 110), 100, 110);
+    let ok1 = ok_expr(enum_ref(ident!("Color").at(3..8), ident!("Red").at(10..13)).at(3..13));
+    let ok2 =
+        ok_expr(enum_ref(ident!("Color").at(100..105), ident!("Red").at(107..110)).at(100..110));
 
     assert!(
         ok1.matches(&ok2),
@@ -193,8 +119,15 @@ fn test_expr_matches_result_with_enum_ok() {
 #[test]
 fn test_expr_matches_result_with_enum_err() {
     // Err(ErrorCode::NotFound) with different spans
-    let err1 = result!(Err: enum_ref!("ErrorCode", "NotFound", 4, 13, 15, 23), 4, 23);
-    let err2 = result!(Err: enum_ref!("ErrorCode", "NotFound", 200, 209, 211, 219), 200, 219);
+    let err1 =
+        err_expr(enum_ref(ident!("ErrorCode").at(4..13), ident!("NotFound").at(15..23)).at(4..23));
+    let err2 = err_expr(
+        enum_ref(
+            ident!("ErrorCode").at(200..209),
+            ident!("NotFound").at(211..219),
+        )
+        .at(200..219),
+    );
 
     assert!(
         err1.matches(&err2),
@@ -205,8 +138,8 @@ fn test_expr_matches_result_with_enum_err() {
 #[test]
 fn test_expr_matches_result_with_different_enum_variants() {
     // Ok(Color::Red) vs Ok(Color::Blue) should NOT match
-    let ok_red = ok_expr!(enum_ref!("Color", "Red", 3, 8, 10, 13), 3, 13);
-    let ok_blue = ok_expr!(enum_ref!("Color", "Blue", 3, 8, 10, 14), 3, 14);
+    let ok_red = ok_expr(enum_ref(ident!("Color").at(3..8), ident!("Red").at(10..13)).at(3..13));
+    let ok_blue = ok_expr(enum_ref(ident!("Color").at(3..8), ident!("Blue").at(10..14)).at(3..14));
 
     assert!(
         !ok_red.matches(&ok_blue),
@@ -217,8 +150,11 @@ fn test_expr_matches_result_with_different_enum_variants() {
 #[test]
 fn test_expr_matches_optional() {
     // Some(Color::Green) with different spans
-    let some1 = some_expr!(enum_ref!("Color", "Green", 5, 10, 12, 17), 5, 17);
-    let some2 = some_expr!(enum_ref!("Color", "Green", 300, 305, 307, 312), 300, 312);
+    let some1 =
+        some_expr(enum_ref(ident!("Color").at(5..10), ident!("Green").at(12..17)).at(5..17));
+    let some2 = some_expr(
+        enum_ref(ident!("Color").at(300..305), ident!("Green").at(307..312)).at(300..312),
+    );
 
     assert!(
         some1.matches(&some2),

--- a/crates/aranya-policy-ast/src/util.rs
+++ b/crates/aranya-policy-ast/src/util.rs
@@ -16,7 +16,7 @@ impl FieldDefinition {
     /// Is this a hashable type?
     pub fn is_hashable(&self) -> bool {
         matches!(
-            &self.field_type.kind,
+            &self.field_type.inner,
             TypeKind::Int | TypeKind::Bool | TypeKind::String | TypeKind::Id | TypeKind::Enum(_)
         )
     }
@@ -25,7 +25,7 @@ impl FieldDefinition {
 impl Expression {
     /// Is this a literal expression?
     pub fn is_literal(&self) -> bool {
-        match &self.kind {
+        match &self.inner {
             ExprKind::Int(_)
             | ExprKind::String(_)
             | ExprKind::Bool(_)

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -16,7 +16,7 @@ use std::{
 use aranya_policy_ast::{
     self as ast, EnumDefinition, ExprKind, Expression, FactCountType, FactDefinition,
     FieldDefinition, Ident, Identifier, LanguageContext, NamedStruct, Param, Span, Statement,
-    StructItem, TypeKind, VType, ident, thir,
+    StructItem, TypeKind, VType, WithSpanExt as _, ident, thir,
 };
 use aranya_policy_module::{
     ActionDef, Attribute, CodeMap, CommandDef, ConstStruct, ConstValue, ExitReason, Field,
@@ -122,34 +122,21 @@ macro_rules! typekind {
 }
 
 mod param {
-    use super::{Ident, Param, Span, TypeKind, VType, ident};
+    use aranya_policy_ast::WithSpanExt as _;
+
+    use super::{Ident, Param, TypeKind, ident};
 
     pub fn envelope() -> Param {
         Param {
-            name: Ident {
-                inner: ident!("envelope"),
-                span: Span::empty(),
-            },
-            ty: VType {
-                inner: TypeKind::Struct(Ident {
-                    inner: ident!("Envelope"),
-                    span: Span::empty(),
-                }),
-                span: Span::empty(),
-            },
+            name: ident!("envelope").nowhere(),
+            ty: TypeKind::Struct(ident!("Envelope").nowhere()).nowhere(),
         }
     }
 
     pub fn this(name: Ident) -> Param {
         Param {
-            name: Ident {
-                inner: ident!("this"),
-                span: Span::empty(),
-            },
-            ty: VType {
-                inner: TypeKind::Struct(name),
-                span: Span::empty(),
-            },
+            name: ident!("this").nowhere(),
+            ty: TypeKind::Struct(name).nowhere(),
         }
     }
 }
@@ -309,14 +296,8 @@ impl<'a> CompileState<'a> {
                     // TODO(eric): Use `Span::default()`?
                     if has_struct_refs {
                         field_definitions.push(FieldDefinition {
-                            identifier: Ident {
-                                inner: field.identifier.inner.clone(),
-                                span: Span::default(),
-                            },
-                            field_type: VType {
-                                inner: field.field_type.inner.clone(),
-                                span: Span::default(),
-                            },
+                            identifier: field.identifier.clone().with_no_span(),
+                            field_type: field.field_type.clone().with_no_span(),
                         });
                     } else {
                         field_definitions.push(field.clone());
@@ -342,14 +323,8 @@ impl<'a> CompileState<'a> {
                         }
                         // TODO(eric): Use `Span::default()`?
                         field_definitions.push(FieldDefinition {
-                            identifier: Ident {
-                                inner: field.identifier.inner.clone(),
-                                span: Span::default(),
-                            },
-                            field_type: VType {
-                                inner: field.field_type.inner.clone(),
-                                span: Span::default(),
-                            },
+                            identifier: field.identifier.clone().with_no_span(),
+                            field_type: field.field_type.clone().with_no_span(),
                         });
                     }
                 }
@@ -1161,13 +1136,7 @@ impl<'a> CompileState<'a> {
         }
 
         self.identifier_types
-            .add_global(
-                identifier.inner.clone(),
-                VType {
-                    inner: vt,
-                    span: Span::default(),
-                },
-            )
+            .add_global(identifier.inner.clone(), vt.nowhere())
             .map_err(|e| self.err(e))?;
 
         Ok(())
@@ -1249,18 +1218,9 @@ impl<'a> CompileState<'a> {
     ) -> Result<(), CompileError> {
         // fake a function def for the seal block
         let args = &[param::this(command.identifier.clone())];
-        let ret = VType {
-            inner: TypeKind::Struct(Ident {
-                inner: ident!("Envelope"),
-                span: Span::default(),
-            }),
-            span: Span::default(),
-        };
+        let ret = TypeKind::Struct(ident!("Envelope").nowhere()).nowhere();
         let seal_function_definition = ast::FunctionDefinition {
-            identifier: Ident {
-                inner: ident!("seal"),
-                span: Span::default(),
-            },
+            identifier: ident!("seal").nowhere(),
             arguments: args.to_vec(),
             return_type: ret.clone(),
             statements: vec![],
@@ -1287,15 +1247,9 @@ impl<'a> CompileState<'a> {
     ) -> Result<(), CompileError> {
         // fake a function def for the open block
         let args = &[param::envelope()];
-        let ret = VType {
-            inner: TypeKind::Struct(command.identifier.clone()),
-            span: Span::default(),
-        };
+        let ret = TypeKind::Struct(command.identifier.clone()).nowhere();
         let open_function_definition = ast::FunctionDefinition {
-            identifier: Ident {
-                inner: ident!("open"),
-                span: Span::default(),
-            },
+            identifier: ident!("open").nowhere(),
             arguments: args.to_vec(),
             return_type: ret.clone(),
             statements: vec![],
@@ -1422,10 +1376,7 @@ impl<'a> CompileState<'a> {
                         })?;
                     for fd in struct_def {
                         // Fields from struct refs always get normalized spans
-                        let field_type = VType {
-                            inner: fd.field_type.inner.clone(),
-                            span: Span::default(),
-                        };
+                        let field_type = fd.field_type.clone().with_no_span();
                         fields
                             .insert(Field {
                                 name: fd.identifier.clone(),
@@ -1834,18 +1785,12 @@ impl<'a> CompileState<'a> {
                         .iter()
                         .map(|a| {
                             StructItem::Field(FieldDefinition {
-                                identifier: Ident {
-                                    inner: a.name.clone(),
-                                    span: Span::default(),
-                                },
+                                identifier: a.name.clone().nowhere(),
                                 field_type: VType::from(&a.vtype),
                             })
                         })
                         .collect();
-                    let ident = Ident {
-                        inner: s.name.clone(),
-                        span: Span::default(),
-                    };
+                    let ident = s.name.clone().nowhere();
                     self.define_struct(ident, &fields)?;
                 }
             }

--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -69,7 +69,7 @@ macro_rules! sig {
             FunctionSignature {
                 args: vec![$(
                     Param {
-                        name: Ident { name: ident!(stringify!($argname)), span: Span::empty() },
+                        name: Ident { inner: ident!(stringify!($argname)), span: Span::empty() },
                         ty: vtype!($($argty0 $($argty1)? $([ $($argty_tt)+ ])?)?)
                     }
                 ),*],
@@ -82,7 +82,7 @@ macro_rules! sig {
 macro_rules! vtype {
     ($($t:tt)*) => {
         VType {
-            kind: typekind!($($t)*),
+            inner: typekind!($($t)*),
             span: Span::empty(),
         }
     }
@@ -127,12 +127,12 @@ mod param {
     pub fn envelope() -> Param {
         Param {
             name: Ident {
-                name: ident!("envelope"),
+                inner: ident!("envelope"),
                 span: Span::empty(),
             },
             ty: VType {
-                kind: TypeKind::Struct(Ident {
-                    name: ident!("Envelope"),
+                inner: TypeKind::Struct(Ident {
+                    inner: ident!("Envelope"),
                     span: Span::empty(),
                 }),
                 span: Span::empty(),
@@ -143,11 +143,11 @@ mod param {
     pub fn this(name: Ident) -> Param {
         Param {
             name: Ident {
-                name: ident!("this"),
+                inner: ident!("this"),
                 span: Span::empty(),
             },
             ty: VType {
-                kind: TypeKind::Struct(name),
+                inner: TypeKind::Struct(name),
                 span: Span::empty(),
             },
         }
@@ -245,7 +245,7 @@ impl<'a> CompileState<'a> {
 
     /// Inserts a fact definition
     fn define_fact(&mut self, fact: &FactDefinition) -> Result<(), CompileError> {
-        if self.m.fact_defs.contains_key(&fact.identifier.name) {
+        if self.m.fact_defs.contains_key(&fact.identifier.inner) {
             return Err(self.err(CompileErrorType::AlreadyDefined(
                 fact.identifier.to_string(),
             )));
@@ -260,16 +260,16 @@ impl<'a> CompileState<'a> {
                     fact.identifier, key.identifier
                 ))));
             }
-            if !identifiers.insert(&key.identifier.name) {
+            if !identifiers.insert(&key.identifier.inner) {
                 return Err(self.err(CompileErrorType::AlreadyDefined(
-                    key.identifier.name.to_string(),
+                    key.identifier.inner.to_string(),
                 )));
             }
         }
 
         // ensure value identifiers are unique
         for value in &fact.value {
-            if !identifiers.insert(&value.identifier.name) {
+            if !identifiers.insert(&value.identifier.inner) {
                 return Err(self.err(CompileErrorType::AlreadyDefined(
                     value.identifier.to_string(),
                 )));
@@ -278,7 +278,7 @@ impl<'a> CompileState<'a> {
 
         self.m
             .fact_defs
-            .insert(fact.identifier.name.clone(), fact.to_owned());
+            .insert(fact.identifier.inner.clone(), fact.to_owned());
         Ok(())
     }
 
@@ -299,7 +299,7 @@ impl<'a> CompileState<'a> {
                 StructItem::Field(field) => {
                     if field_definitions
                         .iter()
-                        .any(|f: &FieldDefinition| f.identifier.name == field.identifier.name)
+                        .any(|f: &FieldDefinition| f.identifier.inner == field.identifier.inner)
                     {
                         return Err(self.err(CompileErrorType::AlreadyDefined(
                             field.identifier.to_string(),
@@ -310,11 +310,11 @@ impl<'a> CompileState<'a> {
                     if has_struct_refs {
                         field_definitions.push(FieldDefinition {
                             identifier: Ident {
-                                name: field.identifier.name.clone(),
+                                inner: field.identifier.inner.clone(),
                                 span: Span::default(),
                             },
                             field_type: VType {
-                                kind: field.field_type.kind.clone(),
+                                inner: field.field_type.inner.clone(),
                                 span: Span::default(),
                             },
                         });
@@ -327,14 +327,14 @@ impl<'a> CompileState<'a> {
                         .m
                         .interface
                         .struct_defs
-                        .get(&field_type_ident.name)
+                        .get(&field_type_ident.inner)
                         .ok_or_else(|| {
                             self.err(CompileErrorType::NotDefined(field_type_ident.to_string()))
                         })?;
                     for field in other {
                         if field_definitions
                             .iter()
-                            .any(|f: &FieldDefinition| f.identifier.name == field.identifier.name)
+                            .any(|f: &FieldDefinition| f.identifier.inner == field.identifier.inner)
                         {
                             return Err(self.err(CompileErrorType::AlreadyDefined(
                                 field.identifier.to_string(),
@@ -343,11 +343,11 @@ impl<'a> CompileState<'a> {
                         // TODO(eric): Use `Span::default()`?
                         field_definitions.push(FieldDefinition {
                             identifier: Ident {
-                                name: field.identifier.name.clone(),
+                                inner: field.identifier.inner.clone(),
                                 span: Span::default(),
                             },
                             field_type: VType {
-                                kind: field.field_type.kind.clone(),
+                                inner: field.field_type.inner.clone(),
                                 span: Span::default(),
                             },
                         });
@@ -363,7 +363,7 @@ impl<'a> CompileState<'a> {
         self.m
             .interface
             .struct_defs
-            .insert(identifier.name, field_definitions);
+            .insert(identifier.inner, field_definitions);
         Ok(())
     }
 
@@ -373,18 +373,20 @@ impl<'a> CompileState<'a> {
     ) -> Result<(), CompileError> {
         let enum_name = &enum_def.identifier;
         // ensure enum name is unique
-        if self.m.interface.enum_defs.contains_key(&enum_name.name) {
-            return Err(self.err(CompileErrorType::AlreadyDefined(enum_name.name.to_string())));
+        if self.m.interface.enum_defs.contains_key(&enum_name.inner) {
+            return Err(self.err(CompileErrorType::AlreadyDefined(
+                enum_name.inner.to_string(),
+            )));
         }
 
         // Add values to enum, checking for duplicates
         let mut values = IndexMap::new();
         for (i, value_name) in enum_def.variants.iter().enumerate() {
-            match values.entry(value_name.name.clone()) {
+            match values.entry(value_name.inner.clone()) {
                 indexmap::map::Entry::Occupied(_) => {
                     return Err(self.err(CompileErrorType::AlreadyDefined(format!(
                         "{}::{}",
-                        enum_name.name, value_name.name
+                        enum_name.inner, value_name.inner
                     ))));
                 }
                 indexmap::map::Entry::Vacant(e) => {
@@ -400,7 +402,7 @@ impl<'a> CompileState<'a> {
         self.m
             .interface
             .enum_defs
-            .insert(enum_name.name.clone(), values);
+            .insert(enum_name.inner.clone(), values);
 
         Ok(())
     }
@@ -412,7 +414,7 @@ impl<'a> CompileState<'a> {
         function_node: &'a ast::FunctionDefinition,
     ) -> Result<&FunctionSignature, CompileError> {
         let def = function_node;
-        match self.function_signatures.entry(def.identifier.name.clone()) {
+        match self.function_signatures.entry(def.identifier.inner.clone()) {
             Entry::Vacant(e) => {
                 let signature = FunctionSignature {
                     args: def.arguments.clone(),
@@ -441,7 +443,7 @@ impl<'a> CompileState<'a> {
         function_node: &'a ast::FinishFunctionDefinition,
     ) -> Result<&FunctionSignature, CompileError> {
         let def = function_node;
-        match self.function_signatures.entry(def.identifier.name.clone()) {
+        match self.function_signatures.entry(def.identifier.inner.clone()) {
             Entry::Vacant(e) => {
                 let signature = FunctionSignature {
                     args: def.arguments.clone(),
@@ -542,10 +544,10 @@ impl<'a> CompileState<'a> {
 
     /// Compile instructions to construct a struct literal
     fn compile_struct_literal(&mut self, s: thir::NamedStruct) -> Result<(), CompileError> {
-        self.append_instruction(Instruction::StructNew(s.identifier.name));
+        self.append_instruction(Instruction::StructNew(s.identifier.inner));
         for (field_name, e) in s.fields {
             self.compile_typed_expression(e)?;
-            self.append_instruction(Instruction::StructSet(field_name.name));
+            self.append_instruction(Instruction::StructSet(field_name.inner));
         }
         Ok(())
     }
@@ -560,15 +562,15 @@ impl<'a> CompileState<'a> {
 
     /// Compile instructions to construct a fact literal
     fn compile_fact_literal(&mut self, f: thir::FactLiteral) -> Result<(), CompileError> {
-        self.append_instruction(Instruction::FactNew(f.identifier.name.clone()));
+        self.append_instruction(Instruction::FactNew(f.identifier.inner.clone()));
         for (k, e) in f.key_fields {
             self.compile_typed_expression(e)?;
-            self.append_instruction(Instruction::FactKeySet(k.name));
+            self.append_instruction(Instruction::FactKeySet(k.inner));
         }
         if let Some(value_fields) = f.value_fields {
             for (k, e) in value_fields {
                 self.compile_typed_expression(e)?;
-                self.append_instruction(Instruction::FactValueSet(k.name));
+                self.append_instruction(Instruction::FactValueSet(k.inner));
             }
         }
         Ok(())
@@ -653,8 +655,8 @@ impl<'a> CompileState<'a> {
             }
             thir::ExprKind::ForeignFunctionCall(f) => {
                 self.append_instruction(Instruction::Meta(Meta::FFI(
-                    f.module.name.clone(),
-                    f.identifier.name.clone(),
+                    f.module.inner.clone(),
+                    f.identifier.inner.clone(),
                 )));
 
                 for arg_e in f.arguments {
@@ -674,20 +676,20 @@ impl<'a> CompileState<'a> {
                 self.append_instruction(Instruction::Return);
             }
             thir::ExprKind::Identifier(i) => {
-                self.append_instruction(Instruction::Get(i.name));
+                self.append_instruction(Instruction::Get(i.inner));
             }
             thir::ExprKind::EnumReference(e) => {
                 self.append_instruction(Instruction::Const(ConstValue::Enum(
-                    e.identifier.name,
+                    e.identifier.inner,
                     e.value,
                 )));
             }
             thir::ExprKind::Dot(t, s) => {
                 self.compile_typed_expression(*t)?;
-                self.append_instruction(Instruction::StructGet(s.name));
+                self.append_instruction(Instruction::StructGet(s.inner));
             }
             thir::ExprKind::Substruct(lhs, sub) => {
-                let Some(sub_field_defns) = self.m.interface.struct_defs.get(&sub.name) else {
+                let Some(sub_field_defns) = self.m.interface.struct_defs.get(&sub.inner) else {
                     return Err(self.err(CompileErrorType::NotDefined(format!(
                         "Struct `{}` not defined",
                         sub
@@ -695,11 +697,11 @@ impl<'a> CompileState<'a> {
                 };
                 let field_names: Vec<Identifier> = sub_field_defns
                     .iter()
-                    .map(|field| field.identifier.name.clone())
+                    .map(|field| field.identifier.inner.clone())
                     .collect();
                 let field_count = field_names.len();
 
-                self.append_instruction(Instruction::StructNew(sub.name));
+                self.append_instruction(Instruction::StructNew(sub.inner));
 
                 self.compile_typed_expression(*lhs)?;
 
@@ -715,7 +717,7 @@ impl<'a> CompileState<'a> {
             thir::ExprKind::Cast(lhs, rhs_ident) => {
                 // NOTE this is implemented only for structs
                 self.compile_typed_expression(*lhs)?;
-                self.append_instruction(Instruction::Cast(rhs_ident.name));
+                self.append_instruction(Instruction::Cast(rhs_ident.inner));
             }
             thir::ExprKind::And(a, b) => {
                 // `a && b` becomes `if a { b } else { false }`
@@ -838,12 +840,14 @@ impl<'a> CompileState<'a> {
             .m
             .interface
             .enum_defs
-            .get(&e.identifier.name)
-            .ok_or_else(|| self.err(CompileErrorType::NotDefined(e.identifier.name.to_string())))?;
-        let value = enum_def.get(&e.value.name).ok_or_else(|| {
+            .get(&e.identifier.inner)
+            .ok_or_else(|| {
+                self.err(CompileErrorType::NotDefined(e.identifier.inner.to_string()))
+            })?;
+        let value = enum_def.get(&e.value.inner).ok_or_else(|| {
             self.err(CompileErrorType::NotDefined(format!(
                 "{}::{}",
-                e.identifier.name, e.value.name
+                e.identifier.inner, e.value.inner
             )))
         })?;
         Ok(*value)
@@ -881,7 +885,7 @@ impl<'a> CompileState<'a> {
             thir::StmtKind::Let(s) => {
                 self.compile_typed_expression(s.expression)?;
                 // Note: Never type check is done during lowering
-                self.append_instruction(Instruction::Def(s.identifier.name));
+                self.append_instruction(Instruction::Def(s.identifier.inner));
             }
             thir::StmtKind::Check(s) => {
                 self.compile_typed_expression(s.expression)?;
@@ -945,7 +949,7 @@ impl<'a> CompileState<'a> {
                 self.define_label(top_label.clone(), self.wp)?;
                 // Fetch next result
                 self.append_instruction(Instruction::Block);
-                self.append_instruction(Instruction::QueryNext(map_stmt.identifier.name.clone()));
+                self.append_instruction(Instruction::QueryNext(map_stmt.identifier.inner.clone()));
                 // If no more results, break
                 self.append_instruction(Instruction::Branch(Target::Unresolved(end_label.clone())));
                 // body
@@ -967,7 +971,7 @@ impl<'a> CompileState<'a> {
 
                 for (k, e) in s.to {
                     self.compile_typed_expression(e)?;
-                    self.append_instruction(Instruction::FactValueSet(k.name));
+                    self.append_instruction(Instruction::FactValueSet(k.inner));
                 }
                 self.append_instruction(Instruction::Update);
             }
@@ -986,7 +990,7 @@ impl<'a> CompileState<'a> {
                 for arg in fc.arguments {
                     self.compile_typed_expression(arg)?;
                 }
-                let label = Label::new(fc.identifier.name, LabelType::Action);
+                let label = Label::new(fc.identifier.inner, LabelType::Action);
                 self.append_instruction(Instruction::Call(Target::Unresolved(label)));
             }
             thir::StmtKind::DebugAssert(s) => {
@@ -1013,7 +1017,7 @@ impl<'a> CompileState<'a> {
 
     /// Checks if the given type is defined. E.g. check struct/enum definitions.
     fn ensure_type_is_defined(&self, vtype: &VType) -> Result<(), CompileError> {
-        match &vtype.kind {
+        match &vtype.inner {
             // primitives
             TypeKind::Bool
             | TypeKind::Id
@@ -1022,12 +1026,12 @@ impl<'a> CompileState<'a> {
             | TypeKind::Never
             | TypeKind::String => {}
             TypeKind::Struct(name) => {
-                if name != "Envelope" && !self.m.interface.struct_defs.contains_key(&name.name) {
+                if name != "Envelope" && !self.m.interface.struct_defs.contains_key(&name.inner) {
                     return Err(self.err(CompileErrorType::NotDefined(format!("struct {name}"))));
                 }
             }
             TypeKind::Enum(name) => {
-                if !self.m.interface.enum_defs.contains_key(&name.name) {
+                if !self.m.interface.enum_defs.contains_key(&name.inner) {
                     return Err(self.err(CompileErrorType::NotDefined(format!("enum {name}"))));
                 }
             }
@@ -1051,7 +1055,7 @@ impl<'a> CompileState<'a> {
             Some(&function_node.return_type),
             function_node.span,
             &function_node.statements,
-            Label::new(function_node.identifier.name.clone(), LabelType::Function),
+            Label::new(function_node.identifier.inner.clone(), LabelType::Function),
         )?;
         self.exit_statement_context();
         Ok(())
@@ -1068,7 +1072,7 @@ impl<'a> CompileState<'a> {
             None,
             function_node.span,
             &function_node.statements,
-            Label::new(function_node.identifier.name.clone(), LabelType::Function),
+            Label::new(function_node.identifier.inner.clone(), LabelType::Function),
         )?;
         // Finish functions cannot have return statements, so we add a return instruction manually.
         self.append_instruction(Instruction::Return);
@@ -1084,7 +1088,7 @@ impl<'a> CompileState<'a> {
         if let Some(handler) = self.builtin_functions.get(fc.identifier.as_str()).copied() {
             handler(self)?;
         } else {
-            let label = Label::new(fc.identifier.name, LabelType::Function);
+            let label = Label::new(fc.identifier.inner, LabelType::Function);
             self.append_instruction(Instruction::Call(Target::Unresolved(label)));
         }
 
@@ -1128,7 +1132,7 @@ impl<'a> CompileState<'a> {
             None,
             action_node.span,
             &action_node.statements,
-            Label::new(action_node.identifier.name.clone(), LabelType::Action),
+            Label::new(action_node.identifier.inner.clone(), LabelType::Action),
         )?;
         // Actions cannot have return statements, so we add a return instruction manually.
         self.append_instruction(Instruction::Return);
@@ -1147,7 +1151,7 @@ impl<'a> CompileState<'a> {
         let value = self.expression_value(expression)?;
         let vt = value.vtype();
 
-        match self.m.interface.globals.entry(identifier.name.clone()) {
+        match self.m.interface.globals.entry(identifier.inner.clone()) {
             Entry::Vacant(e) => {
                 e.insert(value);
             }
@@ -1158,9 +1162,9 @@ impl<'a> CompileState<'a> {
 
         self.identifier_types
             .add_global(
-                identifier.name.clone(),
+                identifier.inner.clone(),
                 VType {
-                    kind: vt,
+                    inner: vt,
                     span: Span::default(),
                 },
             )
@@ -1206,7 +1210,7 @@ impl<'a> CompileState<'a> {
             None,
             Span::empty(),
             &command.policy,
-            Label::new(command.identifier.name.clone(), LabelType::CommandPolicy),
+            Label::new(command.identifier.inner.clone(), LabelType::CommandPolicy),
         )?;
         // Policy blocks should exit via a finish block, so panic if it doesn't.
         self.append_instruction(Instruction::Exit(ExitReason::Panic));
@@ -1224,7 +1228,7 @@ impl<'a> CompileState<'a> {
             None,
             Span::empty(),
             &command.recall,
-            Label::new(command.identifier.name.clone(), LabelType::CommandRecall),
+            Label::new(command.identifier.inner.clone(), LabelType::CommandRecall),
         )?;
         if command.recall.is_empty() {
             // TODO(#544): Handle absent/empty recall properly.
@@ -1246,15 +1250,15 @@ impl<'a> CompileState<'a> {
         // fake a function def for the seal block
         let args = &[param::this(command.identifier.clone())];
         let ret = VType {
-            kind: TypeKind::Struct(Ident {
-                name: ident!("Envelope"),
+            inner: TypeKind::Struct(Ident {
+                inner: ident!("Envelope"),
                 span: Span::default(),
             }),
             span: Span::default(),
         };
         let seal_function_definition = ast::FunctionDefinition {
             identifier: Ident {
-                name: ident!("seal"),
+                inner: ident!("seal"),
                 span: Span::default(),
             },
             arguments: args.to_vec(),
@@ -1269,7 +1273,7 @@ impl<'a> CompileState<'a> {
             Some(&ret),
             span,
             &command.seal,
-            Label::new(command.identifier.name.clone(), LabelType::CommandSeal),
+            Label::new(command.identifier.inner.clone(), LabelType::CommandSeal),
         )?;
         self.exit_statement_context();
 
@@ -1284,12 +1288,12 @@ impl<'a> CompileState<'a> {
         // fake a function def for the open block
         let args = &[param::envelope()];
         let ret = VType {
-            kind: TypeKind::Struct(command.identifier.clone()),
+            inner: TypeKind::Struct(command.identifier.clone()),
             span: Span::default(),
         };
         let open_function_definition = ast::FunctionDefinition {
             identifier: Ident {
-                name: ident!("open"),
+                inner: ident!("open"),
                 span: Span::default(),
             },
             arguments: args.to_vec(),
@@ -1304,7 +1308,7 @@ impl<'a> CompileState<'a> {
             Some(&ret),
             span,
             &command.open,
-            Label::new(command.identifier.name.clone(), LabelType::CommandOpen),
+            Label::new(command.identifier.inner.clone(), LabelType::CommandOpen),
         )?;
         self.exit_statement_context();
 
@@ -1332,7 +1336,7 @@ impl<'a> CompileState<'a> {
         self.identifier_types.enter_function();
         for param in params.iter().rev() {
             self.ensure_type_is_defined(&param.ty)?;
-            self.append_var(param.name.name.clone(), param.ty.clone())?;
+            self.append_var(param.name.inner.clone(), param.ty.clone())?;
         }
         if let Some(return_type) = ret {
             self.ensure_type_is_defined(return_type)?;
@@ -1394,7 +1398,7 @@ impl<'a> CompileState<'a> {
                     // TODO(eric): Use `Span::default()`?
                     let field_type = if has_struct_refs {
                         VType {
-                            kind: f.field_type.kind.clone(),
+                            inner: f.field_type.inner.clone(),
                             span: Span::default(),
                         }
                     } else {
@@ -1412,14 +1416,14 @@ impl<'a> CompileState<'a> {
                         .m
                         .interface
                         .struct_defs
-                        .get(&ref_name.name)
+                        .get(&ref_name.inner)
                         .ok_or_else(|| {
                             self.err(CompileErrorType::NotDefined(ref_name.to_string()))
                         })?;
                     for fd in struct_def {
                         // Fields from struct refs always get normalized spans
                         let field_type = VType {
-                            kind: fd.field_type.kind.clone(),
+                            inner: fd.field_type.inner.clone(),
                             span: Span::default(),
                         };
                         fields
@@ -1611,7 +1615,7 @@ impl<'a> CompileState<'a> {
                                     bug!("checked above");
                                 };
                                 self.append_instruction(Instruction::Unwrap(wrap_type));
-                                self.append_instruction(Instruction::Def(ident.name.clone()));
+                                self.append_instruction(Instruction::Def(ident.inner.clone()));
                             } else {
                                 // Pop the scrutinee value that was duplicated for the branch test (see Dup above)
                                 self.append_instruction(Instruction::Pop);
@@ -1658,7 +1662,7 @@ impl<'a> CompileState<'a> {
                                     bug!("checked above");
                                 };
                                 self.append_instruction(Instruction::Unwrap(wrap_type));
-                                self.append_instruction(Instruction::Def(ident.name.clone()));
+                                self.append_instruction(Instruction::Def(ident.inner.clone()));
                             } else {
                                 // Pop the scrutinee value
                                 self.append_instruction(Instruction::Pop);
@@ -1704,16 +1708,16 @@ impl<'a> CompileState<'a> {
         fn extract_struct_ident(item: &StructItem<FieldDefinition>) -> Option<&Identifier> {
             match item {
                 // { +Foo }
-                StructItem::StructRef(ident) => Some(&ident.name),
+                StructItem::StructRef(ident) => Some(&ident.inner),
                 // { field_name struct Foo }
-                StructItem::Field(field) => field.field_type.as_struct().map(|ident| &ident.name),
+                StructItem::Field(field) => field.field_type.as_struct().map(|ident| &ident.inner),
             }
         }
 
         // Create dependency graph.
         for struct_def in &self.policy.structs {
             let deps = struct_def.items.iter().filter_map(extract_struct_ident);
-            let ident = &struct_def.identifier.name;
+            let ident = &struct_def.identifier.inner;
 
             insert_type_def(ident, UserType::Struct(struct_def))?;
             topo.insert(ident, deps);
@@ -1722,11 +1726,11 @@ impl<'a> CompileState<'a> {
         for effect_def in &self.policy.effects {
             let deps = effect_def.items.iter().filter_map(|item| match item {
                 // { +Foo }
-                StructItem::StructRef(ident) => Some(&ident.name),
+                StructItem::StructRef(ident) => Some(&ident.inner),
                 // { field_name struct Foo }
-                StructItem::Field(field) => field.field_type.as_struct().map(|ident| &ident.name),
+                StructItem::Field(field) => field.field_type.as_struct().map(|ident| &ident.inner),
             });
-            let ident = &effect_def.identifier.name;
+            let ident = &effect_def.identifier.inner;
 
             insert_type_def(ident, UserType::Effect(effect_def))?;
             topo.insert(ident, deps);
@@ -1735,8 +1739,8 @@ impl<'a> CompileState<'a> {
         for fact_def in &self.policy.facts {
             let deps = fact_def
                 .fields()
-                .filter_map(|def| def.field_type.as_struct().map(|ident| &ident.name));
-            let ident = &fact_def.identifier.name;
+                .filter_map(|def| def.field_type.as_struct().map(|ident| &ident.inner));
+            let ident = &fact_def.identifier.inner;
 
             insert_type_def(ident, UserType::Fact(fact_def))?;
             topo.insert(ident, deps);
@@ -1744,7 +1748,7 @@ impl<'a> CompileState<'a> {
 
         for command_def in &self.policy.commands {
             let deps = command_def.fields.iter().filter_map(extract_struct_ident);
-            let ident = &command_def.identifier.name;
+            let ident = &command_def.identifier.inner;
 
             insert_type_def(ident, UserType::Command(command_def))?;
             topo.insert(ident, deps);
@@ -1756,7 +1760,7 @@ impl<'a> CompileState<'a> {
                 .policy
                 .ffi_imports
                 .iter()
-                .any(|import| import.name == ffi_mod.name)
+                .any(|import| import.inner == ffi_mod.name)
             {
                 continue;
             }
@@ -1812,7 +1816,7 @@ impl<'a> CompileState<'a> {
                     self.m
                         .interface
                         .effects
-                        .insert(effect.identifier.name.clone());
+                        .insert(effect.identifier.inner.clone());
                 }
                 UserType::Fact(fact) => {
                     let fields: Vec<StructItem<FieldDefinition>> =
@@ -1831,7 +1835,7 @@ impl<'a> CompileState<'a> {
                         .map(|a| {
                             StructItem::Field(FieldDefinition {
                                 identifier: Ident {
-                                    name: a.name.clone(),
+                                    inner: a.name.clone(),
                                     span: Span::default(),
                                 },
                                 field_type: VType::from(&a.vtype),
@@ -1839,7 +1843,7 @@ impl<'a> CompileState<'a> {
                         })
                         .collect();
                     let ident = Ident {
-                        name: s.name.clone(),
+                        inner: s.name.clone(),
                         span: Span::default(),
                     };
                     self.define_struct(ident, &fields)?;
@@ -1910,7 +1914,7 @@ impl<'a> CompileState<'a> {
 
     /// Get expression value, e.g. ExprKind::Int => ConstValue::Int
     fn expression_value(&self, e: &Expression) -> Result<ConstValue, CompileError> {
-        match &e.kind {
+        match &e.inner {
             ExprKind::Int(v) => Ok(ConstValue::Int(*v)),
             ExprKind::Bool(v) => Ok(ConstValue::Bool(*v)),
             ExprKind::String(v) => Ok(ConstValue::String(v.clone())),
@@ -1919,11 +1923,11 @@ impl<'a> CompileState<'a> {
                     .m
                     .interface
                     .struct_defs
-                    .get(&struct_ast.identifier.name)
+                    .get(&struct_ast.identifier.inner)
                 else {
                     return Err(self.err(CompileErrorType::NotDefined(format!(
                         "Struct `{}` not defined",
-                        struct_ast.identifier.name,
+                        struct_ast.identifier.inner,
                     ))));
                 };
 
@@ -1934,11 +1938,11 @@ impl<'a> CompileState<'a> {
                 } = struct_ast.as_ref();
 
                 Ok(ConstValue::Struct(ConstStruct {
-                    name: identifier.name.clone(),
+                    name: identifier.inner.clone(),
                     fields: {
                         let mut value_fields = BTreeMap::new();
                         for (value, expr) in fields {
-                            value_fields.insert(value.name.clone(), self.expression_value(expr)?);
+                            value_fields.insert(value.inner.clone(), self.expression_value(expr)?);
                         }
                         value_fields
                     },
@@ -1946,17 +1950,17 @@ impl<'a> CompileState<'a> {
             }
             ExprKind::EnumReference(e) => {
                 let value = self.enum_value(e)?;
-                Ok(ConstValue::Enum(e.identifier.name.clone(), value))
+                Ok(ConstValue::Enum(e.identifier.inner.clone(), value))
             }
-            ExprKind::Dot(expr, field_ident) => match &expr.kind {
+            ExprKind::Dot(expr, field_ident) => match &expr.inner {
                 ExprKind::Identifier(struct_ident) => self
                     .m
                     .interface
                     .globals
-                    .get(&struct_ident.name)
+                    .get(&struct_ident.inner)
                     .and_then(|val| match val {
                         ConstValue::Struct(ConstStruct { fields, .. }) => {
-                            fields.get(&field_ident.name).cloned()
+                            fields.get(&field_ident.inner).cloned()
                         }
                         _ => None,
                     })
@@ -2012,7 +2016,7 @@ impl<'a> CompileState<'a> {
                 .m
                 .interface
                 .struct_defs
-                .get(&src_struct_type_name.name)
+                .get(&src_struct_type_name.inner)
                 .assume("identifier with a struct type has that struct already defined")
                 .map_err(|err| self.err(err.into()))?;
 
@@ -2024,23 +2028,23 @@ impl<'a> CompileState<'a> {
 
                 // Ensure we haven't already resolved this field from another source.
                 if let Some(other) = seen.insert(
-                    &src_field_defn.identifier.name,
+                    &src_field_defn.identifier.inner,
                     src_struct_type_name.clone(),
                 ) {
                     return Err(self.err(CompileErrorType::DuplicateSourceFields(
-                        src_struct_type_name.name.clone(),
-                        other.name,
+                        src_struct_type_name.inner.clone(),
+                        other.inner,
                     )));
                 }
 
                 // Ensure this field has the right type.
                 let base_struct_defn = base_struct_defns
                     .iter()
-                    .find(|b_defn| b_defn.identifier.name == src_field_defn.identifier.name)
+                    .find(|b_defn| b_defn.identifier.inner == src_field_defn.identifier.inner)
                     .ok_or_else(|| {
                         self.err(CompileErrorType::SourceStructNotSubsetOfBase(
-                            src_struct_type_name.name.clone(),
-                            base_struct.identifier.name.clone(),
+                            src_struct_type_name.inner.clone(),
+                            base_struct.identifier.inner.clone(),
                         ))
                     })?;
                 if !base_struct_defn
@@ -2059,9 +2063,9 @@ impl<'a> CompileState<'a> {
                 resolved_struct.fields.push((
                     src_field_defn.identifier.clone(),
                     Expression {
-                        kind: ExprKind::Dot(
+                        inner: ExprKind::Dot(
                             Box::new(Expression {
-                                kind: ExprKind::Identifier(src_var_name.clone()),
+                                inner: ExprKind::Identifier(src_var_name.clone()),
                                 span: src_var_name.span,
                             }),
                             src_field_defn.identifier.clone(),

--- a/crates/aranya-policy-compiler/src/compile/lower.rs
+++ b/crates/aranya-policy-compiler/src/compile/lower.rs
@@ -54,7 +54,7 @@ impl CompileState<'_> {
             .m
             .interface
             .struct_defs
-            .get(&s.identifier.name)
+            .get(&s.identifier.inner)
             .cloned()
         else {
             return Err(self.err(CompileErrorType::NotDefined(format!(
@@ -66,7 +66,7 @@ impl CompileState<'_> {
         let s = self.evaluate_sources(s, &struct_def)?;
 
         // Check for duplicate fields in the struct literal
-        if let Some(duplicate_field) = find_duplicate(&s.fields, |(ident, _)| &ident.name) {
+        if let Some(duplicate_field) = find_duplicate(&s.fields, |(ident, _)| &ident.inner) {
             return Err(self.err(CompileErrorType::AlreadyDefined(
                 duplicate_field.to_string(),
             )));
@@ -76,11 +76,11 @@ impl CompileState<'_> {
         for (field_name, e) in &s.fields {
             let def_field_type = &struct_def
                 .iter()
-                .find(|f| f.identifier.name == field_name.name)
+                .find(|f| f.identifier.inner == field_name.inner)
                 .ok_or_else(|| {
                     self.err(CompileErrorType::InvalidType(format!(
                         "field `{}` not found in `Struct {}`",
-                        field_name.name, s.identifier
+                        field_name.inner, s.identifier
                     )))
                 })?
                 .field_type;
@@ -89,7 +89,7 @@ impl CompileState<'_> {
                 return Err(self.err(CompileErrorType::InvalidType(format!(
                     "`Struct {}` field `{}` is not {}",
                     s.identifier,
-                    field_name.name,
+                    field_name.inner,
                     DisplayType(def_field_type)
                 ))));
             }
@@ -157,7 +157,7 @@ impl CompileState<'_> {
         let mut bind_found = false;
         for ((lit_key_name, lit_key_field), schema_key) in fact_key_fields.iter().zip(&fact_def.key)
         {
-            if schema_key.identifier.name != lit_key_name.name {
+            if schema_key.identifier.inner != lit_key_name.inner {
                 return Err(self.err(CompileErrorType::InvalidFactLiteral(format!(
                     "Invalid key: expected {}, got {}",
                     schema_key.identifier, lit_key_name
@@ -210,10 +210,10 @@ impl CompileState<'_> {
         for ((lit_value_name, lit_value_field), schema_value) in
             fact_value_fields.iter().zip(&fact_def.value)
         {
-            if lit_value_name.name != schema_value.identifier.name {
+            if lit_value_name.inner != schema_value.identifier.inner {
                 return Err(self.err(CompileErrorType::InvalidFactLiteral(format!(
                     "Expected value {}, got {}",
-                    schema_value.identifier, lit_value_name.name
+                    schema_value.identifier, lit_value_name.inner
                 ))));
             }
             if let FactField::Expression(e) = &lit_value_field {
@@ -234,7 +234,7 @@ impl CompileState<'_> {
 
     /// Check if finish blocks only use appropriate expressions
     fn check_finish_expression(&mut self, expression: &Expression) -> Result<(), CompileError> {
-        match &expression.kind {
+        match &expression.inner {
             ExprKind::Int(_)
             | ExprKind::String(_)
             | ExprKind::Bool(_)
@@ -258,11 +258,11 @@ impl CompileState<'_> {
             self.check_finish_expression(expression)?;
         }
 
-        Ok(match &expression.kind {
+        Ok(match &expression.inner {
             ExprKind::Int(n) => thir::Expression {
                 kind: thir::ExprKind::Int(*n),
                 vtype: VType {
-                    kind: TypeKind::Int,
+                    inner: TypeKind::Int,
                     span: expression.span,
                 },
                 span: expression.span,
@@ -270,7 +270,7 @@ impl CompileState<'_> {
             ExprKind::String(s) => thir::Expression {
                 kind: thir::ExprKind::String(s.clone()),
                 vtype: VType {
-                    kind: TypeKind::String,
+                    inner: TypeKind::String,
                     span: expression.span,
                 },
                 span: expression.span,
@@ -278,7 +278,7 @@ impl CompileState<'_> {
             ExprKind::Bool(b) => thir::Expression {
                 kind: thir::ExprKind::Bool(*b),
                 vtype: VType {
-                    kind: TypeKind::Bool,
+                    inner: TypeKind::Bool,
                     span: expression.span,
                 },
                 span: expression.span,
@@ -289,7 +289,7 @@ impl CompileState<'_> {
                 match o {
                     None => {
                         inner_vtype = VType {
-                            kind: TypeKind::Never,
+                            inner: TypeKind::Never,
                             span: expression.span,
                         };
                         inner_expr = None;
@@ -300,7 +300,7 @@ impl CompileState<'_> {
                         inner_expr = Some(Box::new(inner));
                     }
                 }
-                if matches!(inner_vtype.kind, TypeKind::Optional(_)) {
+                if matches!(inner_vtype.inner, TypeKind::Optional(_)) {
                     return Err(self.err(CompileErrorType::InvalidType(
                         "Cannot wrap option in another option".into(),
                     )));
@@ -308,7 +308,7 @@ impl CompileState<'_> {
                 thir::Expression {
                     kind: thir::ExprKind::Optional(inner_expr),
                     vtype: VType {
-                        kind: TypeKind::Optional(Box::new(inner_vtype)),
+                        inner: TypeKind::Optional(Box::new(inner_vtype)),
                         span: expression.span,
                     },
                     span: expression.span,
@@ -330,7 +330,7 @@ impl CompileState<'_> {
                     thir::Expression {
                         kind: thir::ExprKind::InternalFunction(thir::InternalFunction::Query(fact)),
                         vtype: VType {
-                            kind: TypeKind::Optional(Box::new(vtype)),
+                            inner: TypeKind::Optional(Box::new(vtype)),
                             span: expression.span,
                         },
                         span: expression.span,
@@ -343,7 +343,7 @@ impl CompileState<'_> {
                             fact,
                         )),
                         vtype: VType {
-                            kind: TypeKind::Bool,
+                            inner: TypeKind::Bool,
                             span: expression.span,
                         },
                         span: expression.span,
@@ -353,11 +353,11 @@ impl CompileState<'_> {
                     let fact = self.lower_fact_literal(fact, false)?;
                     let ty = match cmp_type {
                         FactCountType::UpTo(span) => VType {
-                            kind: TypeKind::Int,
+                            inner: TypeKind::Int,
                             span: *span,
                         },
                         _ => VType {
-                            kind: TypeKind::Bool,
+                            inner: TypeKind::Bool,
                             span: expression.span,
                         },
                     };
@@ -372,7 +372,7 @@ impl CompileState<'_> {
                 InternalFunction::If(c, t, f) => {
                     let cond = self.lower_expression(c)?;
                     if !cond.vtype.fits_type(&VType {
-                        kind: TypeKind::Bool,
+                        inner: TypeKind::Bool,
                         span: c.span,
                     }) {
                         return Err(self.err(CompileErrorType::InvalidType(format!(
@@ -410,7 +410,7 @@ impl CompileState<'_> {
                     }
 
                     let struct_type @ VType {
-                        kind: TypeKind::Struct(_),
+                        inner: TypeKind::Struct(_),
                         ..
                     } = self
                         .identifier_types
@@ -430,7 +430,7 @@ impl CompileState<'_> {
                     }
 
                     let ty = VType {
-                        kind: TypeKind::Bytes,
+                        inner: TypeKind::Bytes,
                         span: expression.span,
                     };
                     thir::Expression {
@@ -448,7 +448,7 @@ impl CompileState<'_> {
                             identifier,
                             return_type:
                                 VType {
-                                    kind: TypeKind::Struct(struct_name),
+                                    inner: TypeKind::Struct(struct_name),
                                     ..
                                 },
                             ..
@@ -463,7 +463,7 @@ impl CompileState<'_> {
                     let e = self.lower_expression(e)?;
                     let ty = &e.vtype;
                     if !ty.fits_type(&VType {
-                        kind: TypeKind::Bytes,
+                        inner: TypeKind::Bytes,
                         span: e.span,
                     }) {
                         return Err(self.err(CompileErrorType::InvalidType(format!(
@@ -472,7 +472,7 @@ impl CompileState<'_> {
                     }
 
                     let ty = VType {
-                        kind: TypeKind::Struct(struct_name),
+                        inner: TypeKind::Struct(struct_name),
                         span: expression.span,
                     };
                     thir::Expression {
@@ -492,7 +492,7 @@ impl CompileState<'_> {
                     thir::Expression {
                         kind: thir::ExprKind::InternalFunction(thir::InternalFunction::Todo(*span)),
                         vtype: VType {
-                            kind: TypeKind::Never,
+                            inner: TypeKind::Never,
                             span: Span::empty(),
                         },
                         span: expression.span,
@@ -502,7 +502,7 @@ impl CompileState<'_> {
             ExprKind::FunctionCall(f) => {
                 let signature = self
                     .function_signatures
-                    .get(&f.identifier.name)
+                    .get(&f.identifier.inner)
                     .ok_or_else(|| {
                         self.err(CompileErrorType::NotDefined(f.identifier.to_string()))
                     })?;
@@ -539,9 +539,9 @@ impl CompileState<'_> {
                     .policy
                     .ffi_imports
                     .iter()
-                    .any(|m| m.name == f.module.name)
+                    .any(|m| m.inner == f.module.inner)
                 {
-                    return Err(self.err(CompileErrorType::NotDefined(f.module.name.to_string())));
+                    return Err(self.err(CompileErrorType::NotDefined(f.module.inner.to_string())));
                 }
 
                 let mut args = Vec::new();
@@ -552,7 +552,7 @@ impl CompileState<'_> {
                         args.push(arg_e);
                     }
                     VType {
-                        kind: TypeKind::Never,
+                        inner: TypeKind::Never,
                         span: Span::empty(),
                     }
                 } else {
@@ -561,9 +561,9 @@ impl CompileState<'_> {
                         .ffi_modules
                         .iter()
                         .enumerate()
-                        .find(|(_, m)| m.name == f.module.name)
+                        .find(|(_, m)| m.name == f.module.inner)
                         .ok_or_else(|| {
-                            self.err(CompileErrorType::NotDefined(f.module.name.to_string()))
+                            self.err(CompileErrorType::NotDefined(f.module.inner.to_string()))
                         })?;
 
                     // find module function by name
@@ -571,11 +571,11 @@ impl CompileState<'_> {
                         .functions
                         .iter()
                         .enumerate()
-                        .find(|(_, proc)| proc.name == f.identifier.name)
+                        .find(|(_, proc)| proc.name == f.identifier.inner)
                         .ok_or_else(|| {
                             self.err(CompileErrorType::NotDefined(format!(
                                 "{}::{}",
-                                f.module.name, f.identifier.name
+                                f.module.inner, f.identifier.inner
                             )))
                         })?;
 
@@ -642,7 +642,7 @@ impl CompileState<'_> {
                 thir::Expression {
                     kind: thir::ExprKind::Return(Box::new(et)),
                     vtype: VType {
-                        kind: TypeKind::Never,
+                        inner: TypeKind::Never,
                         span: expression.span,
                     },
                     span: expression.span,
@@ -664,7 +664,7 @@ impl CompileState<'_> {
             ExprKind::EnumReference(e) => {
                 let value = self.enum_value(e)?;
                 let ty = VType {
-                    kind: TypeKind::Enum(e.identifier.clone()),
+                    inner: TypeKind::Enum(e.identifier.clone()),
                     span: expression.span,
                 };
                 thir::Expression {
@@ -696,11 +696,11 @@ impl CompileState<'_> {
                         })?;
                 let field_def = struct_def
                     .iter()
-                    .find(|f| f.identifier.name == s.name)
+                    .find(|f| f.identifier.inner == s.inner)
                     .ok_or_else(|| {
                         self.err(CompileErrorType::InvalidType(format!(
                             "Struct `{}` has no member `{}`",
-                            name, s.name
+                            name, s.inner
                         )))
                     })?;
                 let ty = field_def.field_type.clone();
@@ -711,11 +711,11 @@ impl CompileState<'_> {
                 }
             }
             ExprKind::Substruct(lhs, sub) => {
-                let Some(sub_field_defns) = self.m.interface.struct_defs.get(&sub.name).cloned()
+                let Some(sub_field_defns) = self.m.interface.struct_defs.get(&sub.inner).cloned()
                 else {
                     return Err(self.err(CompileErrorType::NotDefined(format!(
                         "Struct `{}` not defined",
-                        sub.name
+                        sub.inner
                     ))));
                 };
 
@@ -725,7 +725,8 @@ impl CompileState<'_> {
                         "Expression to the left of the substruct operator is not a struct".into(),
                     ))
                 })?;
-                let Some(lhs_field_defns) = self.m.interface.struct_defs.get(&lhs_struct_name.name)
+                let Some(lhs_field_defns) =
+                    self.m.interface.struct_defs.get(&lhs_struct_name.inner)
                 else {
                     return Err(self.err(CompileErrorType::NotDefined(format!(
                         "Struct `{lhs_struct_name}` is not defined",
@@ -735,21 +736,21 @@ impl CompileState<'_> {
                 // Check that the struct type on the RHS is a subset of the struct expression on the LHS
                 if !sub_field_defns.iter().all(|field_def| {
                     lhs_field_defns.iter().any(|lhs_field| {
-                        lhs_field.identifier.name == field_def.identifier.name
+                        lhs_field.identifier.inner == field_def.identifier.inner
                             && lhs_field
                                 .field_type
-                                .kind
-                                .matches(&field_def.field_type.kind)
+                                .inner
+                                .matches(&field_def.field_type.inner)
                     })
                 }) {
                     return Err(self.err(CompileErrorType::InvalidSubstruct(
-                        sub.name.clone(),
-                        lhs_struct_name.name.clone(),
+                        sub.inner.clone(),
+                        lhs_struct_name.inner.clone(),
                     )));
                 }
 
                 let ty = VType {
-                    kind: TypeKind::Struct(sub.clone()),
+                    inner: TypeKind::Struct(sub.clone()),
                     span: expression.span,
                 };
                 thir::Expression {
@@ -766,7 +767,7 @@ impl CompileState<'_> {
                     .m
                     .interface
                     .struct_defs
-                    .get(&rhs_ident.name)
+                    .get(&rhs_ident.inner)
                     .cloned()
                     .ok_or_else(|| {
                         self.err(CompileErrorType::NotDefined(format!("struct {rhs_ident}")))
@@ -782,7 +783,7 @@ impl CompileState<'_> {
                     .m
                     .interface
                     .struct_defs
-                    .get(&lhs_struct_name.name)
+                    .get(&lhs_struct_name.inner)
                     .ok_or_else(|| {
                         self.err(CompileErrorType::NotDefined(format!(
                             "struct {lhs_struct_name}"
@@ -796,13 +797,13 @@ impl CompileState<'_> {
                         .all(|f| rhs_fields.iter().any(|v| f.matches(v)))
                 {
                     return Err(self.err(CompileErrorType::InvalidCast(
-                        lhs_struct_name.name.clone(),
-                        rhs_ident.name.clone(),
+                        lhs_struct_name.inner.clone(),
+                        rhs_ident.inner.clone(),
                     )));
                 }
 
                 let ty = VType {
-                    kind: TypeKind::Struct(rhs_ident.clone()),
+                    inner: TypeKind::Struct(rhs_ident.clone()),
                     span: rhs_ident.span(),
                 };
                 thir::Expression {
@@ -848,7 +849,7 @@ impl CompileState<'_> {
                         a.vtype.clone(),
                         b.vtype.clone(),
                         VType {
-                            kind,
+                            inner: kind,
                             span: expression.span,
                         },
                         "invalid binary operation",
@@ -861,7 +862,7 @@ impl CompileState<'_> {
                 thir::Expression {
                     kind: constructor(Box::new(a), Box::new(b)),
                     vtype: VType {
-                        kind: TypeKind::Bool,
+                        inner: TypeKind::Bool,
                         span: expression.span,
                     },
                     span: expression.span,
@@ -874,7 +875,7 @@ impl CompileState<'_> {
                 let ty = types::check_type(
                     e.vtype.clone(),
                     VType {
-                        kind: TypeKind::Bool,
+                        inner: TypeKind::Bool,
                         span: expression.span,
                     },
                     "",
@@ -900,7 +901,7 @@ impl CompileState<'_> {
             ExprKind::Is(e, expr_is_some) => {
                 // Evaluate the expression
                 let e = self.lower_expression(e)?;
-                match &e.vtype.kind {
+                match &e.vtype.inner {
                     TypeKind::Optional(_) => {}
                     _ => {
                         return Err(self.err(CompileErrorType::InvalidType(
@@ -912,7 +913,7 @@ impl CompileState<'_> {
                 thir::Expression {
                     kind: thir::ExprKind::Is(Box::new(e), *expr_is_some),
                     vtype: VType {
-                        kind: TypeKind::Bool,
+                        inner: TypeKind::Bool,
                         span: expression.span,
                     },
                     span: expression.span,
@@ -943,10 +944,10 @@ impl CompileState<'_> {
                 thir::Expression {
                     kind: thir::ExprKind::Ok(Box::new(inner.clone())),
                     vtype: VType {
-                        kind: TypeKind::Result(Box::new(ResultTypeKind {
+                        inner: TypeKind::Result(Box::new(ResultTypeKind {
                             ok: inner.vtype,
                             err: VType {
-                                kind: TypeKind::Never,
+                                inner: TypeKind::Never,
                                 span: expression.span,
                             },
                         })),
@@ -960,9 +961,9 @@ impl CompileState<'_> {
                 thir::Expression {
                     kind: thir::ExprKind::Err(Box::new(inner.clone())),
                     vtype: VType {
-                        kind: TypeKind::Result(Box::new(ResultTypeKind {
+                        inner: TypeKind::Result(Box::new(ResultTypeKind {
                             ok: VType {
-                                kind: TypeKind::Never,
+                                inner: TypeKind::Never,
                                 span: expression.span,
                             },
                             err: inner.vtype,
@@ -981,7 +982,7 @@ impl CompileState<'_> {
     ) -> Result<thir::FunctionCall, CompileError> {
         let arg_defs = self
             .function_signatures
-            .get(&fc.identifier.name)
+            .get(&fc.identifier.inner)
             .ok_or_else(|| self.err(CompileErrorType::NotDefined(fc.identifier.to_string())))?
             .args
             .clone();
@@ -1025,7 +1026,7 @@ impl CompileState<'_> {
         let e = self.lower_expression(e)?;
         let vtype = match &e.vtype {
             VType {
-                kind: TypeKind::Optional(t),
+                inner: TypeKind::Optional(t),
                 ..
             } => (**t).clone(),
             _ => {
@@ -1071,7 +1072,7 @@ impl CompileState<'_> {
             let mut seen_ok_literal = false;
             let mut seen_err_literal = false;
             for v in values {
-                let value = &v.kind;
+                let value = &v.inner;
                 let v_span = v.span();
 
                 // Check for duplicate values across all prior values.
@@ -1088,7 +1089,7 @@ impl CompileState<'_> {
                 // Check for unreachable arms (binding before literal across arms)
                 // and subsumed patterns (literal mixed with binding in same arm).
                 match value {
-                    ExprKind::Ok(inner) if matches!(inner.kind, ExprKind::Identifier(_)) => {
+                    ExprKind::Ok(inner) if matches!(inner.inner, ExprKind::Identifier(_)) => {
                         if seen_ok_literal {
                             return Err(self.redundant_match_arm_error(v_span));
                         }
@@ -1100,7 +1101,7 @@ impl CompileState<'_> {
                     ExprKind::Ok(_) => {
                         seen_ok_literal = true;
                     }
-                    ExprKind::Err(inner) if matches!(inner.kind, ExprKind::Identifier(_)) => {
+                    ExprKind::Err(inner) if matches!(inner.inner, ExprKind::Identifier(_)) => {
                         if seen_err_literal {
                             return Err(self.redundant_match_arm_error(v_span));
                         }
@@ -1160,11 +1161,12 @@ impl CompileState<'_> {
                                 .map_err(|err| self.err(err))?;
                             values_out.push(arm_t);
                         } else {
-                            match &value.kind {
+                            match &value.inner {
                                 ExprKind::Ok(inner) | ExprKind::Err(inner) => {
                                     // Binding pattern: Ok(x) or Err(e) where x/e are identifiers
-                                    let is_ok = matches!(&value.kind, ExprKind::Ok(_));
-                                    let TypeKind::Result(result_type) = &scrutinee_type.kind else {
+                                    let is_ok = matches!(&value.inner, ExprKind::Ok(_));
+                                    let TypeKind::Result(result_type) = &scrutinee_type.inner
+                                    else {
                                         return Err(self.err(CompileErrorType::InvalidType(
                                             "Result pattern requires scrutinee to be a Result type"
                                                 .to_string(),
@@ -1175,7 +1177,7 @@ impl CompileState<'_> {
                                     } else {
                                         result_type.err.clone()
                                     };
-                                    let ExprKind::Identifier(ident) = &inner.kind else {
+                                    let ExprKind::Identifier(ident) = &inner.inner else {
                                         return Err(self.err(CompileErrorType::InvalidType(
                                             "Result pattern value must be a literal or an identifier"
                                                 .to_string(),
@@ -1227,7 +1229,7 @@ impl CompileState<'_> {
         // - Ok(x)/Err(e) binding patterns cover all values for that variant
         // - literal patterns cover only specific values, so we compare against
         //   variant cardinality when finite.
-        let result_exhaustive = if let TypeKind::Result(result_type) = &scrutinee_type.kind {
+        let result_exhaustive = if let TypeKind::Result(result_type) = &scrutinee_type.inner {
             let mut has_ok_binding = false;
             let mut has_err_binding = false;
             // Can't use sets because ExprKind doesn't impl Hash/Eq
@@ -1236,14 +1238,14 @@ impl CompileState<'_> {
 
             for (v, _) in &all_values {
                 match v {
-                    ExprKind::Ok(inner) if matches!(inner.kind, ExprKind::Identifier(_)) => {
+                    ExprKind::Ok(inner) if matches!(inner.inner, ExprKind::Identifier(_)) => {
                         has_ok_binding = true;
                     }
-                    ExprKind::Err(inner) if matches!(inner.kind, ExprKind::Identifier(_)) => {
+                    ExprKind::Err(inner) if matches!(inner.inner, ExprKind::Identifier(_)) => {
                         has_err_binding = true;
                     }
-                    ExprKind::Ok(inner) => ok_literals.push(inner.kind.clone()),
-                    ExprKind::Err(inner) => err_literals.push(inner.kind.clone()),
+                    ExprKind::Ok(inner) => ok_literals.push(inner.inner.clone()),
+                    ExprKind::Err(inner) => err_literals.push(inner.inner.clone()),
                     _ => {}
                 }
             }
@@ -1251,12 +1253,12 @@ impl CompileState<'_> {
             let ok_exhaustive = has_ok_binding
                 || self
                     .m
-                    .cardinality(&result_type.ok.kind)
+                    .cardinality(&result_type.ok.inner)
                     .is_some_and(|c| c == ok_literals.len() as u64);
             let err_exhaustive = has_err_binding
                 || self
                     .m
-                    .cardinality(&result_type.err.kind)
+                    .cardinality(&result_type.err.inner)
                     .is_some_and(|c| c == err_literals.len() as u64);
 
             ok_exhaustive && err_exhaustive
@@ -1268,7 +1270,7 @@ impl CompileState<'_> {
             && !result_exhaustive
             && self
                 .m
-                .cardinality(&scrutinee_type.kind)
+                .cardinality(&scrutinee_type.inner)
                 .is_none_or(|c| c > all_values.len() as u64);
 
         if missing_default {
@@ -1295,7 +1297,7 @@ impl CompileState<'_> {
                                 thir::ExprKind::Ok(inner) | thir::ExprKind::Err(inner) => {
                                     if let thir::ExprKind::Identifier(ident) = &inner.kind {
                                         self.identifier_types
-                                            .add(ident.name.clone(), inner.vtype.clone())
+                                            .add(ident.inner.clone(), inner.vtype.clone())
                                             .map_err(|e| self.err(e))?;
                                     }
                                 }
@@ -1340,7 +1342,7 @@ impl CompileState<'_> {
                                 thir::ExprKind::Ok(inner) | thir::ExprKind::Err(inner) => {
                                     if let thir::ExprKind::Identifier(ident) = &inner.kind {
                                         self.identifier_types
-                                            .add(ident.name.clone(), inner.vtype.clone())
+                                            .add(ident.inner.clone(), inner.vtype.clone())
                                             .map_err(|e| self.err(e))?;
                                     }
                                 }
@@ -1410,7 +1412,7 @@ impl CompileState<'_> {
             // example, check whether an expression disallowed in finish context has been
             // evaluated from deep within a call chain. Further static analysis will have to
             // be done to ensure that.
-            let kind = match (&statement.kind, &context) {
+            let kind = match (&statement.inner, &context) {
                 (
                     StmtKind::Let(s),
                     StatementContext::Action(_)
@@ -1420,7 +1422,7 @@ impl CompileState<'_> {
                 ) => {
                     let et = self.lower_expression(&s.expression)?;
                     self.identifier_types
-                        .add(s.identifier.name.clone(), et.vtype.clone())
+                        .add(s.identifier.inner.clone(), et.vtype.clone())
                         .map_err(|e| self.err(e))?;
                     // NOTE: We allow assigning Never, which is useful for stubbing out code during development.
                     thir::StmtKind::Let(thir::LetStatement {
@@ -1437,7 +1439,7 @@ impl CompileState<'_> {
                 ) => {
                     let et = self.lower_expression(&s.expression)?;
                     if !et.vtype.fits_type(&VType {
-                        kind: TypeKind::Bool,
+                        inner: TypeKind::Bool,
                         span: s.expression.span,
                     }) {
                         return Err(self.err(CompileErrorType::InvalidType(String::from(
@@ -1470,7 +1472,7 @@ impl CompileState<'_> {
                     for (cond, branch) in &s.branches {
                         let cond = self.lower_expression(cond)?;
                         if !cond.vtype.fits_type(&VType {
-                            kind: TypeKind::Bool,
+                            inner: TypeKind::Bool,
                             span: cond.span,
                         }) {
                             return Err(self.err(CompileErrorType::InvalidType(format!(
@@ -1507,7 +1509,7 @@ impl CompileState<'_> {
                         .policy
                         .commands
                         .iter()
-                        .find(|c| c.identifier.name == ident.name)
+                        .find(|c| c.identifier.inner == ident.inner)
                         .assume("command must be defined")?
                         .persistence;
                     if !action.persistence.matches(command_persistence) {
@@ -1559,9 +1561,9 @@ impl CompileState<'_> {
                     self.identifier_types.enter_block();
                     self.identifier_types
                         .add(
-                            map_stmt.identifier.name.clone(),
+                            map_stmt.identifier.inner.clone(),
                             VType {
-                                kind: TypeKind::Struct(map_stmt.fact.identifier.clone()),
+                                inner: TypeKind::Struct(map_stmt.fact.identifier.clone()),
                                 span: map_stmt.fact.identifier.span,
                             },
                         )
@@ -1658,7 +1660,7 @@ impl CompileState<'_> {
                 (StmtKind::FunctionCall(f), StatementContext::Finish) => {
                     let signature = self
                         .function_signatures
-                        .get(&f.identifier.name)
+                        .get(&f.identifier.inner)
                         .ok_or_else(|| {
                             self.err_loc(
                                 CompileErrorType::NotDefined(f.identifier.to_string()),
@@ -1697,10 +1699,10 @@ impl CompileState<'_> {
                         .policy
                         .actions
                         .iter()
-                        .find(|a| a.identifier == fc.identifier.name)
+                        .find(|a| a.identifier == fc.identifier.inner)
                     else {
                         return Err(self.err_loc(
-                            CompileErrorType::NotDefined(fc.identifier.name.to_string()),
+                            CompileErrorType::NotDefined(fc.identifier.inner.to_string()),
                             statement.span,
                         ));
                     };
@@ -1709,7 +1711,7 @@ impl CompileState<'_> {
                         return Err(self.err_loc(
                             CompileErrorType::BadArgument(format!(
                                 "call to `{}` has {} arguments, but it should have {}",
-                                fc.identifier.name,
+                                fc.identifier.inner,
                                 fc.arguments.len(),
                                 action_def.arguments.len()
                             )),
@@ -1725,7 +1727,7 @@ impl CompileState<'_> {
                             return Err(self.err_loc(
                                 CompileErrorType::BadArgument(format!(
                                     "invalid argument type for `{}`: expected `{}`, but got `{}`",
-                                    expected_arg.name.name,
+                                    expected_arg.name.inner,
                                     DisplayType(&expected_arg.ty),
                                     arg.vtype,
                                 )),
@@ -1745,7 +1747,7 @@ impl CompileState<'_> {
                     let _: VType = types::check_type(
                         e.vtype.clone(),
                         VType {
-                            kind: TypeKind::Bool,
+                            inner: TypeKind::Bool,
                             span: e.span,
                         },
                         "",

--- a/crates/aranya-policy-compiler/src/compile/target.rs
+++ b/crates/aranya-policy-compiler/src/compile/target.rs
@@ -79,12 +79,13 @@ impl CompileTarget {
             TypeKind::Bool => Some(2),
             TypeKind::Optional(vtype) => {
                 // Add 1 for the None case.
-                self.cardinality(&vtype.kind).and_then(|c| c.checked_add(1))
+                self.cardinality(&vtype.inner)
+                    .and_then(|c| c.checked_add(1))
             }
             TypeKind::Struct(ident) => {
-                let defs = self.interface.struct_defs.get(&ident.name)?;
+                let defs = self.interface.struct_defs.get(&ident.inner)?;
                 defs.iter()
-                    .map(|def| self.cardinality(&def.field_type.kind))
+                    .map(|def| self.cardinality(&def.field_type.inner))
                     .reduce(|acc, e| match e {
                         None => None,
                         Some(v) => acc.and_then(|w| v.checked_mul(w)),
@@ -92,14 +93,14 @@ impl CompileTarget {
                     .flatten()
             }
             TypeKind::Enum(ident) => {
-                let defs = self.interface.enum_defs.get(&ident.name)?;
+                let defs = self.interface.enum_defs.get(&ident.inner)?;
                 Some(defs.len() as u64)
             }
             TypeKind::Never => Some(0),
             TypeKind::Result(result_type) => {
                 // Result cardinality is the sum of the cardinalities of the ok and err types.
-                let ok_cardinality = self.cardinality(&result_type.ok.kind)?;
-                let err_cardinality = self.cardinality(&result_type.err.kind)?;
+                let ok_cardinality = self.cardinality(&result_type.ok.inner)?;
+                let err_cardinality = self.cardinality(&result_type.err.inner)?;
                 ok_cardinality.checked_add(err_cardinality)
             }
         }

--- a/crates/aranya-policy-compiler/src/compile/types.rs
+++ b/crates/aranya-policy-compiler/src/compile/types.rs
@@ -152,7 +152,7 @@ pub fn check_type(
     target_type: VType,
     errmsg: &'static str,
 ) -> Result<VType, TypeUnifyError> {
-    match ty.kind {
+    match ty.inner {
         TypeKind::Never => Ok(target_type),
         _ => {
             if ty.fits_type(&target_type) {
@@ -173,7 +173,7 @@ pub struct DisplayType<'a>(pub &'a VType);
 
 impl Display for DisplayType<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.0.kind {
+        match &self.0.inner {
             TypeKind::String => f.write_str("string"),
             TypeKind::Bytes => f.write_str("bytes"),
             TypeKind::Int => f.write_str("int"),
@@ -202,10 +202,10 @@ impl CompileState<'_> {
             .m
             .interface
             .struct_defs
-            .contains_key(&s.identifier.name)
+            .contains_key(&s.identifier.inner)
         {
             Ok(VType {
-                kind: TypeKind::Struct(s.identifier.clone()),
+                inner: TypeKind::Struct(s.identifier.clone()),
                 span: s.identifier.span,
             })
         } else {
@@ -219,9 +219,9 @@ impl CompileState<'_> {
     /// Construct the type of a query based on its fact argument, or error if the fact is
     /// not defined.
     pub(super) fn query_fact_type(&self, f: &FactLiteral) -> Result<VType, CompileError> {
-        if self.m.fact_defs.contains_key(&f.identifier.name) {
+        if self.m.fact_defs.contains_key(&f.identifier.inner) {
             Ok(VType {
-                kind: TypeKind::Struct(f.identifier.clone()),
+                inner: TypeKind::Struct(f.identifier.clone()),
                 span: f.identifier.span,
             })
         } else {
@@ -235,13 +235,13 @@ impl CompileState<'_> {
 
 #[allow(clippy::result_large_err)]
 pub(super) fn unify_pair(left: VType, right: VType) -> Result<VType, TypeUnifyError> {
-    match (&left.kind, &right.kind) {
+    match (&left.inner, &right.inner) {
         (_, TypeKind::Never) => Ok(left),
         (TypeKind::Never, _) => Ok(right),
         (TypeKind::Optional(left), TypeKind::Optional(right)) => {
             let inner = unify_pair(left.as_ref().clone(), right.as_ref().clone())?;
             Ok(VType {
-                kind: TypeKind::Optional(Box::new(inner)),
+                inner: TypeKind::Optional(Box::new(inner)),
                 span: aranya_policy_ast::Span::empty(), // TODO
             })
         }
@@ -249,7 +249,7 @@ pub(super) fn unify_pair(left: VType, right: VType) -> Result<VType, TypeUnifyEr
             let ok = unify_pair(left_result.ok.clone(), right_result.ok.clone())?;
             let err = unify_pair(left_result.err.clone(), right_result.err.clone())?;
             Ok(VType {
-                kind: TypeKind::Result(Box::new(aranya_policy_ast::ResultTypeKind { ok, err })),
+                inner: TypeKind::Result(Box::new(aranya_policy_ast::ResultTypeKind { ok, err })),
                 span: aranya_policy_ast::Span::empty(), // TODO
             })
         }

--- a/crates/aranya-policy-derive/src/ffi.rs
+++ b/crates/aranya-policy-derive/src/ffi.rs
@@ -661,13 +661,13 @@ impl Func {
 
                     // arg name should match definition
                     if !ident.to_string().starts_with("_")
-                        && def.name.name != ident.to_string().as_str()
+                        && def.name.inner != ident.to_string().as_str()
                     {
                         return Err(Error::new_spanned(
                             ident,
                             format!(
                                 "arg identifier `{ident}` should match definition (`{}`)",
-                                def.name.name
+                                def.name.inner
                             ),
                         ));
                     }
@@ -728,7 +728,7 @@ impl<'a> VTypeTokens<'a> {
 impl ToTokens for VTypeTokens<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let vm = self.vm;
-        let item = match &self.vtype.kind {
+        let item = match &self.vtype.inner {
             TypeKind::String => quote!(String),
             TypeKind::Bytes => quote!(Bytes),
             TypeKind::Int => quote!(Int),
@@ -782,7 +782,7 @@ impl ToTokens for TypeTokens<'_> {
         let alloc = self.alloc;
         let crypto = self.crypto;
         let vm = self.vm;
-        let item = match &self.vtype.kind {
+        let item = match &self.vtype.inner {
             TypeKind::String => quote!(#vm::Text),
             TypeKind::Bytes => quote!(#alloc::vec::Vec<u8>),
             TypeKind::Int => quote!(i64),

--- a/crates/aranya-policy-ifgen-build/src/imp.rs
+++ b/crates/aranya-policy-ifgen-build/src/imp.rs
@@ -29,7 +29,7 @@ pub fn generate_code(target: &PolicyInterface) -> String {
         .map(|(id, fields)| {
             let doc = format!(" {} policy struct.", id);
             let name = mk_ident(id);
-            let names = fields.iter().map(|f| mk_ident(&f.identifier.name));
+            let names = fields.iter().map(|f| mk_ident(&f.identifier.inner));
             let types = fields.iter().map(|f| vtype_to_rtype(&f.field_type));
             quote! {
                 #[doc = #doc]
@@ -64,7 +64,7 @@ pub fn generate_code(target: &PolicyInterface) -> String {
             .unwrap_or_else(|| panic!("Effect not defined: {s}"));
         let doc = format!(" {} policy effect.", s);
         let ident = mk_ident(s);
-        let field_idents = fields.iter().map(|f| mk_ident(&f.identifier.name));
+        let field_idents = fields.iter().map(|f| mk_ident(&f.identifier.inner));
         let field_types = fields.iter().map(|f| vtype_to_rtype(&f.field_type));
         quote! {
             #[doc = #doc]
@@ -175,18 +175,18 @@ pub fn generate_code(target: &PolicyInterface) -> String {
 
 fn vtype_to_rtype(ty: &VType) -> TokenStream {
     use aranya_policy_ast::TypeKind;
-    match &ty.kind {
+    match &ty.inner {
         TypeKind::String => quote! { Text },
         TypeKind::Bytes => quote! { Vec<u8> },
         TypeKind::Int => quote! { i64 },
         TypeKind::Bool => quote! { bool },
         TypeKind::Id => quote! { BaseId },
         TypeKind::Struct(st) => {
-            let ident = mk_ident(&st.name);
+            let ident = mk_ident(&st.inner);
             quote! { #ident }
         }
         TypeKind::Enum(st) => {
-            let ident = mk_ident(&st.name);
+            let ident = mk_ident(&st.inner);
             quote! { #ident }
         }
         TypeKind::Optional(opt) => {
@@ -281,16 +281,16 @@ fn collect_reachable_types(target: &PolicyInterface) -> HashSet<Identifier> {
     ) {
         match ty {
             TypeKind::Struct(s) => {
-                if found.insert(s.name.clone()) {
+                if found.insert(s.inner.clone()) {
                     for field in struct_defs[s.as_str()] {
-                        visit(struct_defs, found, &field.field_type.kind);
+                        visit(struct_defs, found, &field.field_type.inner);
                     }
                 }
             }
             TypeKind::Enum(s) => {
-                found.insert(s.name.clone());
+                found.insert(s.inner.clone());
             }
-            TypeKind::Optional(inner) => visit(struct_defs, found, &inner.kind),
+            TypeKind::Optional(inner) => visit(struct_defs, found, &inner.inner),
             _ => {}
         }
     }
@@ -305,7 +305,7 @@ fn collect_reachable_types(target: &PolicyInterface) -> HashSet<Identifier> {
 
     for def in target.action_defs.iter() {
         for param in def.params.iter() {
-            visit(&struct_defs, &mut found, &param.ty.kind);
+            visit(&struct_defs, &mut found, &param.ty.inner);
         }
     }
 
@@ -315,7 +315,7 @@ fn collect_reachable_types(target: &PolicyInterface) -> HashSet<Identifier> {
             .get(id)
             .unwrap_or_else(|| panic!("Effect not defined: {id}"));
         for field in fields {
-            visit(&struct_defs, &mut found, &field.field_type.kind);
+            visit(&struct_defs, &mut found, &field.field_type.inner);
         }
     }
 

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -199,7 +199,7 @@ impl ChunkParser<'_> {
                     |span| ParseError::new(ParseErrorKind::Bug, bug.msg().to_owned(), Some(span)),
                 )
             })?;
-        Ok(Ident { name, span })
+        Ok(Ident { inner: name, span })
     }
 
     /// Parse a type token (one of the types under Rule::vtype) into a
@@ -279,7 +279,7 @@ impl ChunkParser<'_> {
                 let inner_type = self.parse_type_inner(token, style, Some(pest_span))?;
 
                 // Disallow nested optionals for old syntax
-                if is_old && matches!(inner_type.kind, TypeKind::Optional(_)) {
+                if is_old && matches!(inner_type.inner, TypeKind::Optional(_)) {
                     return Err(ParseError::new(
                         ParseErrorKind::InvalidType,
                         String::from("Cannot nest optional types with `optional T` syntax"),
@@ -342,7 +342,7 @@ impl ChunkParser<'_> {
                 ));
             }
         };
-        Ok(VType { kind, span })
+        Ok(VType { inner: kind, span })
     }
 
     /// Parse a Rule::field_definition token into a FieldDef.
@@ -563,11 +563,11 @@ impl ChunkParser<'_> {
                             Some(span),
                         )
                     })?;
-                    Ok(Expression{kind: ExprKind::Int(n), span})
+                    Ok(Expression{inner: ExprKind::Int(n), span})
                 }
                 Rule::string_literal => {
                     let s = self.parse_string_literal(primary)?;
-                    Ok(Expression{kind: ExprKind::String(s), span})
+                    Ok(Expression{inner: ExprKind::String(s), span})
                 }
                 Rule::bool_literal => {
                     let mut pairs = primary.clone().into_inner();
@@ -580,10 +580,10 @@ impl ChunkParser<'_> {
                     })?;
                     match token.as_rule() {
                         Rule::btrue => {
-                            Ok(Expression{kind:ExprKind::Bool(true), span})
+                            Ok(Expression{inner:ExprKind::Bool(true), span})
                         }
                         Rule::bfalse => {
-                            Ok(Expression{kind:ExprKind::Bool(false), span})
+                            Ok(Expression{inner:ExprKind::Bool(false), span})
                         }
                         t => Err(ParseError::new(
                             ParseErrorKind::Unknown,
@@ -622,7 +622,7 @@ impl ChunkParser<'_> {
                             ))
                         }
                     };
-                    Ok(Expression { kind: ExprKind::Optional(opt_expr), span })
+                    Ok(Expression { inner: ExprKind::Optional(opt_expr), span })
                 }
                 Rule::result_literal => {
                     let token = primary.clone().into_inner().next().ok_or_else(|| {
@@ -644,7 +644,7 @@ impl ChunkParser<'_> {
                             })?;
                             let expr = self.parse_expression(v)?;
                             Ok(Expression {
-                                kind: ExprKind::Ok(Box::new(expr)),
+                                inner: ExprKind::Ok(Box::new(expr)),
                                 span
                             })
                         }
@@ -659,7 +659,7 @@ impl ChunkParser<'_> {
                             })?;
                             let expr = self.parse_expression(v)?;
                             Ok(Expression {
-                                kind: ExprKind::Err(Box::new(expr)),
+                                inner: ExprKind::Err(Box::new(expr)),
                                 span,
                             })
                         }
@@ -672,24 +672,24 @@ impl ChunkParser<'_> {
                 }
                 Rule::named_struct_literal => {
                     let ns = self.parse_named_struct_literal(primary)?;
-                    Ok(Expression { kind: ExprKind::NamedStruct(ns), span })
+                    Ok(Expression { inner: ExprKind::NamedStruct(ns), span })
                 }
                 Rule::function_call => {
                     let fc = self.parse_function_call(primary)?;
-                    Ok(Expression { kind: ExprKind::FunctionCall(fc), span })
+                    Ok(Expression { inner: ExprKind::FunctionCall(fc), span })
                 }
                 Rule::foreign_function_call => {
                     let ffc = self.parse_foreign_function_call(primary)?;
-                    Ok(Expression { kind: ExprKind::ForeignFunctionCall(ffc), span })
+                    Ok(Expression { inner: ExprKind::ForeignFunctionCall(ffc), span })
                 }
                 Rule::return_expression => {
                     let pc = self.descend(primary);
                     let expression = pc.consume_expression(self)?;
-                    Ok(Expression{kind:ExprKind::Return(Box::new(expression)),span})
+                    Ok(Expression{inner:ExprKind::Return(Box::new(expression)),span})
                 }
                 Rule::enum_reference => {
                     let er = self.parse_enum_reference(primary)?;
-                    Ok(Expression { kind: ExprKind::EnumReference(er), span })
+                    Ok(Expression { inner: ExprKind::EnumReference(er), span })
                 }
                 Rule::query => {
                     let mut pairs = primary.clone().into_inner();
@@ -702,7 +702,7 @@ impl ChunkParser<'_> {
                     })?;
                     let fact_literal = self.parse_fact_literal(token)?;
                     Ok(Expression {
-                        kind: ExprKind::InternalFunction(InternalFunction::Query(fact_literal)),
+                        inner: ExprKind::InternalFunction(InternalFunction::Query(fact_literal)),
                         span,
                     })
                 }
@@ -717,7 +717,7 @@ impl ChunkParser<'_> {
                     })?;
                     let fact_literal = self.parse_fact_literal(token)?;
                     Ok(Expression{
-                        kind: ExprKind::InternalFunction(InternalFunction::Exists(fact_literal)),
+                        inner: ExprKind::InternalFunction(InternalFunction::Exists(fact_literal)),
                         span,
                     })
                 }
@@ -746,7 +746,7 @@ impl ChunkParser<'_> {
                     })?;
                     let inner = self.parse_expression(token)?;
                     let span = self.to_ast_span(primary.as_span())?;
-                    Ok(Expression{kind:ExprKind::InternalFunction(
+                    Ok(Expression{inner:ExprKind::InternalFunction(
                         InternalFunction::Serialize(Box::new(inner)),
                     ), span})
                 }
@@ -761,15 +761,15 @@ impl ChunkParser<'_> {
                     })?;
                     let inner = self.parse_expression(token)?;
                     Ok(Expression {
-                        kind: ExprKind::InternalFunction(InternalFunction::Deserialize(Box::new(inner))),
+                        inner: ExprKind::InternalFunction(InternalFunction::Deserialize(Box::new(inner))),
                         span,
                     })
                 }
                 Rule::this => {
                     let span = self.to_ast_span(primary.as_span())?;
                     Ok(Expression {
-                        kind: ExprKind::Identifier(Ident {
-                            name: ident!("this"),
+                        inner: ExprKind::Identifier(Ident {
+                            inner: ident!("this"),
                             span,
                         }),
                         span,
@@ -778,7 +778,7 @@ impl ChunkParser<'_> {
                 Rule::todo => {
                     let span = self.to_ast_span(primary.as_span())?;
                     Ok(Expression {
-                        kind: ExprKind::InternalFunction(InternalFunction::Todo(span)),
+                        inner: ExprKind::InternalFunction(InternalFunction::Todo(span)),
                         span,
                     })
                 }
@@ -786,7 +786,7 @@ impl ChunkParser<'_> {
                     let span = self.to_ast_span(primary.as_span())?;
                     let ident = self.remain(primary).consume_ident(self)?;
                     Ok(Expression {
-                        kind: ExprKind::Identifier(ident),
+                        inner: ExprKind::Identifier(ident),
                         span,
                     })
                 }
@@ -816,7 +816,7 @@ impl ChunkParser<'_> {
                         ))
                     }
                 };
-                Ok(Expression{kind,span:combined_span})
+                Ok(Expression{inner: kind,span:combined_span})
             })
             .map_infix(|lhs, op, rhs| {
                 let lhs = lhs?;
@@ -853,7 +853,7 @@ impl ChunkParser<'_> {
                         Some(op_span),
                     )),
                 };
-                Ok(Expression{ kind, span: combined_span })
+                Ok(Expression{ inner: kind, span: combined_span })
             })
             .map_postfix(|lhs, op| {
                 let lhs = lhs?;
@@ -898,7 +898,7 @@ impl ChunkParser<'_> {
                         Some(op_span),
                     )),
                 };
-                Ok(Expression{kind, span: combined_span})
+                Ok(Expression{inner: kind, span: combined_span})
             })
             .parse(pairs)
     }
@@ -911,7 +911,7 @@ impl ChunkParser<'_> {
         let span = self.to_ast_span(expr.as_span())?;
         let stmt_vec = statement_list;
         Ok(Expression {
-            kind: ExprKind::Block(stmt_vec, Box::new(inner_expr)),
+            inner: ExprKind::Block(stmt_vec, Box::new(inner_expr)),
             span,
         })
     }
@@ -954,7 +954,7 @@ impl ChunkParser<'_> {
         }
 
         Ok(Expression {
-            kind: ExprKind::Match(Box::new(MatchExpression { scrutinee, arms })),
+            inner: ExprKind::Match(Box::new(MatchExpression { scrutinee, arms })),
             span,
         })
     }
@@ -987,7 +987,7 @@ impl ChunkParser<'_> {
         })?;
         let fact = self.parse_fact_literal(token)?;
         Ok(Expression {
-            kind: ExprKind::InternalFunction(InternalFunction::FactCount(cmp_type, limit, fact)),
+            inner: ExprKind::InternalFunction(InternalFunction::FactCount(cmp_type, limit, fact)),
             span,
         })
     }
@@ -1024,7 +1024,7 @@ impl ChunkParser<'_> {
         let else_expr = self.parse_block_expression(token)?;
 
         Ok(Expression {
-            kind: ExprKind::InternalFunction(InternalFunction::If(
+            inner: ExprKind::InternalFunction(InternalFunction::If(
                 Box::new(condition),
                 Box::new(then_expr),
                 Box::new(else_expr),
@@ -1306,7 +1306,7 @@ impl ChunkParser<'_> {
                     ));
                 }
             };
-            statements.push(Statement { kind, span });
+            statements.push(Statement { inner: kind, span });
         }
 
         Ok(statements)

--- a/crates/aranya-policy-module/src/data.rs
+++ b/crates/aranya-policy-module/src/data.rs
@@ -3,7 +3,7 @@ extern crate alloc;
 use alloc::{borrow::ToOwned as _, boxed::Box, collections::BTreeMap, format, string::String};
 use core::fmt::{self, Display};
 
-use aranya_policy_ast::{Ident, Identifier, ResultTypeKind, Span, Text, TypeKind, VType};
+use aranya_policy_ast::{Identifier, ResultTypeKind, Text, TypeKind, WithSpanExt as _};
 use serde::{Deserialize, Serialize};
 
 /// A constant or literal value used in policy.
@@ -56,48 +56,27 @@ impl ConstValue {
             Self::Int(_) => TypeKind::Int,
             Self::Bool(_) => TypeKind::Bool,
             Self::String(_) => TypeKind::String,
-            Self::Enum(name, _) => TypeKind::Enum(Ident {
-                inner: name.to_owned(),
-                span: Span::empty(),
-            }),
-            Self::Struct(s) => TypeKind::Struct(Ident {
-                inner: s.name.clone(),
-                span: Span::empty(),
-            }),
+            Self::Enum(name, _) => TypeKind::Enum(name.to_owned().nowhere()),
+            Self::Struct(s) => TypeKind::Struct(s.name.clone().nowhere()),
             Self::Option(o) => {
                 let inner_kind = match o {
                     Some(inner_value) => inner_value.vtype(),
                     None => TypeKind::Never,
                 };
-                TypeKind::Optional(Box::new(VType {
-                    inner: inner_kind,
-                    span: Span::empty(),
-                }))
+                TypeKind::Optional(Box::new(inner_kind.nowhere()))
             }
             Self::Result(Ok(ok)) => {
                 let ok_kind = ok.vtype();
                 TypeKind::Result(Box::new(ResultTypeKind {
-                    ok: VType {
-                        inner: ok_kind,
-                        span: Span::empty(),
-                    },
-                    err: VType {
-                        inner: TypeKind::Never,
-                        span: Span::empty(),
-                    },
+                    ok: ok_kind.nowhere(),
+                    err: TypeKind::Never.nowhere(),
                 }))
             }
             Self::Result(Err(err)) => {
                 let err_kind = err.vtype();
                 TypeKind::Result(Box::new(ResultTypeKind {
-                    ok: VType {
-                        inner: TypeKind::Never,
-                        span: Span::empty(),
-                    },
-                    err: VType {
-                        inner: err_kind,
-                        span: Span::empty(),
-                    },
+                    ok: TypeKind::Never.nowhere(),
+                    err: err_kind.nowhere(),
                 }))
             }
         }

--- a/crates/aranya-policy-module/src/data.rs
+++ b/crates/aranya-policy-module/src/data.rs
@@ -57,11 +57,11 @@ impl ConstValue {
             Self::Bool(_) => TypeKind::Bool,
             Self::String(_) => TypeKind::String,
             Self::Enum(name, _) => TypeKind::Enum(Ident {
-                name: name.to_owned(),
+                inner: name.to_owned(),
                 span: Span::empty(),
             }),
             Self::Struct(s) => TypeKind::Struct(Ident {
-                name: s.name.clone(),
+                inner: s.name.clone(),
                 span: Span::empty(),
             }),
             Self::Option(o) => {
@@ -70,7 +70,7 @@ impl ConstValue {
                     None => TypeKind::Never,
                 };
                 TypeKind::Optional(Box::new(VType {
-                    kind: inner_kind,
+                    inner: inner_kind,
                     span: Span::empty(),
                 }))
             }
@@ -78,11 +78,11 @@ impl ConstValue {
                 let ok_kind = ok.vtype();
                 TypeKind::Result(Box::new(ResultTypeKind {
                     ok: VType {
-                        kind: ok_kind,
+                        inner: ok_kind,
                         span: Span::empty(),
                     },
                     err: VType {
-                        kind: TypeKind::Never,
+                        inner: TypeKind::Never,
                         span: Span::empty(),
                     },
                 }))
@@ -91,11 +91,11 @@ impl ConstValue {
                 let err_kind = err.vtype();
                 TypeKind::Result(Box::new(ResultTypeKind {
                     ok: VType {
-                        kind: TypeKind::Never,
+                        inner: TypeKind::Never,
                         span: Span::empty(),
                     },
                     err: VType {
-                        kind: err_kind,
+                        inner: err_kind,
                         span: Span::empty(),
                     },
                 }))

--- a/crates/aranya-policy-module/src/ffi.rs
+++ b/crates/aranya-policy-module/src/ffi.rs
@@ -2,7 +2,7 @@
 extern crate alloc;
 use alloc::boxed::Box;
 
-use aranya_policy_ast::{Ident, Identifier, ResultTypeKind, Span, TypeKind, VType};
+use aranya_policy_ast::{Identifier, ResultTypeKind, Span, TypeKind, VType, WithSpanExt as _};
 
 /// The type of a value
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -53,14 +53,8 @@ impl From<&Type<'_>> for VType {
             Type::Int => TypeKind::Int,
             Type::Bool => TypeKind::Bool,
             Type::Id => TypeKind::Id,
-            Type::Struct(s) => TypeKind::Struct(Ident {
-                inner: s.clone(),
-                span: Span::default(),
-            }),
-            Type::Enum(e) => TypeKind::Enum(Ident {
-                inner: e.clone(),
-                span: Span::default(),
-            }),
+            Type::Struct(s) => TypeKind::Struct(s.clone().nowhere()),
+            Type::Enum(e) => TypeKind::Enum(e.clone().nowhere()),
             Type::Optional(t) => TypeKind::Optional(Box::new((*t).into())),
             Type::Result(ok, err) => TypeKind::Result(Box::new(ResultTypeKind {
                 ok: (*ok).into(),

--- a/crates/aranya-policy-module/src/ffi.rs
+++ b/crates/aranya-policy-module/src/ffi.rs
@@ -54,11 +54,11 @@ impl From<&Type<'_>> for VType {
             Type::Bool => TypeKind::Bool,
             Type::Id => TypeKind::Id,
             Type::Struct(s) => TypeKind::Struct(Ident {
-                name: s.clone(),
+                inner: s.clone(),
                 span: Span::default(),
             }),
             Type::Enum(e) => TypeKind::Enum(Ident {
-                name: e.clone(),
+                inner: e.clone(),
                 span: Span::default(),
             }),
             Type::Optional(t) => TypeKind::Optional(Box::new((*t).into())),
@@ -68,7 +68,7 @@ impl From<&Type<'_>> for VType {
             })),
         };
         Self {
-            kind,
+            inner: kind,
             span: Span::empty(),
         }
     }

--- a/crates/aranya-policy-runner/src/runfile.rs
+++ b/crates/aranya-policy-runner/src/runfile.rs
@@ -179,7 +179,7 @@ impl RunFile {
                         match parse_expression(&full_expression) {
                             Ok(expr) => {
                                 // Successfully parsed an expression. Add it to the list of runnables.
-                                match expr.kind {
+                                match expr.inner {
                                     ExprKind::FunctionCall(_) => {
                                         do_things.push(PolicyRunnable::Action(full_expression));
                                     }

--- a/crates/aranya-policy-vm/src/data.rs
+++ b/crates/aranya-policy-vm/src/data.rs
@@ -161,7 +161,7 @@ impl Value {
     ///
     /// let value = Value::Int(1);
     /// let int_type = VType {
-    ///     kind: TypeKind::Int,
+    ///     inner: TypeKind::Int,
     ///     span: Span::empty(),
     /// };
     ///
@@ -169,14 +169,14 @@ impl Value {
     /// ```
     pub fn fits_type(&self, expected_type: &VType) -> bool {
         use aranya_policy_ast::TypeKind;
-        match (self, &expected_type.kind) {
+        match (self, &expected_type.inner) {
             (Self::Int(_), TypeKind::Int) => true,
             (Self::Bool(_), TypeKind::Bool) => true,
             (Self::String(_), TypeKind::String) => true,
             (Self::Bytes(_), TypeKind::Bytes) => true,
-            (Self::Struct(s), TypeKind::Struct(ident)) => s.name == ident.name,
+            (Self::Struct(s), TypeKind::Struct(ident)) => s.name == ident.inner,
             (Self::Id(_), TypeKind::Id) => true,
-            (Self::Enum(name, _), TypeKind::Enum(ident)) => *name == ident.name,
+            (Self::Enum(name, _), TypeKind::Enum(ident)) => *name == ident.inner,
             (Self::Option(Some(value)), TypeKind::Optional(ty)) => value.fits_type(ty),
             (Self::Option(None), TypeKind::Optional(_)) => true,
             (Self::Result(Ok(inner)), TypeKind::Result(result_type)) => {
@@ -514,12 +514,12 @@ impl HashableValue {
     /// Checks to see if a [`HashableValue`] matches some [`VType`]
     pub fn fits_type(&self, expected_type: &VType) -> bool {
         use aranya_policy_ast::TypeKind;
-        match (self, &expected_type.kind) {
+        match (self, &expected_type.inner) {
             (Self::Int(_), TypeKind::Int) => true,
             (Self::Bool(_), TypeKind::Bool) => true,
             (Self::String(_), TypeKind::String) => true,
             (Self::Id(_), TypeKind::Id) => true,
-            (Self::Enum(name, _), TypeKind::Enum(ident)) => *name == ident.name,
+            (Self::Enum(name, _), TypeKind::Enum(ident)) => *name == ident.inner,
             // Option and Result are not hashable, so they can never fit a type
             _ => false,
         }

--- a/crates/aranya-policy-vm/src/machine.rs
+++ b/crates/aranya-policy-vm/src/machine.rs
@@ -33,7 +33,7 @@ const STACK_SIZE: usize = 100;
 /// Compares a fact's keys and values to its schema.
 /// Bind values are omitted from keys/values, so we only compare the given keys/values. This allows us to do partial matches.
 fn validate_fact_schema(fact: &Fact, schema: &ast::FactDefinition) -> bool {
-    if fact.name != schema.identifier.name {
+    if fact.name != schema.identifier.inner {
         return false;
     }
 
@@ -41,7 +41,7 @@ fn validate_fact_schema(fact: &Fact, schema: &ast::FactDefinition) -> bool {
         let Some(key_value) = schema
             .key
             .iter()
-            .find(|k| k.identifier.name == key.identifier)
+            .find(|k| k.identifier.inner == key.identifier)
         else {
             return false;
         };
@@ -56,7 +56,7 @@ fn validate_fact_schema(fact: &Fact, schema: &ast::FactDefinition) -> bool {
         let Some(schema_value) = schema
             .value
             .iter()
-            .find(|v| v.identifier.name == value.identifier)
+            .find(|v| v.identifier.inner == value.identifier)
         else {
             return false;
         };
@@ -473,14 +473,14 @@ where
                 // Check for struct fields that do not exist in the
                 // definition.
                 for f in &s.fields {
-                    if !fields.iter().any(|v| &v.identifier.name == f.0) {
+                    if !fields.iter().any(|v| &v.identifier.inner == f.0) {
                         return Err(mk_err());
                     }
                 }
                 // Ensure all defined fields exist and have the same
                 // types.
                 for f in fields {
-                    match s.fields.get(&f.identifier.name) {
+                    match s.fields.get(&f.identifier.inner) {
                         Some(v) => {
                             if !v.fits_type(&f.field_type) {
                                 return Err(mk_err());
@@ -710,7 +710,7 @@ where
                     .ok_or_else(|| self.err(MachineErrorType::InvalidSchema(s.name.clone())))?;
                 if !struct_def_fields
                     .iter()
-                    .any(|f| f.identifier.name == field_name)
+                    .any(|f| f.identifier.inner == field_name)
                 {
                     return Err(self.err(MachineErrorType::InvalidStructMember(field_name)));
                 }
@@ -745,7 +745,7 @@ where
                 for (field_name, field_val) in field_name_value_pairs {
                     let Some(field_defn) = struct_def_fields
                         .iter()
-                        .find(|f| f.identifier.name == field_name)
+                        .find(|f| f.identifier.inner == field_name)
                     else {
                         return Err(self.err(MachineErrorType::InvalidStructMember(field_name)));
                     };
@@ -1012,7 +1012,7 @@ where
                             let field_type = &field.field_type;
 
                             // Check if the source struct has this field
-                            let value = s.fields.get(&field_name.name).ok_or_else(|| {
+                            let value = s.fields.get(&field_name.inner).ok_or_else(|| {
                                 self.err(MachineErrorType::Unknown(alloc::format!(
                                     "cannot cast to `struct {}`: missing field `{}`",
                                     identifier,

--- a/crates/aranya-policy-vm/src/serialize.rs
+++ b/crates/aranya-policy-vm/src/serialize.rs
@@ -94,7 +94,7 @@ impl SerializeCtx<'_> {
             let v = s
                 .fields
                 .get(d.identifier.as_str())
-                .ok_or_else(|| SerializeError::MissingField(d.identifier.name.clone()))?;
+                .ok_or_else(|| SerializeError::MissingField(d.identifier.inner.clone()))?;
             self.serialize_value(v)?;
         }
         Ok(())
@@ -170,8 +170,8 @@ impl DeserializeCtx<'_> {
             .ok_or_else(|| DeserializeError::UnknownStruct(name.clone()))?;
         let mut fields = BTreeMap::new();
         for d in def {
-            let v = self.deserialize_value(&d.field_type.kind)?;
-            fields.insert(d.identifier.name.clone(), v);
+            let v = self.deserialize_value(&d.field_type.inner)?;
+            fields.insert(d.identifier.inner.clone(), v);
         }
         Ok(Struct::new(name, fields))
     }
@@ -206,26 +206,26 @@ impl DeserializeCtx<'_> {
                 Value::Id(BaseId::from_bytes(*x))
             }
             TypeKind::Struct(ident) => {
-                let x = self.deserialize_struct(ident.name.clone())?;
+                let x = self.deserialize_struct(ident.inner.clone())?;
                 Value::Struct(x)
             }
             TypeKind::Enum(ident) => {
                 let x = postcard_core::de::try_take_i64(self)?.ok_or(Bad)?;
-                Value::Enum(ident.name.clone(), x)
+                Value::Enum(ident.inner.clone(), x)
             }
             TypeKind::Optional(vtype) => {
                 let tag = self.pop()?;
                 match tag {
                     0 => Value::NONE,
-                    1 => Value::Option(Some(Box::new(self.deserialize_value(&vtype.kind)?))),
+                    1 => Value::Option(Some(Box::new(self.deserialize_value(&vtype.inner)?))),
                     _ => return Err(Bad),
                 }
             }
             TypeKind::Result(res) => {
                 let tag = self.pop()?;
                 Value::Result(match tag {
-                    0 => Ok(Box::new(self.deserialize_value(&res.ok.kind)?)),
-                    1 => Err(Box::new(self.deserialize_value(&res.err.kind)?)),
+                    0 => Ok(Box::new(self.deserialize_value(&res.ok.inner)?)),
+                    1 => Err(Box::new(self.deserialize_value(&res.err.inner)?)),
                     _ => return Err(Bad),
                 })
             }

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -176,11 +176,11 @@ fn test_structs() -> anyhow::Result<()> {
         machine.struct_defs.get("Bar"),
         Some(&vec![ast::FieldDefinition {
             identifier: ast::Ident {
-                name: ident!("x"),
+                inner: ident!("x"),
                 span: ast::Span::new(33, 34)
             },
             field_type: ast::VType {
-                kind: ast::TypeKind::Int,
+                inner: ast::TypeKind::Int,
                 span: ast::Span::new(35, 38)
             }
         }])
@@ -2489,7 +2489,7 @@ fn test_result() -> anyhow::Result<()> {
                 }
             }
         }
-        
+
         function try(succeed bool) result[int, enum Err] {
             // error propagation is done explicilty, until we have `?` operator
             return match try_return(succeed) {

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -6,7 +6,7 @@ mod bits;
 use std::{collections::BTreeMap, iter};
 
 use aranya_crypto::{BaseId, DeviceId, policy::CmdId};
-use aranya_policy_ast::{self as ast, Version};
+use aranya_policy_ast::{self as ast, Version, WithSpanExt as _};
 use aranya_policy_compiler::Compiler;
 use aranya_policy_lang::lang::parse_policy_str;
 use aranya_policy_vm::{
@@ -175,14 +175,8 @@ fn test_structs() -> anyhow::Result<()> {
     assert_eq!(
         machine.struct_defs.get("Bar"),
         Some(&vec![ast::FieldDefinition {
-            identifier: ast::Ident {
-                inner: ident!("x"),
-                span: ast::Span::new(33, 34)
-            },
-            field_type: ast::VType {
-                inner: ast::TypeKind::Int,
-                span: ast::Span::new(35, 38)
-            }
+            identifier: ident!("x").at(33..34),
+            field_type: ast::TypeKind::Int.at(35..38),
         }])
     );
 

--- a/crates/aranya-runtime/src/vm_policy.rs
+++ b/crates/aranya-runtime/src/vm_policy.rs
@@ -229,7 +229,7 @@ fn get_command_priorities(
 ) -> Result<BTreeMap<Identifier, VmPriority>, AttributeError> {
     let mut priority_map = BTreeMap::new();
     for def in machine.command_defs.iter() {
-        let name = &def.name.name;
+        let name = &def.name.inner;
         let attrs = PriorityAttrs::load(name.as_str(), def)?;
         match def.persistence {
             Persistence::Persistent => {


### PR DESCRIPTION
`WithSpan` replaces each of the adhoc wrappers which just add a span, so now e.g. `type VType = WithSpan<TypeKind>`. `WithSpanExt` adds extension methods to wrap a type into a `WithSpan`.