### PR TITLE
sync: hide wire format

### DIFF
--- a/crates/aranya-core-example/src/main.rs
+++ b/crates/aranya-core-example/src/main.rs
@@ -18,7 +18,7 @@ use aranya_core::{
     },
     policy::{FfiCallable, VmEffect, VmPolicy, VmPolicyStore},
     storage::{FileManager, LinearStorageProvider},
-    sync::{MAX_SYNC_MESSAGE_SIZE, PeerCache, SyncRequester, SyncResponder, SyncType},
+    sync::{MAX_SYNC_MESSAGE_SIZE, PeerCache, SyncIncoming, SyncRequester, SyncResponder},
 };
 use aranya_crypto_ffi::Ffi as CryptoFfi;
 use aranya_device_ffi::FfiDevice as DeviceFfi;
@@ -180,12 +180,11 @@ fn dispatch(
     provider: &mut LinearStorageProvider<FileManager>,
     response_cache: &mut PeerCache,
 ) -> Result<usize> {
-    let sync_type: SyncType = postcard::from_bytes(data)?;
-    let len = match sync_type {
-        SyncType::Poll { request } => {
+    let len = match SyncIncoming::decode(data)? {
+        SyncIncoming::Poll { raw, .. } => {
             let mut responder = SyncResponder::new();
             let mut buffers = TraversalBuffers::default();
-            responder.receive(request)?;
+            responder.receive(raw)?;
             responder.poll(target, provider, response_cache, &mut buffers)?
         }
         _ => anyhow::bail!("unsupported sync type"),

--- a/crates/aranya-core-example/src/main.rs
+++ b/crates/aranya-core-example/src/main.rs
@@ -181,10 +181,10 @@ fn dispatch(
     response_cache: &mut PeerCache,
 ) -> Result<usize> {
     let len = match SyncIncoming::decode(data)? {
-        SyncIncoming::Poll { raw, .. } => {
+        SyncIncoming::Poll(poll) => {
             let mut responder = SyncResponder::new();
             let mut buffers = TraversalBuffers::default();
-            responder.receive(raw)?;
+            responder.receive(poll)?;
             responder.poll(target, provider, response_cache, &mut buffers)?
         }
         _ => anyhow::bail!("unsupported sync type"),

--- a/crates/aranya-core/src/lib.rs
+++ b/crates/aranya-core/src/lib.rs
@@ -135,13 +135,15 @@ pub mod sync {
     //! Peer-to-peer sync protocol for replicating graph state.
     //!
     //! A [`SyncRequester`] polls a peer; a [`SyncResponder`] serves the polled
-    //! request. Messages up to [`MAX_SYNC_MESSAGE_SIZE`] bytes are exchanged
-    //! as [`SyncType`] envelopes over any transport the caller provides.
+    //! request. Transports decode incoming bytes with [`SyncIncoming::decode`]
+    //! and dispatch on the returned variant; messages up to
+    //! [`MAX_SYNC_MESSAGE_SIZE`] bytes are exchanged over any transport the
+    //! caller provides.
 
     #[doc(inline)]
     pub use aranya_runtime::sync::{
-        COMMAND_RESPONSE_MAX, CommandMeta, MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX, PeerCache,
-        SubscribeResult, SyncCommand, SyncError, SyncHelloType, SyncRequestMessage, SyncRequester,
-        SyncResponder, SyncResponseMessage, SyncType,
+        COMMAND_RESPONSE_MAX, MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX, PeerCache, PushIncoming,
+        SubscribeResponse, SyncCommand, SyncError, SyncHeads, SyncHello, SyncIncoming,
+        SyncRequester, SyncResponder,
     };
 }

--- a/crates/aranya-core/src/lib.rs
+++ b/crates/aranya-core/src/lib.rs
@@ -142,8 +142,9 @@ pub mod sync {
 
     #[doc(inline)]
     pub use aranya_runtime::sync::{
-        COMMAND_RESPONSE_MAX, MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX, PeerCache, PollIncoming,
-        PushIncoming, SubscribeResponse, SyncCommand, SyncError, SyncHeads, SyncHello,
-        SyncIncoming, SyncRequester, SyncResponder,
+        COMMAND_RESPONSE_MAX, HelloNotification, HelloSubscribe, HelloUnsubscribe,
+        MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX, PeerCache, PollIncoming, PushIncoming,
+        SubscribeIncoming, SubscribeResponse, SyncCommand, SyncError, SyncHeads, SyncHello,
+        SyncIncoming, SyncRequester, SyncResponder, UnsubscribeIncoming,
     };
 }

--- a/crates/aranya-core/src/lib.rs
+++ b/crates/aranya-core/src/lib.rs
@@ -142,8 +142,8 @@ pub mod sync {
 
     #[doc(inline)]
     pub use aranya_runtime::sync::{
-        COMMAND_RESPONSE_MAX, MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX, PeerCache, PushIncoming,
-        SubscribeResponse, SyncCommand, SyncError, SyncHeads, SyncHello, SyncIncoming,
-        SyncRequester, SyncResponder,
+        COMMAND_RESPONSE_MAX, MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX, PeerCache, PollIncoming,
+        PushIncoming, SubscribeResponse, SyncCommand, SyncError, SyncHeads, SyncHello,
+        SyncIncoming, SyncRequester, SyncResponder,
     };
 }

--- a/crates/aranya-runtime/src/sync/mod.rs
+++ b/crates/aranya-runtime/src/sync/mod.rs
@@ -1,22 +1,28 @@
 //! Interface for syncing state between clients.
+//!
+//! Transports decode incoming bytes into a [`SyncIncoming`] and dispatch on
+//! its variants; the on-wire postcard layout is hidden behind that
+//! enumeration so it can evolve without breaking consumers.
+
+use core::time::Duration;
 
 use buggy::Bug;
+use heapless::Vec;
 use postcard::Error as PostcardError;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     Address, MaxCut, Prior,
     command::{CmdId, Command, Priority},
-    storage::{MAX_COMMAND_LENGTH, StorageError},
+    storage::{GraphId, MAX_COMMAND_LENGTH, StorageError},
 };
 
-mod dispatcher;
 mod requester;
 mod responder;
+mod wire;
 
-pub use dispatcher::{SubscribeResult, SyncHelloType, SyncType};
-pub use requester::{SyncRequestMessage, SyncRequester};
-pub use responder::{PeerCache, SyncResponder, SyncResponseMessage};
+pub use requester::SyncRequester;
+pub use responder::{PeerCache, SyncResponder};
 
 // TODO: These should all be compile time parameters
 
@@ -52,26 +58,6 @@ const SEGMENT_BUFFER_MAX: usize = 100;
 // TODO: Use postcard to calculate max size (which accounts for overhead)
 // https://docs.rs/postcard/latest/postcard/experimental/max_size/index.html
 pub const MAX_SYNC_MESSAGE_SIZE: usize = 1024 + MAX_COMMAND_LENGTH * COMMAND_RESPONSE_MAX;
-
-/// Represents high-level data of a command.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct CommandMeta {
-    id: CmdId,
-    priority: Priority,
-    parent: Prior<Address>,
-    policy_length: u32,
-    length: u32,
-    max_cut: MaxCut,
-}
-
-impl CommandMeta {
-    pub fn address(&self) -> Address {
-        Address {
-            id: self.id,
-            max_cut: self.max_cut,
-        }
-    }
-}
 
 /// An error returned by the syncer.
 #[derive(Debug, thiserror::Error)]
@@ -128,5 +114,201 @@ impl<'a> Command for SyncCommand<'a> {
 
     fn max_cut(&self) -> Result<MaxCut, Bug> {
         Ok(self.max_cut)
+    }
+}
+
+// Re-imports of pub(crate) wire types used in helper conversions below.
+use responder::SyncResponseMessage;
+use wire::{SubscribeResult, SyncHelloType, SyncType};
+
+/// A decoded incoming sync message.
+///
+/// Transports decode the raw bytes received over the network with
+/// [`SyncIncoming::decode`] and then dispatch on the returned variant.
+/// The on-wire postcard layout is encapsulated by this enum and the
+/// associated helper types — consumers don't depend on the wire
+/// representation directly.
+#[allow(clippy::large_enum_variant)]
+pub enum SyncIncoming<'a> {
+    /// A sync poll. Forward [`raw`] to [`SyncResponder::receive`].
+    ///
+    /// [`raw`]: SyncIncoming::Poll::raw
+    Poll {
+        /// The session identifier for this poll.
+        session_id: u128,
+        /// Encoded request bytes to feed back to [`SyncResponder::receive`].
+        raw: &'a [u8],
+    },
+    /// A subscription request from a peer.
+    Subscribe {
+        /// The graph being subscribed to.
+        graph_id: GraphId,
+        /// Number of seconds the subscription should remain open.
+        remain_open: u64,
+        /// Maximum bytes the responder may push.
+        max_bytes: u64,
+        /// The peer's known graph heads.
+        heads: SyncHeads,
+    },
+    /// An unsubscribe request from a peer.
+    Unsubscribe {
+        /// The graph being unsubscribed from.
+        graph_id: GraphId,
+    },
+    /// A push from a subscribed peer. Hand to [`SyncRequester::receive_push`].
+    Push(PushIncoming<'a>),
+    /// A subscription-control hello message.
+    Hello(SyncHello),
+}
+
+impl<'a> SyncIncoming<'a> {
+    /// Decode an incoming sync message from raw bytes.
+    pub fn decode(data: &'a [u8]) -> Result<Self, SyncError> {
+        let (sync_type, remaining) = postcard::take_from_bytes::<SyncType>(data)?;
+        let consumed = data.len().saturating_sub(remaining.len());
+        // Postcard variant tags for SyncType (5 variants) all encode in 1
+        // varint byte. The body of each variant immediately follows.
+        let body = data.get(1..consumed).unwrap_or(&[]);
+        Ok(match sync_type {
+            SyncType::Poll { request } => Self::Poll {
+                session_id: request.session_id(),
+                raw: body,
+            },
+            SyncType::Subscribe {
+                remain_open,
+                max_bytes,
+                commands,
+                graph_id,
+            } => Self::Subscribe {
+                graph_id,
+                remain_open,
+                max_bytes,
+                heads: SyncHeads { inner: commands },
+            },
+            SyncType::Unsubscribe { graph_id } => Self::Unsubscribe { graph_id },
+            SyncType::Push { message, graph_id } => Self::Push(PushIncoming {
+                graph_id,
+                session_id: message.session_id(),
+                message,
+                command_data: remaining,
+            }),
+            SyncType::Hello(hello) => Self::Hello(hello.into()),
+        })
+    }
+}
+
+/// A peer's sample of known graph heads, carried in [`SyncIncoming::Subscribe`].
+pub struct SyncHeads {
+    inner: Vec<Address, COMMAND_SAMPLE_MAX>,
+}
+
+impl SyncHeads {
+    /// Returns the heads as a slice.
+    pub fn as_slice(&self) -> &[Address] {
+        &self.inner
+    }
+
+    /// Iterates over the heads.
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = Address> + ExactSizeIterator + '_ {
+        self.inner.iter().copied()
+    }
+}
+
+/// A subscription-control message: subscribe, unsubscribe, or hello.
+#[derive(Debug)]
+pub enum SyncHello {
+    /// Subscribe to receive hello notifications from this peer.
+    Subscribe {
+        /// Specifies the graph.
+        graph_id: GraphId,
+        /// Delay between notifications when graph changes (rate limiting).
+        graph_change_delay: Duration,
+        /// How long the subscription should last.
+        duration: Duration,
+        /// Schedule-based hello sending delay.
+        schedule_delay: Duration,
+    },
+    /// Unsubscribe from hello notifications.
+    Unsubscribe {
+        /// Specifies the graph.
+        graph_id: GraphId,
+    },
+    /// Notification message sent to subscribers.
+    Hello {
+        /// Specifies the graph.
+        graph_id: GraphId,
+        /// The current head of the sender's graph.
+        head: Address,
+    },
+}
+
+impl From<SyncHelloType> for SyncHello {
+    fn from(t: SyncHelloType) -> Self {
+        match t {
+            SyncHelloType::Subscribe {
+                graph_id,
+                graph_change_delay,
+                duration,
+                schedule_delay,
+            } => Self::Subscribe {
+                graph_id,
+                graph_change_delay,
+                duration,
+                schedule_delay,
+            },
+            SyncHelloType::Unsubscribe { graph_id } => Self::Unsubscribe { graph_id },
+            SyncHelloType::Hello { graph_id, head } => Self::Hello { graph_id, head },
+        }
+    }
+}
+
+/// An opaque container for a received push message. Hand to
+/// [`SyncRequester::receive_push`] to extract the contained commands.
+pub struct PushIncoming<'a> {
+    graph_id: GraphId,
+    session_id: u128,
+    pub(crate) message: SyncResponseMessage,
+    pub(crate) command_data: &'a [u8],
+}
+
+impl PushIncoming<'_> {
+    /// Returns the graph this push targets.
+    pub fn graph_id(&self) -> GraphId {
+        self.graph_id
+    }
+
+    /// Returns the sender's session identifier.
+    pub fn session_id(&self) -> u128 {
+        self.session_id
+    }
+}
+
+/// The result of a [`SyncIncoming::Subscribe`] dispatch, sent back to the
+/// requester so it knows whether the subscription was accepted.
+#[derive(Debug)]
+pub enum SubscribeResponse {
+    /// The subscription was accepted.
+    Success,
+    /// The responder is at its subscription limit.
+    TooManySubscriptions,
+}
+
+impl SubscribeResponse {
+    /// Encode into `target`. Returns the number of bytes written.
+    pub fn encode_to(self, target: &mut [u8]) -> Result<usize, SyncError> {
+        let inner = match self {
+            Self::Success => SubscribeResult::Success,
+            Self::TooManySubscriptions => SubscribeResult::TooManySubscriptions,
+        };
+        Ok(postcard::to_slice(&inner, target)?.len())
+    }
+
+    /// Decode from raw bytes.
+    pub fn decode(data: &[u8]) -> Result<Self, SyncError> {
+        let inner: SubscribeResult = postcard::from_bytes(data)?;
+        Ok(match inner {
+            SubscribeResult::Success => Self::Success,
+            SubscribeResult::TooManySubscriptions => Self::TooManySubscriptions,
+        })
     }
 }

--- a/crates/aranya-runtime/src/sync/mod.rs
+++ b/crates/aranya-runtime/src/sync/mod.rs
@@ -132,21 +132,9 @@ pub enum SyncIncoming<'a> {
     /// A sync poll. Hand to [`SyncResponder::receive`].
     Poll(PollIncoming),
     /// A subscription request from a peer.
-    Subscribe {
-        /// The graph being subscribed to.
-        graph_id: GraphId,
-        /// Number of seconds the subscription should remain open.
-        remain_open: u64,
-        /// Maximum bytes the responder may push.
-        max_bytes: u64,
-        /// The peer's known graph heads.
-        heads: SyncHeads,
-    },
+    Subscribe(SubscribeIncoming),
     /// An unsubscribe request from a peer.
-    Unsubscribe {
-        /// The graph being unsubscribed from.
-        graph_id: GraphId,
-    },
+    Unsubscribe(UnsubscribeIncoming),
     /// A push from a subscribed peer. Hand to [`SyncRequester::receive_push`].
     Push(PushIncoming<'a>),
     /// A subscription-control hello message.
@@ -167,13 +155,15 @@ impl<'a> SyncIncoming<'a> {
                 max_bytes,
                 commands,
                 graph_id,
-            } => Self::Subscribe {
+            } => Self::Subscribe(SubscribeIncoming {
                 graph_id,
                 remain_open,
                 max_bytes,
                 heads: SyncHeads { inner: commands },
-            },
-            SyncType::Unsubscribe { graph_id } => Self::Unsubscribe { graph_id },
+            }),
+            SyncType::Unsubscribe { graph_id } => {
+                Self::Unsubscribe(UnsubscribeIncoming { graph_id })
+            }
             SyncType::Push { message, graph_id } => Self::Push(PushIncoming {
                 graph_id,
                 session_id: message.session_id(),
@@ -206,28 +196,11 @@ impl SyncHeads {
 #[derive(Debug)]
 pub enum SyncHello {
     /// Subscribe to receive hello notifications from this peer.
-    Subscribe {
-        /// Specifies the graph.
-        graph_id: GraphId,
-        /// Delay between notifications when graph changes (rate limiting).
-        graph_change_delay: Duration,
-        /// How long the subscription should last.
-        duration: Duration,
-        /// Schedule-based hello sending delay.
-        schedule_delay: Duration,
-    },
+    Subscribe(HelloSubscribe),
     /// Unsubscribe from hello notifications.
-    Unsubscribe {
-        /// Specifies the graph.
-        graph_id: GraphId,
-    },
+    Unsubscribe(HelloUnsubscribe),
     /// Notification message sent to subscribers.
-    Hello {
-        /// Specifies the graph.
-        graph_id: GraphId,
-        /// The current head of the sender's graph.
-        head: Address,
-    },
+    Hello(HelloNotification),
 }
 
 impl From<SyncHelloType> for SyncHello {
@@ -238,15 +211,82 @@ impl From<SyncHelloType> for SyncHello {
                 graph_change_delay,
                 duration,
                 schedule_delay,
-            } => Self::Subscribe {
+            } => Self::Subscribe(HelloSubscribe {
                 graph_id,
                 graph_change_delay,
                 duration,
                 schedule_delay,
-            },
-            SyncHelloType::Unsubscribe { graph_id } => Self::Unsubscribe { graph_id },
-            SyncHelloType::Hello { graph_id, head } => Self::Hello { graph_id, head },
+            }),
+            SyncHelloType::Unsubscribe { graph_id } => {
+                Self::Unsubscribe(HelloUnsubscribe { graph_id })
+            }
+            SyncHelloType::Hello { graph_id, head } => {
+                Self::Hello(HelloNotification { graph_id, head })
+            }
         }
+    }
+}
+
+/// An opaque container for a hello-protocol subscribe request.
+#[derive(Debug)]
+pub struct HelloSubscribe {
+    graph_id: GraphId,
+    graph_change_delay: Duration,
+    duration: Duration,
+    schedule_delay: Duration,
+}
+
+impl HelloSubscribe {
+    /// Returns the graph being subscribed to.
+    pub fn graph_id(&self) -> GraphId {
+        self.graph_id
+    }
+
+    /// Returns the delay between notifications when the graph changes (rate limiting).
+    pub fn graph_change_delay(&self) -> Duration {
+        self.graph_change_delay
+    }
+
+    /// Returns how long the subscription should last.
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// Returns the schedule-based hello sending delay.
+    pub fn schedule_delay(&self) -> Duration {
+        self.schedule_delay
+    }
+}
+
+/// An opaque container for a hello-protocol unsubscribe request.
+#[derive(Debug)]
+pub struct HelloUnsubscribe {
+    graph_id: GraphId,
+}
+
+impl HelloUnsubscribe {
+    /// Returns the graph being unsubscribed from.
+    pub fn graph_id(&self) -> GraphId {
+        self.graph_id
+    }
+}
+
+/// An opaque container for a hello notification sent to subscribers.
+#[derive(Debug)]
+pub struct HelloNotification {
+    graph_id: GraphId,
+    head: Address,
+}
+
+impl HelloNotification {
+    /// Returns the graph this notification is for.
+    pub fn graph_id(&self) -> GraphId {
+        self.graph_id
+    }
+
+    /// Returns the current head of the sender's graph.
+    pub fn head(&self) -> Address {
+        self.head
     }
 }
 
@@ -261,6 +301,48 @@ impl PollIncoming {
     /// Returns the sender's session identifier.
     pub fn session_id(&self) -> u128 {
         self.session_id
+    }
+}
+
+/// An opaque container for a received subscribe message.
+pub struct SubscribeIncoming {
+    graph_id: GraphId,
+    remain_open: u64,
+    max_bytes: u64,
+    heads: SyncHeads,
+}
+
+impl SubscribeIncoming {
+    /// Returns the graph being subscribed to.
+    pub fn graph_id(&self) -> GraphId {
+        self.graph_id
+    }
+
+    /// Returns how long the subscription should remain open.
+    pub fn remain_open(&self) -> Duration {
+        Duration::from_secs(self.remain_open)
+    }
+
+    /// Returns the maximum number of bytes the responder may push.
+    pub fn max_bytes(&self) -> u64 {
+        self.max_bytes
+    }
+
+    /// Returns the peer's known graph heads.
+    pub fn heads(&self) -> &SyncHeads {
+        &self.heads
+    }
+}
+
+/// An opaque container for a received unsubscribe message.
+pub struct UnsubscribeIncoming {
+    graph_id: GraphId,
+}
+
+impl UnsubscribeIncoming {
+    /// Returns the graph being unsubscribed from.
+    pub fn graph_id(&self) -> GraphId {
+        self.graph_id
     }
 }
 

--- a/crates/aranya-runtime/src/sync/mod.rs
+++ b/crates/aranya-runtime/src/sync/mod.rs
@@ -21,6 +21,7 @@ mod requester;
 mod responder;
 mod wire;
 
+use requester::SyncRequestMessage;
 pub use requester::SyncRequester;
 use responder::SyncResponseMessage;
 pub use responder::{PeerCache, SyncResponder};
@@ -128,15 +129,8 @@ impl<'a> Command for SyncCommand<'a> {
 /// representation directly.
 #[allow(clippy::large_enum_variant)]
 pub enum SyncIncoming<'a> {
-    /// A sync poll. Forward [`raw`] to [`SyncResponder::receive`].
-    ///
-    /// [`raw`]: SyncIncoming::Poll::raw
-    Poll {
-        /// The session identifier for this poll.
-        session_id: u128,
-        /// Encoded request bytes to feed back to [`SyncResponder::receive`].
-        raw: &'a [u8],
-    },
+    /// A sync poll. Hand to [`SyncResponder::receive`].
+    Poll(PollIncoming),
     /// A subscription request from a peer.
     Subscribe {
         /// The graph being subscribed to.
@@ -163,15 +157,11 @@ impl<'a> SyncIncoming<'a> {
     /// Decode an incoming sync message from raw bytes.
     pub fn decode(data: &'a [u8]) -> Result<Self, SyncError> {
         let (sync_type, remaining) = postcard::take_from_bytes::<SyncType>(data)?;
-        let consumed = data.len().saturating_sub(remaining.len());
-        // Postcard variant tags for SyncType (5 variants) all encode in 1
-        // varint byte. The body of each variant immediately follows.
-        let body = data.get(1..consumed).unwrap_or(&[]);
         Ok(match sync_type {
-            SyncType::Poll { request } => Self::Poll {
+            SyncType::Poll { request } => Self::Poll(PollIncoming {
                 session_id: request.session_id(),
-                raw: body,
-            },
+                message: request,
+            }),
             SyncType::Subscribe {
                 remain_open,
                 max_bytes,
@@ -257,6 +247,20 @@ impl From<SyncHelloType> for SyncHello {
             SyncHelloType::Unsubscribe { graph_id } => Self::Unsubscribe { graph_id },
             SyncHelloType::Hello { graph_id, head } => Self::Hello { graph_id, head },
         }
+    }
+}
+
+/// An opaque container for a received poll message. Hand to
+/// [`SyncResponder::receive`] to update the responder's state.
+pub struct PollIncoming {
+    session_id: u128,
+    pub(crate) message: SyncRequestMessage,
+}
+
+impl PollIncoming {
+    /// Returns the sender's session identifier.
+    pub fn session_id(&self) -> u128 {
+        self.session_id
     }
 }
 

--- a/crates/aranya-runtime/src/sync/mod.rs
+++ b/crates/aranya-runtime/src/sync/mod.rs
@@ -22,7 +22,9 @@ mod responder;
 mod wire;
 
 pub use requester::SyncRequester;
+use responder::SyncResponseMessage;
 pub use responder::{PeerCache, SyncResponder};
+use wire::{SubscribeResult, SyncHelloType, SyncType};
 
 // TODO: These should all be compile time parameters
 
@@ -116,10 +118,6 @@ impl<'a> Command for SyncCommand<'a> {
         Ok(self.max_cut)
     }
 }
-
-// Re-imports of pub(crate) wire types used in helper conversions below.
-use responder::SyncResponseMessage;
-use wire::{SubscribeResult, SyncHelloType, SyncType};
 
 /// A decoded incoming sync message.
 ///

--- a/crates/aranya-runtime/src/sync/requester.rs
+++ b/crates/aranya-runtime/src/sync/requester.rs
@@ -6,8 +6,8 @@ use heapless::Vec;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    COMMAND_RESPONSE_MAX, COMMAND_SAMPLE_MAX, PEER_HEAD_MAX, PeerCache, REQUEST_MISSING_MAX,
-    SyncCommand, SyncError, dispatcher::SyncType, responder::SyncResponseMessage,
+    COMMAND_RESPONSE_MAX, COMMAND_SAMPLE_MAX, PEER_HEAD_MAX, PeerCache, PushIncoming,
+    REQUEST_MISSING_MAX, SyncCommand, SyncError, responder::SyncResponseMessage, wire::SyncType,
 };
 use crate::{
     Address, GraphId, Location, TraversalBuffer,
@@ -22,7 +22,7 @@ use crate::{
 /// Messages sent from the requester to the responder.
 #[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub enum SyncRequestMessage {
+pub(crate) enum SyncRequestMessage {
     /// Initiate a new Sync
     SyncRequest {
         /// A new random value produced by a cryptographically secure RNG.
@@ -69,7 +69,7 @@ pub enum SyncRequestMessage {
 }
 
 impl SyncRequestMessage {
-    pub fn session_id(&self) -> u128 {
+    pub(crate) fn session_id(&self) -> u128 {
         match self {
             Self::SyncRequest { session_id, .. } => *session_id,
             Self::RequestMissing { session_id, .. } => *session_id,
@@ -183,8 +183,17 @@ impl SyncRequester {
         self.get_sync_commands(message, remaining)
     }
 
+    /// Apply a push received via [`SyncIncoming::Push`](super::SyncIncoming::Push).
+    /// Returns parsed sync commands borrowed from the original push payload.
+    pub fn receive_push<'data>(
+        &mut self,
+        push: PushIncoming<'data>,
+    ) -> Result<Option<Vec<SyncCommand<'data>, COMMAND_RESPONSE_MAX>>, SyncError> {
+        self.get_sync_commands(push.message, push.command_data)
+    }
+
     /// Extract SyncCommands from a SyncResponseMessage and remaining bytes.
-    pub fn get_sync_commands<'data>(
+    fn get_sync_commands<'data>(
         &mut self,
         message: SyncResponseMessage,
         remaining: &'data [u8],

--- a/crates/aranya-runtime/src/sync/responder.rs
+++ b/crates/aranya-runtime/src/sync/responder.rs
@@ -3,11 +3,13 @@ use heapless::Vec;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    COMMAND_RESPONSE_MAX, COMMAND_SAMPLE_MAX, CommandMeta, MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX,
-    SEGMENT_BUFFER_MAX, SyncError, requester::SyncRequestMessage,
+    COMMAND_RESPONSE_MAX, COMMAND_SAMPLE_MAX, MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX,
+    SEGMENT_BUFFER_MAX, SyncError,
+    requester::SyncRequestMessage,
+    wire::{CommandMeta, SyncType},
 };
 use crate::{
-    StorageError, SyncType,
+    StorageError,
     command::{Address, CmdId, Command as _},
     storage::{
         GraphId, Location, MaxCut, Segment as _, Storage, StorageProvider, TraversalBuffer,
@@ -85,7 +87,7 @@ impl PeerCache {
 /// Messages sent from the responder to the requester.
 #[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub enum SyncResponseMessage {
+pub(crate) enum SyncResponseMessage {
     /// Sent in response to a `SyncRequest`
     SyncResponse {
         /// A random-value produced by a cryptographically secure RNG.
@@ -130,7 +132,7 @@ pub enum SyncResponseMessage {
 }
 
 impl SyncResponseMessage {
-    pub fn session_id(&self) -> u128 {
+    pub(crate) fn session_id(&self) -> u128 {
         match self {
             Self::SyncResponse { session_id, .. } => *session_id,
             Self::SyncEnd { session_id, .. } => *session_id,
@@ -267,8 +269,41 @@ impl SyncResponder {
         Ok(length)
     }
 
-    /// Receive a sync message. Updates the responders state for later polling.
-    pub fn receive(&mut self, message: SyncRequestMessage) -> Result<(), SyncError> {
+    /// Receive a sync message. Updates the responder's state for later polling.
+    ///
+    /// `data` is the postcard-encoded `SyncRequestMessage` carried by a
+    /// [`SyncIncoming::Poll`](crate::sync::SyncIncoming::Poll).
+    pub fn receive(&mut self, data: &[u8]) -> Result<(), SyncError> {
+        let (message, _) = postcard::take_from_bytes::<SyncRequestMessage>(data)?;
+        self.dispatch(message)
+    }
+
+    /// Begin a new session in-process, without going through the wire.
+    ///
+    /// Used by transports that need to push out an unsolicited update to a
+    /// subscribed peer: instead of round-tripping a `SyncRequest` through the
+    /// network, the transport seeds the responder directly with the heads it
+    /// already knows about.
+    pub fn start_session(
+        &mut self,
+        session_id: u128,
+        graph_id: GraphId,
+        max_bytes: u64,
+        heads: &[Address],
+    ) -> Result<(), SyncError> {
+        let mut commands: Vec<Address, COMMAND_SAMPLE_MAX> = Vec::new();
+        commands
+            .extend_from_slice(heads)
+            .map_err(|()| SyncError::CommandOverflow)?;
+        self.dispatch(SyncRequestMessage::SyncRequest {
+            session_id,
+            graph_id,
+            max_bytes,
+            commands,
+        })
+    }
+
+    fn dispatch(&mut self, message: SyncRequestMessage) -> Result<(), SyncError> {
         if self.session_id.is_none() {
             self.session_id = Some(message.session_id());
         }

--- a/crates/aranya-runtime/src/sync/responder.rs
+++ b/crates/aranya-runtime/src/sync/responder.rs
@@ -3,7 +3,7 @@ use heapless::Vec;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    COMMAND_RESPONSE_MAX, COMMAND_SAMPLE_MAX, MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX,
+    COMMAND_RESPONSE_MAX, COMMAND_SAMPLE_MAX, MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX, PollIncoming,
     SEGMENT_BUFFER_MAX, SyncError,
     requester::SyncRequestMessage,
     wire::{CommandMeta, SyncType},
@@ -269,13 +269,9 @@ impl SyncResponder {
         Ok(length)
     }
 
-    /// Receive a sync message. Updates the responder's state for later polling.
-    ///
-    /// `data` is the postcard-encoded `SyncRequestMessage` carried by a
-    /// [`SyncIncoming::Poll`](crate::sync::SyncIncoming::Poll).
-    pub fn receive(&mut self, data: &[u8]) -> Result<(), SyncError> {
-        let (message, _) = postcard::take_from_bytes::<SyncRequestMessage>(data)?;
-        self.dispatch(message)
+    /// Receive a sync poll. Updates the responder's state for later polling.
+    pub fn receive(&mut self, poll: PollIncoming) -> Result<(), SyncError> {
+        self.dispatch(poll.message)
     }
 
     /// Begin a new session in-process, without going through the wire.

--- a/crates/aranya-runtime/src/sync/wire.rs
+++ b/crates/aranya-runtime/src/sync/wire.rs
@@ -1,14 +1,24 @@
+//! Postcard-shaped wire types for the sync protocol.
+//!
+//! These are kept `pub(crate)` so the on-wire layout can evolve without
+//! breaking consumers of `aranya-runtime::sync`. The public dispatch surface
+//! is in [`super`] (`SyncIncoming`, `SyncHello`, `SyncHeads`,
+//! `SubscribeResponse`).
+
 use core::time::Duration;
 
 use heapless::Vec;
 use serde::{Deserialize, Serialize};
 
-use super::{COMMAND_SAMPLE_MAX, SyncResponseMessage, requester::SyncRequestMessage};
-use crate::{Address, GraphId};
+use super::{COMMAND_SAMPLE_MAX, requester::SyncRequestMessage};
+use crate::{
+    Address, GraphId, MaxCut, Prior,
+    command::{CmdId, Priority},
+};
 
 /// The sync hello message types for subscription-based notifications.
 #[derive(Serialize, Deserialize, Debug)]
-pub enum SyncHelloType {
+pub(crate) enum SyncHelloType {
     /// Subscribe to receive hello notifications from this peer
     Subscribe {
         /// Specifies the graph.
@@ -38,7 +48,7 @@ pub enum SyncHelloType {
 /// The sync type to dispatch.
 #[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub enum SyncType {
+pub(crate) enum SyncType {
     /// This will include a sync request and be
     /// immediately responded to with a sync response.
     Poll {
@@ -69,7 +79,7 @@ pub enum SyncType {
     Push {
         /// A message containing commands that the pusher believes the peer
         /// does not have.
-        message: SyncResponseMessage,
+        message: super::responder::SyncResponseMessage,
         /// The graph this push is for.
         graph_id: GraphId,
     },
@@ -79,7 +89,18 @@ pub enum SyncType {
 
 /// The result of attempting to subscribe.
 #[derive(Serialize, Deserialize, Debug)]
-pub enum SubscribeResult {
+pub(crate) enum SubscribeResult {
     Success,
     TooManySubscriptions,
+}
+
+/// Represents high-level data of a command.
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct CommandMeta {
+    pub(crate) id: CmdId,
+    pub(crate) priority: Priority,
+    pub(crate) parent: Prior<Address>,
+    pub(crate) policy_length: u32,
+    pub(crate) length: u32,
+    pub(crate) max_cut: MaxCut,
 }

--- a/crates/aranya-runtime/src/testing/dsl.rs
+++ b/crates/aranya-runtime/src/testing/dsl.rs
@@ -68,7 +68,7 @@ use tracing::{debug, error};
 use crate::{
     Address, COMMAND_RESPONSE_MAX, ClientError, ClientState, CmdId, Command as _, GraphId,
     Location, MAX_SYNC_MESSAGE_SIZE, MaxCut, PeerCache, PolicyError, Prior, Segment as _, Storage,
-    StorageError, StorageProvider, SyncError, SyncRequester, SyncResponder, SyncType,
+    StorageError, StorageProvider, SyncError, SyncIncoming, SyncRequester, SyncResponder,
     TraversalBuffer, TraversalBuffers,
     testing::{
         protocol::{TestActions, TestEffect, TestPolicyStore, TestSink},
@@ -84,7 +84,7 @@ fn default_max_syncs() -> u64 {
     1
 }
 
-/// Dispatches the SyncType contained in data.
+/// Dispatches the sync message contained in data.
 /// This function is only for testing using polling. In production
 /// usage the syncer implementation will handle this.
 pub fn dispatch(
@@ -94,18 +94,17 @@ pub fn dispatch(
     response_cache: &mut PeerCache,
     buffers: &mut TraversalBuffers,
 ) -> Result<usize, SyncError> {
-    let sync_type: SyncType = postcard::from_bytes(data)?;
-    let len = match sync_type {
-        SyncType::Poll { request } => {
+    let len = match SyncIncoming::decode(data)? {
+        SyncIncoming::Poll { raw, .. } => {
             let mut response_syncer = SyncResponder::new();
-            response_syncer.receive(request)?;
+            response_syncer.receive(raw)?;
             assert!(response_syncer.ready());
             response_syncer.poll(target, provider, response_cache, buffers)?
         }
-        SyncType::Subscribe { .. } => unimplemented!(),
-        SyncType::Unsubscribe { .. } => unimplemented!(),
-        SyncType::Push { .. } => unimplemented!(),
-        SyncType::Hello(_) => unimplemented!(),
+        SyncIncoming::Subscribe { .. } => unimplemented!(),
+        SyncIncoming::Unsubscribe { .. } => unimplemented!(),
+        SyncIncoming::Push(_) => unimplemented!(),
+        SyncIncoming::Hello(_) => unimplemented!(),
     };
     Ok(len)
 }

--- a/crates/aranya-runtime/src/testing/dsl.rs
+++ b/crates/aranya-runtime/src/testing/dsl.rs
@@ -95,9 +95,9 @@ pub fn dispatch(
     buffers: &mut TraversalBuffers,
 ) -> Result<usize, SyncError> {
     let len = match SyncIncoming::decode(data)? {
-        SyncIncoming::Poll { raw, .. } => {
+        SyncIncoming::Poll(poll) => {
             let mut response_syncer = SyncResponder::new();
-            response_syncer.receive(raw)?;
+            response_syncer.receive(poll)?;
             assert!(response_syncer.ready());
             response_syncer.poll(target, provider, response_cache, buffers)?
         }

--- a/crates/aranya-runtime/src/testing/dsl.rs
+++ b/crates/aranya-runtime/src/testing/dsl.rs
@@ -101,8 +101,8 @@ pub fn dispatch(
             assert!(response_syncer.ready());
             response_syncer.poll(target, provider, response_cache, buffers)?
         }
-        SyncIncoming::Subscribe { .. } => unimplemented!(),
-        SyncIncoming::Unsubscribe { .. } => unimplemented!(),
+        SyncIncoming::Subscribe(_) => unimplemented!(),
+        SyncIncoming::Unsubscribe(_) => unimplemented!(),
         SyncIncoming::Push(_) => unimplemented!(),
         SyncIncoming::Hello(_) => unimplemented!(),
     };

--- a/crates/aranya-tcp-syncer/src/lib.rs
+++ b/crates/aranya-tcp-syncer/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
     net::{Shutdown, SocketAddr, TcpListener, TcpStream},
     ops::DerefMut as _,
     sync::{Arc, Mutex, mpsc},
-    time::{Duration, SystemTime},
+    time::SystemTime,
 };
 
 use anyhow::Result;
@@ -255,28 +255,23 @@ where
                     &mut self.buffers,
                 )?
             }
-            SyncIncoming::Subscribe {
-                remain_open,
-                max_bytes,
-                heads,
-                graph_id,
-            } => {
+            SyncIncoming::Subscribe(sub) => {
                 self.subscriptions.retain(|_, s| !s.expired());
                 match self.subscriptions.insert(
-                    (peer_address, graph_id),
+                    (peer_address, sub.graph_id()),
                     Subscription {
                         close_time: SystemTime::now()
-                            .checked_add(Duration::from_secs(remain_open))
+                            .checked_add(sub.remain_open())
                             .assume("must not overflow")?,
-                        remaining_bytes: max_bytes,
+                        remaining_bytes: sub.max_bytes(),
                     },
                 ) {
                     Ok(_) => {
                         let response_cache = self.remote_heads.entry(peer_address).or_default();
                         let mut client = self.client_state.lock().expect("poisoned");
                         client.update_heads(
-                            graph_id,
-                            heads.iter(),
+                            sub.graph_id(),
+                            sub.heads().iter(),
                             response_cache,
                             &mut self.buffers.primary,
                         )?;
@@ -285,8 +280,8 @@ where
                     Err(_) => SubscribeResponse::TooManySubscriptions.encode_to(target)?,
                 }
             }
-            SyncIncoming::Unsubscribe { graph_id } => {
-                self.subscriptions.remove(&(peer_address, graph_id));
+            SyncIncoming::Unsubscribe(unsub) => {
+                self.subscriptions.remove(&(peer_address, unsub.graph_id()));
                 0
             }
             SyncIncoming::Push(push) => {

--- a/crates/aranya-tcp-syncer/src/lib.rs
+++ b/crates/aranya-tcp-syncer/src/lib.rs
@@ -241,11 +241,11 @@ where
         target: &mut [u8],
     ) -> Result<usize> {
         let len = match SyncIncoming::decode(data)? {
-            SyncIncoming::Poll { raw, .. } => {
+            SyncIncoming::Poll(poll) => {
                 let response_cache = self.remote_heads.entry(peer_address).or_default();
                 let mut client = self.client_state.lock().expect("poisoned");
                 let mut response_syncer = SyncResponder::new();
-                response_syncer.receive(raw)?;
+                response_syncer.receive(poll)?;
                 assert!(response_syncer.ready());
 
                 response_syncer.poll(

--- a/crates/aranya-tcp-syncer/src/lib.rs
+++ b/crates/aranya-tcp-syncer/src/lib.rs
@@ -17,13 +17,13 @@ use std::{
 use anyhow::Result;
 use aranya_crypto::{Csprng as _, Rng};
 use aranya_runtime::{
-    ClientState, Command as _, MAX_SYNC_MESSAGE_SIZE, PeerCache, SubscribeResult, SyncError,
-    SyncRequestMessage, SyncRequester, SyncResponder, SyncType, TraversalBuffers,
+    ClientState, Command as _, MAX_SYNC_MESSAGE_SIZE, PeerCache, SubscribeResponse, SyncError,
+    SyncIncoming, SyncRequester, SyncResponder, TraversalBuffers,
     policy::{PolicyStore, Sink},
     storage::{GraphId, StorageProvider},
 };
 use buggy::{BugExt as _, bug};
-use heapless::{FnvIndexMap, Vec};
+use heapless::FnvIndexMap;
 use tracing::error;
 
 /// FNVIndexMap requires that the size be a power of 2.
@@ -67,7 +67,7 @@ where
     SP: StorageProvider,
     S: Sink<<PS as PolicyStore>::Effect>,
 {
-    let mut req = std::vec::Vec::new();
+    let mut req = Vec::new();
     stream.read_to_end(&mut req)?;
     let (peer_address, req) = postcard::take_from_bytes::<SocketAddr>(&req)?;
     let mut buffer = vec![0u8; MAX_SYNC_MESSAGE_SIZE];
@@ -94,7 +94,7 @@ where
     subscriptions: FnvIndexMap<(SocketAddr, GraphId), Subscription, MAXIMUM_SUBSCRIPTIONS>,
     client_state: Arc<Mutex<ClientState<PS, SP>>>,
     sink: Arc<Mutex<S>>,
-    return_address: std::vec::Vec<u8>,
+    return_address: Vec<u8>,
     buffers: TraversalBuffers,
 }
 
@@ -154,7 +154,7 @@ where
         stream.write_all(&self.return_address)?;
         stream.write_all(&buffer)?;
         stream.shutdown(Shutdown::Write)?;
-        let mut received_data = std::vec::Vec::new();
+        let mut received_data = Vec::new();
         stream.read_to_end(&mut received_data)?;
         // An empty response means we're up to date and there's nothing to sync.
         if !received_data.is_empty()
@@ -209,10 +209,9 @@ where
         if buffer.is_empty() {
             return Ok(());
         }
-        let result: SubscribeResult = postcard::from_bytes(&buffer)?;
-        match result {
-            SubscribeResult::Success => Ok(()),
-            SubscribeResult::TooManySubscriptions => bug!("TooManySubscriptions"),
+        match SubscribeResponse::decode(&buffer)? {
+            SubscribeResponse::Success => Ok(()),
+            SubscribeResponse::TooManySubscriptions => bug!("TooManySubscriptions"),
         }
     }
 
@@ -241,13 +240,12 @@ where
         data: &[u8],
         target: &mut [u8],
     ) -> Result<usize> {
-        let (sync_type, remaining): (SyncType, &[u8]) = postcard::take_from_bytes(data)?;
-        let len = match sync_type {
-            SyncType::Poll { request } => {
+        let len = match SyncIncoming::decode(data)? {
+            SyncIncoming::Poll { raw, .. } => {
                 let response_cache = self.remote_heads.entry(peer_address).or_default();
                 let mut client = self.client_state.lock().expect("poisoned");
                 let mut response_syncer = SyncResponder::new();
-                response_syncer.receive(request)?;
+                response_syncer.receive(raw)?;
                 assert!(response_syncer.ready());
 
                 response_syncer.poll(
@@ -257,10 +255,10 @@ where
                     &mut self.buffers,
                 )?
             }
-            SyncType::Subscribe {
+            SyncIncoming::Subscribe {
                 remain_open,
                 max_bytes,
-                commands,
+                heads,
                 graph_id,
             } => {
                 self.subscriptions.retain(|_, s| !s.expired());
@@ -278,25 +276,23 @@ where
                         let mut client = self.client_state.lock().expect("poisoned");
                         client.update_heads(
                             graph_id,
-                            commands.as_slice().iter().copied(),
+                            heads.iter(),
                             response_cache,
                             &mut self.buffers.primary,
                         )?;
-                        postcard::to_slice(&SubscribeResult::Success, target)?.len()
+                        SubscribeResponse::Success.encode_to(target)?
                     }
-                    Err(_) => {
-                        postcard::to_slice(&SubscribeResult::TooManySubscriptions, target)?.len()
-                    }
+                    Err(_) => SubscribeResponse::TooManySubscriptions.encode_to(target)?,
                 }
             }
-            SyncType::Unsubscribe { graph_id } => {
+            SyncIncoming::Unsubscribe { graph_id } => {
                 self.subscriptions.remove(&(peer_address, graph_id));
                 0
             }
-            SyncType::Push { message, graph_id } => {
-                let mut sync_requester =
-                    SyncRequester::new_session_id(graph_id, message.session_id());
-                if let Some(cmds) = sync_requester.get_sync_commands(message, remaining)?
+            SyncIncoming::Push(push) => {
+                let graph_id = push.graph_id();
+                let mut sync_requester = SyncRequester::new_session_id(graph_id, push.session_id());
+                if let Some(cmds) = sync_requester.receive_push(push)?
                     && !cmds.is_empty()
                 {
                     {
@@ -318,7 +314,7 @@ where
                 }
                 0
             }
-            SyncType::Hello(_) => {
+            SyncIncoming::Hello(_) => {
                 // Hello messages are fire-and-forget, no response needed
                 0
             }
@@ -339,16 +335,7 @@ where
             Rng.fill_bytes(&mut dst);
             let session_id = u128::from_le_bytes(dst);
             let mut response_syncer = SyncResponder::new();
-            let mut commands = Vec::new();
-            commands
-                .extend_from_slice(response_cache.heads())
-                .expect("infallible error");
-            response_syncer.receive(SyncRequestMessage::SyncRequest {
-                session_id,
-                graph_id,
-                max_bytes: 0,
-                commands,
-            })?;
+            response_syncer.start_session(session_id, graph_id, 0, response_cache.heads())?;
             assert!(response_syncer.ready());
             let mut target = vec![0u8; MAX_SYNC_MESSAGE_SIZE];
             let len = response_syncer.push(


### PR DESCRIPTION
Move the postcard-shaped wire types (SyncType, SyncHelloType, SubscribeResult, CommandMeta) into a pub(crate) wire module and expose a SyncIncoming::decode dispatch surface so the on-wire layout can evolve without breaking consumers. 