### PR TITLE
runtime: breaking changes for rkyv support with u64

### DIFF
--- a/crates/aranya-model/src/model.rs
+++ b/crates/aranya-model/src/model.rs
@@ -53,7 +53,7 @@ where
     fn add_policy(&mut self, policy: &[u8]) -> Result<PolicyId, PolicyError> {
         // TODO: (Scott) Implement once `add_policy` method is implemented in the policy_vm
         // For now return dummy PolicyId
-        Ok(PolicyId::new(policy[0] as usize))
+        Ok(PolicyId::new(policy[0].into()))
     }
 
     fn get_policy(&self, _id: PolicyId) -> Result<&Self::Policy, PolicyError> {

--- a/crates/aranya-runtime/src/client/session.rs
+++ b/crates/aranya-runtime/src/client/session.rs
@@ -162,7 +162,7 @@ impl<SP: StorageProvider, PS: PolicyStore> Session<SP, PS> {
 fn session_parent(graph_id: GraphId) -> Prior<Address> {
     Prior::Single(Address {
         id: CmdId::transmute(graph_id),
-        max_cut: MaxCut(0),
+        max_cut: MaxCut::new(0),
     })
 }
 

--- a/crates/aranya-runtime/src/client/transaction.rs
+++ b/crates/aranya-runtime/src/client/transaction.rs
@@ -682,7 +682,7 @@ mod test {
             let mut max_cuts = HashMap::new();
             let mut buffer = TraversalBuffer::new();
             for (max_cut, &id) in ids.iter().enumerate() {
-                let max_cut = MaxCut(max_cut);
+                let max_cut = MaxCut::new(max_cut as u64);
                 let cmd = SeqCommand::new(id, prior, max_cut);
                 trx.add_commands(
                     &[cmd],
@@ -848,7 +848,7 @@ mod test {
         use crate::Query as _;
         let head = storage.get_head().unwrap();
         let p = storage.get_fact_perspective(head).unwrap();
-        p.query(name, &Keys::default()).unwrap()
+        p.query(name, &[]).unwrap()
     }
 
     #[test]
@@ -868,7 +868,7 @@ mod test {
         #[cfg(feature = "graphviz")]
         graphviz::dot(g, "simple");
 
-        assert_eq!(g.get_head().unwrap().max_cut, MaxCut(3));
+        assert_eq!(g.get_head().unwrap().max_cut, MaxCut::new(3));
 
         let seq = lookup(g, "seq").unwrap();
         let seq = std::str::from_utf8(&seq).unwrap();
@@ -902,7 +902,7 @@ mod test {
         #[cfg(feature = "graphviz")]
         graphviz::dot(g, "complex");
 
-        assert_eq!(g.get_head().unwrap().max_cut, MaxCut(15));
+        assert_eq!(g.get_head().unwrap().max_cut, MaxCut::new(15));
 
         let seq = lookup(g, "seq").unwrap();
         let seq = std::str::from_utf8(&seq).unwrap();
@@ -935,7 +935,7 @@ mod test {
         #[cfg(feature = "graphviz")]
         graphviz::dot(g, "duplicates");
 
-        assert_eq!(g.get_head().unwrap().max_cut, MaxCut(4));
+        assert_eq!(g.get_head().unwrap().max_cut, MaxCut::new(4));
 
         let seq = lookup(g, "seq").unwrap();
         let seq = std::str::from_utf8(&seq).unwrap();
@@ -957,7 +957,7 @@ mod test {
         #[cfg(feature = "graphviz")]
         graphviz::dot(g, "mid_braid_1");
 
-        assert_eq!(g.get_head().unwrap().max_cut, MaxCut(7));
+        assert_eq!(g.get_head().unwrap().max_cut, MaxCut::new(7));
 
         let seq = lookup(g, "seq").unwrap();
         let seq = std::str::from_utf8(&seq).unwrap();
@@ -979,7 +979,7 @@ mod test {
         #[cfg(feature = "graphviz")]
         graphviz::dot(g, "mid_braid_2");
 
-        assert_eq!(g.get_head().unwrap().max_cut, MaxCut(7));
+        assert_eq!(g.get_head().unwrap().max_cut, MaxCut::new(7));
 
         let seq = lookup(g, "seq").unwrap();
         let seq = std::str::from_utf8(&seq).unwrap();
@@ -1004,7 +1004,7 @@ mod test {
         #[cfg(feature = "graphviz")]
         graphviz::dot(g, "finalize_success");
 
-        assert_eq!(g.get_head().unwrap().max_cut, MaxCut(9));
+        assert_eq!(g.get_head().unwrap().max_cut, MaxCut::new(9));
 
         let seq = lookup(g, "seq").unwrap();
         let seq = std::str::from_utf8(&seq).unwrap();

--- a/crates/aranya-runtime/src/command.rs
+++ b/crates/aranya-runtime/src/command.rs
@@ -51,7 +51,7 @@ pub trait Command {
     /// Return this command's max cut. Max cut is the maximum distance to the init command.
     fn max_cut(&self) -> Result<MaxCut, Bug> {
         match self.parent() {
-            Prior::None => Ok(MaxCut(0)),
+            Prior::None => Ok(MaxCut::new(0)),
             Prior::Single(l) => Ok(l.max_cut.checked_add(1).assume("must not overflow")?),
             Prior::Merge(l, r) => Ok(l
                 .max_cut
@@ -115,7 +115,7 @@ impl Prior<Address> {
     /// Returns the max cut for the command that is after this prior.
     pub fn next_max_cut(&self) -> Result<MaxCut, Bug> {
         Ok(match self {
-            Self::None => MaxCut(1),
+            Self::None => MaxCut::new(1),
             Self::Single(l) => l.max_cut.checked_add(1).assume("must not overflow")?,
             Self::Merge(l, r) => l
                 .max_cut

--- a/crates/aranya-runtime/src/policy.rs
+++ b/crates/aranya-runtime/src/policy.rs
@@ -36,10 +36,12 @@ impl From<core::convert::Infallible> for PolicyError {
 }
 
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
-pub struct PolicyId(usize);
+#[serde(transparent)]
+#[repr(transparent)]
+pub struct PolicyId(u64);
 
 impl PolicyId {
-    pub fn new(id: usize) -> Self {
+    pub fn new(id: u64) -> Self {
         Self(id)
     }
 }

--- a/crates/aranya-runtime/src/storage/linear/io.rs
+++ b/crates/aranya-runtime/src/storage/linear/io.rs
@@ -39,7 +39,7 @@ pub trait Write {
     /// A function is used to allow the item to contain its offset.
     fn append<F, T>(&mut self, builder: F) -> Result<T, StorageError>
     where
-        F: FnOnce(usize) -> T,
+        F: FnOnce(u64) -> T,
         T: Serialize;
 
     /// Set the commit head.
@@ -49,7 +49,7 @@ pub trait Write {
 /// A share-able reader for a linear storage graph.
 pub trait Read: Clone {
     /// Fetch an item written by `Write::append`.
-    fn fetch<T>(&self, offset: usize) -> Result<T, StorageError>
+    fn fetch<T>(&self, offset: u64) -> Result<T, StorageError>
     where
         T: DeserializeOwned;
 }

--- a/crates/aranya-runtime/src/storage/linear/libc/imp.rs
+++ b/crates/aranya-runtime/src/storage/linear/libc/imp.rs
@@ -237,7 +237,7 @@ impl Write for Writer {
 
     fn append<F, T>(&mut self, builder: F) -> Result<T, StorageError>
     where
-        F: FnOnce(usize) -> T,
+        F: FnOnce(u64) -> T,
         T: Serialize,
     {
         let offset = self.root.free_offset;
@@ -245,7 +245,7 @@ impl Write for Writer {
         let item = builder(
             offset
                 .try_into()
-                .assume("`free_offset` can be converted to `usize`")?,
+                .assume("`free_offset` can be converted to `u64`")?,
         );
         let new_offset = self.file.dump(offset, &item)?;
 
@@ -280,7 +280,7 @@ impl Root {
     fn new() -> Self {
         Self {
             generation: 0,
-            head: Location::new(SegmentIndex(usize::MAX), MaxCut(usize::MAX)),
+            head: Location::new(SegmentIndex::new(u64::MAX), MaxCut::new(u64::MAX)),
             free_offset: FREE_START,
             checksum: 0,
         }
@@ -289,8 +289,8 @@ impl Root {
     fn calc_checksum(&self) -> u64 {
         let mut hasher = aranya_crypto::dangerous::siphasher::sip::SipHasher::new();
         hasher.write_u64(self.generation);
-        hasher.write_u64(self.head.segment.0 as u64);
-        hasher.write_u64(self.head.max_cut.0 as u64);
+        hasher.write_u64(self.head.segment.get());
+        hasher.write_u64(self.head.max_cut.get());
         hasher.write_i64(self.free_offset);
         hasher.finish()
     }
@@ -311,7 +311,7 @@ pub struct Reader {
 }
 
 impl Read for Reader {
-    fn fetch<T>(&self, offset: usize) -> Result<T, StorageError>
+    fn fetch<T>(&self, offset: u64) -> Result<T, StorageError>
     where
         T: DeserializeOwned,
     {

--- a/crates/aranya-runtime/src/storage/linear/mod.rs
+++ b/crates/aranya-runtime/src/storage/linear/mod.rs
@@ -55,7 +55,7 @@ pub use io::*;
 /// 16 is our initial guess for balance.
 ///
 /// This must be at least 2.
-const MAX_FACT_INDEX_DEPTH: usize = 16;
+const MAX_FACT_INDEX_DEPTH: u64 = 16;
 
 pub struct LinearStorageProvider<FM: IoManager> {
     manager: FM,
@@ -80,7 +80,7 @@ struct SegmentRepr {
     parents: Prior<Address>,
     policy: PolicyId,
     /// Offset in file to associated fact index.
-    facts: usize,
+    facts: u64,
     commands: Vec1<CommandData>,
     max_cut: MaxCut,
     skip_list: Vec<Location>,
@@ -119,13 +119,13 @@ pub struct LinearFactIndex<R> {
 #[derive(Debug, Serialize, Deserialize)]
 struct FactIndexRepr {
     /// Self offset in file.
-    offset: usize,
+    offset: u64,
     /// Offset of prior fact index.
-    prior: Option<usize>,
+    prior: Option<u64>,
     /// Depth of this fact index.
     ///
     /// `prior.depth + 1`, or just `1` if no prior
-    depth: usize,
+    depth: u64,
     /// Facts in sorted order
     facts: NamedFactMap,
 }
@@ -183,7 +183,7 @@ impl<R> LinearFactPerspective<R> {
 enum FactPerspectivePrior<R> {
     None,
     FactPerspective(Box<LinearFactPerspective<R>>),
-    FactIndex { offset: usize, reader: R },
+    FactIndex { offset: u64, reader: R },
 }
 
 impl<R> FactPerspectivePrior<R> {
@@ -221,7 +221,7 @@ impl<FM: IoManager> StorageProvider for LinearStorageProvider<FM> {
             Prior::None,
             policy_id,
             FactPerspectivePrior::None,
-            MaxCut(0),
+            MaxCut::new(0),
             None,
         )
     }
@@ -333,13 +333,13 @@ impl<W: Write> LinearStorage<W> {
             .try_into()
             .map_err(|_| StorageError::EmptyPerspective)?;
         let segment = writer.append(|offset| SegmentRepr {
-            offset: SegmentIndex(offset),
+            offset: SegmentIndex::new(offset),
             prior: Prior::None,
             parents: Prior::None,
             policy: init.policy,
             facts,
             commands,
-            max_cut: MaxCut(0),
+            max_cut: MaxCut::new(0),
             skip_list: vec![],
         })?;
 
@@ -352,7 +352,7 @@ impl<W: Write> LinearStorage<W> {
                         .commands
                         .len()
                         .checked_sub(1)
-                        .assume("vec1 length >= 1")?,
+                        .assume("vec1 length >= 1")? as u64,
                 )
                 .assume("valid max cut")?,
         );
@@ -538,7 +538,7 @@ impl<F: Write> Storage for LinearStorage<F> {
 
     fn get_segment(&self, location: Location) -> Result<Self::Segment, StorageError> {
         let reader = self.writer.readonly();
-        let repr = reader.fetch(location.segment.0)?;
+        let repr = reader.fetch(location.segment.get())?;
         let seg = LinearSegment { repr, reader };
 
         Ok(seg)
@@ -577,8 +577,8 @@ impl<F: Write> Storage for LinearStorage<F> {
             let mut skips = vec![];
             for _ in 0..count {
                 let segment = self.get_segment(l)?;
-                if l.max_cut > MaxCut(0) {
-                    let max_cut = MaxCut(rng.gen_range(0..l.max_cut.0));
+                if l.max_cut > MaxCut::new(0) {
+                    let max_cut = MaxCut::new(rng.gen_range(0..l.max_cut.get()));
                     if let Some(skip) = self.get_skip(segment, max_cut)? {
                         if !skips.contains(&skip) {
                             skips.push(skip);
@@ -611,7 +611,7 @@ impl<F: Write> Storage for LinearStorage<F> {
             }
         };
         let repr = self.writer.append(|offset| SegmentRepr {
-            offset: SegmentIndex(offset),
+            offset: SegmentIndex::new(offset),
             prior: perspective.prior,
             parents: perspective.parents,
             policy: perspective.policy,
@@ -712,7 +712,7 @@ impl<R: Read> Segment for LinearSegment<R> {
         let cmd_idx = self.repr.cmd_index(location.max_cut).ok()?;
         let data = self.repr.commands.get(cmd_idx)?;
         let parent = if let Some(prev) = usize::checked_sub(cmd_idx, 1) {
-            if let Some(max_cut) = self.repr.max_cut.checked_add(prev) {
+            if let Some(max_cut) = self.repr.max_cut.checked_add(prev as u64) {
                 Prior::Single(Address {
                     id: self.repr.commands[prev].id,
                     max_cut,
@@ -757,7 +757,7 @@ impl<R: Read> Segment for LinearSegment<R> {
                     .commands
                     .len()
                     .checked_sub(1)
-                    .assume("must not overflow")?,
+                    .assume("must not overflow")? as u64,
             )
             .assume("must not overflow")?)
     }
@@ -767,6 +767,7 @@ impl SegmentRepr {
     fn cmd_index(&self, max_cut: MaxCut) -> Result<usize, StorageError> {
         max_cut
             .distance_from(self.max_cut)
+            .and_then(|x| usize::try_from(x).ok())
             .ok_or(StorageError::CommandOutOfBounds(Location::new(
                 self.offset,
                 max_cut,
@@ -1069,7 +1070,7 @@ impl<R: Read> Perspective for LinearPerspective<R> {
                         self.commands
                             .len()
                             .checked_sub(1)
-                            .assume("must not overflow")?,
+                            .assume("must not overflow")? as u64,
                     )
                     .assume("must not overflow")?,
             })

--- a/crates/aranya-runtime/src/storage/linear/testing.rs
+++ b/crates/aranya-runtime/src/storage/linear/testing.rs
@@ -79,10 +79,10 @@ impl io::Write for Writer {
 
     fn append<F, T>(&mut self, builder: F) -> Result<T, StorageError>
     where
-        F: FnOnce(usize) -> T,
+        F: FnOnce(u64) -> T,
         T: serde::Serialize,
     {
-        let offset = self.shared.items.lock().len();
+        let offset = self.shared.items.lock().len() as u64;
         let item = builder(offset);
         let bytes = postcard::to_allocvec(&item)
             .map_err(|_| StorageError::IoError)?
@@ -98,16 +98,17 @@ impl io::Write for Writer {
 }
 
 impl io::Read for Reader {
-    fn fetch<T>(&self, offset: usize) -> Result<T, StorageError>
+    fn fetch<T>(&self, offset: u64) -> Result<T, StorageError>
     where
         T: serde::de::DeserializeOwned,
     {
         let items = self.shared.items.lock();
-        let bytes = items
-            .get(offset)
+        let bytes = usize::try_from(offset)
+            .ok()
+            .and_then(|offset| items.get(offset))
             .ok_or(StorageError::SegmentOutOfBounds(Location::new(
-                SegmentIndex(offset),
-                MaxCut(usize::MAX), // Not right but this is just for testing...
+                SegmentIndex::new(offset),
+                MaxCut::new(u64::MAX), // Not right but this is just for testing...
             )))?;
         postcard::from_bytes(bytes).map_err(|_| StorageError::IoError)
     }

--- a/crates/aranya-runtime/src/storage/mod.rs
+++ b/crates/aranya-runtime/src/storage/mod.rs
@@ -292,8 +292,9 @@ aranya_crypto::custom_id! {
 }
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
 #[repr(transparent)]
-pub struct SegmentIndex(pub usize);
+pub struct SegmentIndex(u64);
 
 impl fmt::Display for SegmentIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -301,9 +302,20 @@ impl fmt::Display for SegmentIndex {
     }
 }
 
+impl SegmentIndex {
+    pub fn new(val: u64) -> Self {
+        Self(val)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
 #[repr(transparent)]
-pub struct MaxCut(pub usize);
+pub struct MaxCut(u64);
 
 impl fmt::Display for MaxCut {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -312,22 +324,30 @@ impl fmt::Display for MaxCut {
 }
 
 impl MaxCut {
+    pub fn new(val: u64) -> Self {
+        Self(val)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
     /// Adds an amount to the max cut, returning `None` on overflow.
     #[must_use]
-    pub fn checked_add(self, other: usize) -> Option<Self> {
-        self.0.checked_add(other).map(Self)
+    pub fn checked_add(self, other: u64) -> Option<Self> {
+        self.get().checked_add(other).map(Self::new)
     }
 
     /// Gets a max cut one lower than this, returning `None` on overflow.
     #[must_use]
     pub fn decremented(self) -> Option<Self> {
-        self.0.checked_sub(1).map(Self)
+        self.get().checked_sub(1).map(Self::new)
     }
 
     /// Gets the distance between two max cuts, returning `None` on overflow.
     #[must_use]
-    pub fn distance_from(self, other: Self) -> Option<usize> {
-        self.0.checked_sub(other.0)
+    pub fn distance_from(self, other: Self) -> Option<u64> {
+        self.get().checked_sub(other.get())
     }
 }
 
@@ -954,7 +974,7 @@ mod queue_tests {
     use super::*;
 
     fn loc(seg: usize, mc: usize) -> Location {
-        Location::new(SegmentIndex(seg), MaxCut(mc))
+        Location::new(SegmentIndex::new(seg as u64), MaxCut::new(mc as u64))
     }
 
     #[test]
@@ -1012,7 +1032,7 @@ mod queue_tests {
         queue.push(loc(0, 5)).unwrap();
         queue.push(loc(0, 8)).unwrap();
         let l = queue.pop().unwrap().unwrap();
-        assert_eq!(l.max_cut, MaxCut(8));
+        assert_eq!(l.max_cut, MaxCut::new(8));
         assert!(queue.is_empty());
     }
 
@@ -1023,7 +1043,7 @@ mod queue_tests {
         // Higher max_cut uncovered: segment head moved beyond covered point.
         queue.push_covered(loc(0, 8), false).unwrap();
         let (l, covered) = queue.pop_covered().unwrap().unwrap();
-        assert_eq!(l.max_cut, MaxCut(8));
+        assert_eq!(l.max_cut, MaxCut::new(8));
         assert!(!covered);
     }
 
@@ -1034,7 +1054,7 @@ mod queue_tests {
         // Lower max_cut should not change anything.
         queue.push_covered(loc(0, 3), true).unwrap();
         let (l, covered) = queue.pop_covered().unwrap().unwrap();
-        assert_eq!(l.max_cut, MaxCut(8));
+        assert_eq!(l.max_cut, MaxCut::new(8));
         assert!(!covered);
     }
 
@@ -1044,7 +1064,7 @@ mod queue_tests {
         queue.push_covered(loc(0, 5), true).unwrap();
         // pop() should return only the location.
         let l = queue.pop().unwrap().unwrap();
-        assert_eq!(l.max_cut, MaxCut(5));
+        assert_eq!(l.max_cut, MaxCut::new(5));
         assert!(queue.is_empty());
     }
 
@@ -1068,19 +1088,19 @@ mod queue_tests {
 
         let mut result: heapless::Vec<Location, 8> = heapless::Vec::new();
         queue
-            .drain_above(MaxCut(4), |loc| {
+            .drain_above(MaxCut::new(4), |loc| {
                 let _ = result.push(loc);
             })
             .unwrap();
 
         // Entries with max_cut > 4 should be drained.
         assert_eq!(result.len(), 2);
-        assert!(result.iter().any(|l| l.max_cut == MaxCut(7)));
-        assert!(result.iter().any(|l| l.max_cut == MaxCut(5)));
+        assert!(result.iter().any(|l| l.max_cut == MaxCut::new(7)));
+        assert!(result.iter().any(|l| l.max_cut == MaxCut::new(5)));
 
         // Only max_cut=3 should remain in the queue.
         let remaining = queue.pop().unwrap().unwrap();
-        assert_eq!(remaining.max_cut, MaxCut(3));
+        assert_eq!(remaining.max_cut, MaxCut::new(3));
         assert!(queue.is_empty());
     }
 
@@ -1096,15 +1116,15 @@ mod queue_tests {
 
         let mut drained: heapless::Vec<Location, 8> = heapless::Vec::new();
         queue
-            .drain_above(MaxCut(4), |loc| {
+            .drain_above(MaxCut::new(4), |loc| {
                 let _ = drained.push(loc);
             })
             .unwrap();
 
         // Only uncovered entries above threshold should be passed to f.
         assert_eq!(drained.len(), 2);
-        assert!(drained.iter().any(|l| l.segment == SegmentIndex(1)));
-        assert!(drained.iter().any(|l| l.segment == SegmentIndex(4)));
+        assert!(drained.iter().any(|l| l.segment.get() == 1));
+        assert!(drained.iter().any(|l| l.segment.get() == 4));
 
         // Covered entry above threshold (seg=2) should be discarded.
         // Entries below threshold should remain: seg=0 (uncovered), seg=3 (covered).
@@ -1113,7 +1133,7 @@ mod queue_tests {
             remaining.push((l.segment, covered));
         }
         assert_eq!(remaining.len(), 2);
-        assert!(remaining.contains(&(SegmentIndex(0), false)));
-        assert!(remaining.contains(&(SegmentIndex(3), true)));
+        assert!(remaining.contains(&(SegmentIndex::new(0), false)));
+        assert!(remaining.contains(&(SegmentIndex::new(3), true)));
     }
 }

--- a/crates/aranya-runtime/src/testing/protocol.rs
+++ b/crates/aranya-runtime/src/testing/protocol.rs
@@ -102,7 +102,7 @@ impl PolicyStore for TestPolicyStore {
     type Effect = TestEffect;
 
     fn add_policy(&mut self, policy: &[u8]) -> Result<PolicyId, PolicyError> {
-        Ok(PolicyId::new(policy[0] as usize))
+        Ok(PolicyId::new(policy[0].into()))
     }
 
     fn get_policy(&self, _id: PolicyId) -> Result<&Self::Policy, PolicyError> {
@@ -307,7 +307,7 @@ impl Policy for TestPolicy {
         let parent = match facts.head_address()? {
             Prior::None => Address {
                 id: CmdId::default(),
-                max_cut: MaxCut(0),
+                max_cut: MaxCut::new(0),
             },
             Prior::Single(id) => id,
             Prior::Merge(_, _) => bug!("cannot get merge command in call_action"),

--- a/crates/aranya-runtime/src/testing/vm.rs
+++ b/crates/aranya-runtime/src/testing/vm.rs
@@ -328,7 +328,7 @@ impl PolicyStore for TestPolicyStore {
     type Effect = VmEffect;
 
     fn add_policy(&mut self, policy: &[u8]) -> Result<PolicyId, PolicyError> {
-        Ok(PolicyId::new(policy[0] as usize))
+        Ok(PolicyId::new(policy[0].into()))
     }
 
     fn get_policy(&self, _id: PolicyId) -> Result<&Self::Policy, PolicyError> {


### PR DESCRIPTION
Makes `SegmentIndex`, `MaxCut`, and `PolicyId` opaque wrappers of `u64`.

This will allow them to be `u64_le` wrappers later so they can implement `rkyv::Portable` and thus archive as themselves.