### PR TITLE
runtime: make error enums nonexhaustive

### DIFF
--- a/crates/aranya-runtime/src/client.rs
+++ b/crates/aranya-runtime/src/client.rs
@@ -17,6 +17,7 @@ pub use self::{session::Session, transaction::Transaction};
 
 /// An error returned by the runtime client.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ClientError {
     #[error("no such parent: {0}")]
     NoSuchParent(CmdId),

--- a/crates/aranya-runtime/src/client/transaction.rs
+++ b/crates/aranya-runtime/src/client/transaction.rs
@@ -434,7 +434,7 @@ fn make_braid_segment<S: Storage, PS: PolicyStore>(
 
         // If the command failed in an uncontrolled way, rollback
         if let Err(e) = result
-            && e != PolicyError::Check
+            && !matches!(e, PolicyError::Check)
         {
             sink.rollback();
             return Err(e.into());

--- a/crates/aranya-runtime/src/policy.rs
+++ b/crates/aranya-runtime/src/policy.rs
@@ -13,7 +13,8 @@ use crate::{
 };
 
 /// An error returned by a runtime policy store or policy.
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum PolicyError {
     #[error("read error")]
     Read,

--- a/crates/aranya-runtime/src/storage/mod.rs
+++ b/crates/aranya-runtime/src/storage/mod.rs
@@ -390,7 +390,9 @@ impl LocatedAddress {
 }
 
 /// An error returned by [`Storage`] or [`StorageProvider`].
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[non_exhaustive]
 pub enum StorageError {
     #[error("storage already exists")]
     StorageExists,

--- a/crates/aranya-runtime/src/sync/mod.rs
+++ b/crates/aranya-runtime/src/sync/mod.rs
@@ -64,6 +64,7 @@ pub const MAX_SYNC_MESSAGE_SIZE: usize = 1024 + MAX_COMMAND_LENGTH * COMMAND_RES
 
 /// An error returned by the syncer.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum SyncError {
     #[error("sync session ID does not match")]
     SessionMismatch,

--- a/crates/aranya-runtime/src/vm_policy/error.rs
+++ b/crates/aranya-runtime/src/vm_policy/error.rs
@@ -2,8 +2,9 @@ use alloc::{format, string::String};
 
 use crate::{policy::PolicyError, storage::StorageError};
 
-#[derive(Debug, thiserror::Error)]
 /// Errors that can occur because of creation or use of VmPolicy.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum VmPolicyError {
     /// An error happened while deserializing a command struct. Stores an interior
     /// [postcard::Error].


### PR DESCRIPTION
This lets us add variants without a breaking change.

I also removed `PartialEq + Eq` impls since they aren't really necessary and can make it harder to add in certain types as fields in the error.