### PR TITLE
runtime: rkyv support changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,8 @@ dependencies = [
  "heapless",
  "postcard",
  "proptest",
+ "rend",
+ "rkyv",
  "serde",
  "serde_json",
  "spideroak-base58",
@@ -2061,6 +2063,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
 dependencies = [
  "bytecheck",
+ "zerocopy 0.8.25",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]

--- a/crates/aranya-runtime/Cargo.toml
+++ b/crates/aranya-runtime/Cargo.toml
@@ -20,6 +20,8 @@ aranya-policy-vm = { version = "0.22.0", path = "../aranya-policy-vm" }
 
 heapless = { workspace = true, features = ["serde"] }
 postcard = { workspace = true, features = ["alloc"] }
+rend = { version = "0.5", default-features = false, features = ["zerocopy-0_8"] }
+rkyv = { workspace = true }
 serde = { workspace = true, default-features = false, features = ["derive", "alloc"] }
 spideroak-base58 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/aranya-runtime/src/client/session.rs
+++ b/crates/aranya-runtime/src/client/session.rs
@@ -5,7 +5,6 @@
 //! Design doc: [Aranya Sessions](https://github.com/aranya-project/aranya-docs/blob/main/src/Aranya-Sessions-note.md)
 
 use alloc::{
-    boxed::Box,
     collections::{BTreeMap, btree_map},
     string::String,
     sync::Arc,
@@ -17,13 +16,11 @@ use buggy::{Bug, bug};
 use yoke::{Yoke, Yokeable};
 
 use crate::{
-    Address, Checkpoint, ClientError, ClientState, CmdId, Command, Fact, FactPerspective, GraphId,
-    Keys, MaxCut, NullSink, Perspective, Policy, PolicyId, PolicyStore, Prior, Priority, Query,
-    QueryMut, Revertable, Segment as _, Sink, Storage, StorageError, StorageProvider,
+    Address, Bytes, Checkpoint, ClientError, ClientState, CmdId, Command, Fact, FactPerspective,
+    GraphId, Keys, MaxCut, NullSink, Perspective, Policy, PolicyId, PolicyStore, Prior, Priority,
+    Query, QueryMut, Revertable, Segment as _, Sink, Storage, StorageError, StorageProvider,
     policy::{ActionPlacement, CommandPlacement},
 };
-
-type Bytes = Box<[u8]>;
 
 /// Ephemeral session used to handle/generate off-graph commands.
 pub struct Session<SP: StorageProvider, PS> {
@@ -302,7 +299,7 @@ impl<SP, PS, MS> Query for SessionPerspective<'_, SP, PS, MS>
 where
     SP: StorageProvider,
 {
-    fn query(&self, name: &str, keys: &[Box<[u8]>]) -> Result<Option<Box<[u8]>>, StorageError> {
+    fn query(&self, name: &str, keys: &[Bytes]) -> Result<Option<Bytes>, StorageError> {
         if let Some(slot) = self
             .session
             .current_facts
@@ -321,7 +318,7 @@ where
     fn query_prefix(
         &self,
         name: &str,
-        prefix: &[Box<[u8]>],
+        prefix: &[Bytes],
     ) -> Result<Self::QueryIterator, StorageError> {
         let prior = self.session.base_facts.query_prefix(name, prefix)?;
         let current = Yoke::<PrefixIter<'static>, _>::attach_to_cart(
@@ -347,8 +344,7 @@ struct PrefixIter<'map> {
 
 impl<'map> PrefixIter<'map> {
     fn new(map: &'map BTreeMap<Keys, Option<Bytes>>, prefix: Keys) -> Self {
-        let range =
-            map.range::<[Box<[u8]>], _>((Bound::Included(prefix.as_ref()), Bound::Unbounded));
+        let range = map.range::<[Bytes], _>((Bound::Included(prefix.as_ref()), Bound::Unbounded));
         Self { range, prefix }
     }
 }
@@ -393,7 +389,7 @@ where
 }
 
 impl<SP: StorageProvider, PS, MS> QueryMut for SessionPerspective<'_, SP, PS, MS> {
-    fn insert(&mut self, name: String, keys: Keys, value: Box<[u8]>) {
+    fn insert(&mut self, name: String, keys: Keys, value: Bytes) -> Result<(), StorageError> {
         self.session
             .fact_log
             .push((name.clone(), keys.clone(), Some(value.clone())));
@@ -401,9 +397,10 @@ impl<SP: StorageProvider, PS, MS> QueryMut for SessionPerspective<'_, SP, PS, MS
             .entry(name)
             .or_default()
             .insert(keys, Some(value));
+        Ok(())
     }
 
-    fn delete(&mut self, name: String, keys: Keys) {
+    fn delete(&mut self, name: String, keys: Keys) -> Result<(), StorageError> {
         self.session
             .fact_log
             .push((name.clone(), keys.clone(), None));
@@ -411,6 +408,7 @@ impl<SP: StorageProvider, PS, MS> QueryMut for SessionPerspective<'_, SP, PS, MS
             .entry(name)
             .or_default()
             .insert(keys, None);
+        Ok(())
     }
 }
 
@@ -451,7 +449,7 @@ where
         }
     }
 
-    fn revert(&mut self, checkpoint: Checkpoint) -> Result<(), Bug> {
+    fn revert(&mut self, checkpoint: Checkpoint) -> Result<(), StorageError> {
         if checkpoint.index == self.session.fact_log.len() {
             return Ok(());
         }
@@ -491,11 +489,11 @@ mod test {
             Ok((&[b"f"], b"f0")),
             Err(StorageError::IoError),
         ];
-        let current: Vec<([Box<[u8]>; 1], Option<&[u8]>)> = vec![
-            ([Box::new(*b"a")], None),
-            ([Box::new(*b"b")], Some(b"b1")),
-            ([Box::new(*b"e")], None),
-            ([Box::new(*b"j")], None),
+        let current: Vec<([Bytes; 1], Option<&[u8]>)> = vec![
+            ([Bytes::from(*b"a")], None),
+            ([Bytes::from(*b"b")], Some(b"b1")),
+            ([Bytes::from(*b"e")], None),
+            ([Bytes::from(*b"j")], None),
         ];
         let merged: Vec<Result<(&[&[u8]], &[u8]), _>> = vec![
             Ok((&[b"b"], b"b1")),
@@ -514,7 +512,7 @@ mod test {
             }),
             current
                 .into_iter()
-                .map(|(k, v)| (k.into_iter().collect(), v.map(Box::from))),
+                .map(|(k, v)| (k.into_iter().collect(), v.map(Bytes::from))),
         )
         .collect();
         let want: Vec<_> = merged

--- a/crates/aranya-runtime/src/client/transaction.rs
+++ b/crates/aranya-runtime/src/client/transaction.rs
@@ -554,7 +554,7 @@ mod test {
 
     use super::*;
     use crate::{
-        ClientState, Keys, MaxCut, MemSpill, MergeIds, Perspective, Policy, Priority,
+        Bytes, ClientState, Keys, MaxCut, MemSpill, MergeIds, Perspective, Policy, Priority,
         policy::{ActionPlacement, CommandPlacement},
         storage::linear::testing::MemStorageProvider,
         testing::{hash_for_testing_only, short_b58},
@@ -617,13 +617,17 @@ mod test {
                 .assume("can query")?
                 .as_deref()
             {
-                facts.insert(
-                    "seq".into(),
-                    Keys::default(),
-                    [seq, b":", data].concat().into(),
-                );
+                facts
+                    .insert(
+                        "seq".into(),
+                        Keys::default(),
+                        [seq, b":", data].concat().into(),
+                    )
+                    .unwrap();
             } else {
-                facts.insert("seq".into(), Keys::default(), data.into());
+                facts
+                    .insert("seq".into(), Keys::default(), data.into())
+                    .unwrap();
             }
             Ok(())
         }
@@ -921,7 +925,7 @@ mod test {
         };
     }
 
-    fn lookup(storage: &impl Storage, name: &str) -> Option<Box<[u8]>> {
+    fn lookup(storage: &impl Storage, name: &str) -> Option<Bytes> {
         use crate::Query as _;
         let head = storage.get_head().unwrap();
         let p = storage.get_fact_perspective(head).unwrap();

--- a/crates/aranya-runtime/src/command.rs
+++ b/crates/aranya-runtime/src/command.rs
@@ -1,12 +1,23 @@
 pub use aranya_crypto::policy::CmdId;
 use buggy::{Bug, BugExt as _};
-use serde::{Deserialize, Serialize};
 
 use crate::{MaxCut, Prior};
 
 /// Identify how the client will sort the associated [`Command`].
 // Note: Order of variants affects derived Ord: Merge is least and Init is greatest.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
 pub enum Priority {
     /// Indicates two branches in the parent graph have been merged at this
     /// command. A command with this priority must have two parents,
@@ -100,12 +111,30 @@ impl<C: Command> Command for &C {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, Ord, PartialEq, PartialOrd, Eq)]
 /// An address contains all of the information needed to find a command in
 /// another graph.
 ///
 /// The command id identifies the command you're searching for and the
 /// max_cut allows that command to be found efficiently.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    rkyv::Portable,
+    rkyv::bytecheck::CheckBytes,
+)]
+#[rkyv(as = Self)]
+#[bytecheck(crate = rkyv::bytecheck)]
+#[repr(C)]
 pub struct Address {
     pub id: CmdId,
     pub max_cut: MaxCut,

--- a/crates/aranya-runtime/src/lib.rs
+++ b/crates/aranya-runtime/src/lib.rs
@@ -51,6 +51,7 @@ mod prior;
 pub mod storage;
 pub mod sync;
 pub mod testing;
+pub(crate) mod util;
 pub mod vm_policy;
 
 pub use crate::{

--- a/crates/aranya-runtime/src/policy.rs
+++ b/crates/aranya-runtime/src/policy.rs
@@ -4,7 +4,7 @@
 //! to process [`Command`]s and defines how the runtime's graph is constructed.
 
 use buggy::Bug;
-use serde::{Deserialize, Serialize};
+use rkyv::rend::u64_le;
 
 use crate::{
     Address,
@@ -36,14 +36,31 @@ impl From<core::convert::Infallible> for PolicyError {
     }
 }
 
-#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Ord,
+    PartialOrd,
+    Eq,
+    PartialEq,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    rkyv::Portable,
+    rkyv::bytecheck::CheckBytes,
+)]
+#[rkyv(as = Self)]
+#[bytecheck(crate = rkyv::bytecheck)]
 #[serde(transparent)]
 #[repr(transparent)]
-pub struct PolicyId(u64);
+pub struct PolicyId(#[serde(with = "crate::util::u64_le_serde")] u64_le);
 
 impl PolicyId {
     pub fn new(id: u64) -> Self {
-        Self(id)
+        Self(id.into())
     }
 }
 

--- a/crates/aranya-runtime/src/policy.rs
+++ b/crates/aranya-runtime/src/policy.rs
@@ -4,7 +4,7 @@
 //! to process [`Command`]s and defines how the runtime's graph is constructed.
 
 use buggy::Bug;
-use rkyv::rend::u64_le;
+use rend::u64_le;
 
 use crate::{
     Address,

--- a/crates/aranya-runtime/src/prior.rs
+++ b/crates/aranya-runtime/src/prior.rs
@@ -1,7 +1,23 @@
-use serde::{Deserialize, Serialize};
-
 /// Refer to immediately prior commands in a graph, usually via `Prior<CmdId>` or `Prior<Location>`.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    rkyv::Portable,
+    rkyv::bytecheck::CheckBytes,
+)]
+#[rkyv(as = Prior<T::Archived>)]
+#[bytecheck(crate = rkyv::bytecheck)]
+#[repr(u8)]
 pub enum Prior<T> {
     /// No parents (init command)
     None,

--- a/crates/aranya-runtime/src/storage/linear/mod.rs
+++ b/crates/aranya-runtime/src/storage/linear/mod.rs
@@ -1165,12 +1165,6 @@ mod test {
                 assert_eq!(a.value.as_ref(), format!("{b:?}").as_bytes());
             }
         }
-
-        {
-            let prefix = &["bc", "", ""];
-            let prefix: Keys = prefix.iter().map(|k| Bytes::from(k.as_bytes())).collect();
-            assert!(fp.query_prefix(name, &prefix).is_err());
-        }
     }
 
     struct LinearBackend;

--- a/crates/aranya-runtime/src/storage/linear/mod.rs
+++ b/crates/aranya-runtime/src/storage/linear/mod.rs
@@ -36,8 +36,8 @@ use serde::{Deserialize, Serialize};
 use vec1::Vec1;
 
 use crate::{
-    Address, Checkpoint, CmdId, Command, Fact, FactIndex, FactPerspective, GraphId, Keys, Location,
-    MaxCut, Perspective, PolicyId, Prior, Priority, Query, QueryMut, Revertable, Segment,
+    Address, Bytes, Checkpoint, CmdId, Command, Fact, FactIndex, FactPerspective, GraphId, Keys,
+    Location, MaxCut, Perspective, PolicyId, Prior, Priority, Query, QueryMut, Revertable, Segment,
     SegmentIndex, Storage, StorageError, StorageProvider, TraversalBuffer,
 };
 
@@ -103,8 +103,6 @@ pub struct LinearCommand<'a> {
     data: &'a [u8],
     max_cut: MaxCut,
 }
-
-type Bytes = Box<[u8]>;
 
 type Update = (String, Keys, Option<Bytes>);
 type FactMap = BTreeMap<Keys, Option<Box<[u8]>>>;
@@ -424,7 +422,7 @@ impl<F: Write> Storage for LinearStorage<F> {
             };
             let mut facts = LinearFactPerspective::new(prior);
             for data in &segment.repr.commands[..=segment.repr.cmd_index(parent.max_cut)?] {
-                facts.apply_updates(&data.updates);
+                facts.apply_updates(&data.updates)?;
             }
             if facts.prior.is_none() {
                 facts.map.retain(|_, kv| !kv.is_empty());
@@ -484,7 +482,7 @@ impl<F: Write> Storage for LinearStorage<F> {
         };
         let mut facts = LinearFactPerspective::new(prior);
         for data in &segment.repr.commands[..=segment.repr.cmd_index(location.max_cut)?] {
-            facts.apply_updates(&data.updates);
+            facts.apply_updates(&data.updates)?;
         }
 
         Ok(facts)
@@ -822,7 +820,7 @@ impl Iterator for QueryIterator {
 }
 
 impl<R: Read> Query for LinearFactIndex<R> {
-    fn query(&self, name: &str, keys: &[Box<[u8]>]) -> Result<Option<Box<[u8]>>, StorageError> {
+    fn query(&self, name: &str, keys: &[Bytes]) -> Result<Option<Bytes>, StorageError> {
         let mut prior = Some(&self.repr);
         let mut slot; // Need to store deserialized value.
         while let Some(facts) = prior {
@@ -836,11 +834,7 @@ impl<R: Read> Query for LinearFactIndex<R> {
     }
 
     type QueryIterator = QueryIterator;
-    fn query_prefix(
-        &self,
-        name: &str,
-        prefix: &[Box<[u8]>],
-    ) -> Result<QueryIterator, StorageError> {
+    fn query_prefix(&self, name: &str, prefix: &[Bytes]) -> Result<QueryIterator, StorageError> {
         Ok(QueryIterator::new(
             self.query_prefix_inner(name, prefix)?.into_iter(),
         ))
@@ -848,11 +842,7 @@ impl<R: Read> Query for LinearFactIndex<R> {
 }
 
 impl<R: Read> LinearFactIndex<R> {
-    fn query_prefix_inner(
-        &self,
-        name: &str,
-        prefix: &[Box<[u8]>],
-    ) -> Result<FactMap, StorageError> {
+    fn query_prefix_inner(&self, name: &str, prefix: &[Bytes]) -> Result<FactMap, StorageError> {
         let mut matches = BTreeMap::new();
         let mut prior = Some(&self.repr);
         let mut slot; // Need to store deserialized value.
@@ -877,33 +867,34 @@ impl<R> LinearFactPerspective<R> {
         self.map.clear();
     }
 
-    fn apply_updates(&mut self, updates: &[Update]) {
-        for (name, key, value) in updates {
+    fn apply_updates(&mut self, updates: &[Update]) -> Result<(), StorageError> {
+        for (name, keys, value) in updates {
             if self.prior.is_none() {
                 if let Some(value) = value {
                     self.map
                         .entry(name.clone())
                         .or_default()
-                        .insert(key.clone(), Some(value.clone()));
+                        .insert(keys.clone(), Some(value.clone()));
                 } else if let Some(e) = self.map.get_mut(name) {
-                    e.remove(key);
+                    e.remove(keys);
                 }
             } else {
                 self.map
                     .entry(name.clone())
                     .or_default()
-                    .insert(key.clone(), value.clone());
+                    .insert(keys.clone(), value.clone());
             }
         }
+        Ok(())
     }
 }
 
 impl<R: Read> FactPerspective for LinearFactPerspective<R> {}
 
 impl<R: Read> Query for LinearFactPerspective<R> {
-    fn query(&self, name: &str, keys: &[Box<[u8]>]) -> Result<Option<Box<[u8]>>, StorageError> {
+    fn query(&self, name: &str, keys: &[Bytes]) -> Result<Option<Bytes>, StorageError> {
         if let Some(wrapped) = self.map.get(name).and_then(|m| m.get(keys)) {
-            return Ok(wrapped.as_deref().map(Box::from));
+            return Ok(wrapped.as_deref().map(Bytes::from));
         }
         match &self.prior {
             FactPerspectivePrior::None => Ok(None),
@@ -920,11 +911,7 @@ impl<R: Read> Query for LinearFactPerspective<R> {
     }
 
     type QueryIterator = QueryIterator;
-    fn query_prefix(
-        &self,
-        name: &str,
-        prefix: &[Box<[u8]>],
-    ) -> Result<QueryIterator, StorageError> {
+    fn query_prefix(&self, name: &str, prefix: &[Bytes]) -> Result<QueryIterator, StorageError> {
         Ok(QueryIterator::new(
             self.query_prefix_inner(name, prefix)?.into_iter(),
         ))
@@ -932,11 +919,7 @@ impl<R: Read> Query for LinearFactPerspective<R> {
 }
 
 impl<R: Read> LinearFactPerspective<R> {
-    fn query_prefix_inner(
-        &self,
-        name: &str,
-        prefix: &[Box<[u8]>],
-    ) -> Result<FactMap, StorageError> {
+    fn query_prefix_inner(&self, name: &str, prefix: &[Bytes]) -> Result<FactMap, StorageError> {
         let mut matches = match &self.prior {
             FactPerspectivePrior::None => BTreeMap::new(),
             FactPerspectivePrior::FactPerspective(prior) => {
@@ -962,11 +945,12 @@ impl<R: Read> LinearFactPerspective<R> {
 }
 
 impl<R: Read> QueryMut for LinearFactPerspective<R> {
-    fn insert(&mut self, name: String, keys: Keys, value: Bytes) {
+    fn insert(&mut self, name: String, keys: Keys, value: Bytes) -> Result<(), StorageError> {
         self.map.entry(name).or_default().insert(keys, Some(value));
+        Ok(())
     }
 
-    fn delete(&mut self, name: String, keys: Keys) {
+    fn delete(&mut self, name: String, keys: Keys) -> Result<(), StorageError> {
         if self.prior.is_none() {
             // No need for tombstones with no prior.
             if let Some(kv) = self.map.get_mut(&name) {
@@ -975,35 +959,35 @@ impl<R: Read> QueryMut for LinearFactPerspective<R> {
         } else {
             self.map.entry(name).or_default().insert(keys, None);
         }
+        Ok(())
     }
 }
 
 impl<R: Read> FactPerspective for LinearPerspective<R> {}
 
 impl<R: Read> Query for LinearPerspective<R> {
-    fn query(&self, name: &str, keys: &[Box<[u8]>]) -> Result<Option<Box<[u8]>>, StorageError> {
+    fn query(&self, name: &str, keys: &[Bytes]) -> Result<Option<Bytes>, StorageError> {
         self.facts.query(name, keys)
     }
 
     type QueryIterator = QueryIterator;
-    fn query_prefix(
-        &self,
-        name: &str,
-        prefix: &[Box<[u8]>],
-    ) -> Result<QueryIterator, StorageError> {
+    fn query_prefix(&self, name: &str, prefix: &[Bytes]) -> Result<QueryIterator, StorageError> {
         self.facts.query_prefix(name, prefix)
     }
 }
 
 impl<R: Read> QueryMut for LinearPerspective<R> {
-    fn insert(&mut self, name: String, keys: Keys, value: Bytes) {
-        self.facts.insert(name.clone(), keys.clone(), value.clone());
+    fn insert(&mut self, name: String, keys: Keys, value: Bytes) -> Result<(), StorageError> {
+        self.facts
+            .insert(name.clone(), keys.clone(), value.clone())?;
         self.current_updates.push((name, keys, Some(value)));
+        Ok(())
     }
 
-    fn delete(&mut self, name: String, keys: Keys) {
-        self.facts.delete(name.clone(), keys.clone());
+    fn delete(&mut self, name: String, keys: Keys) -> Result<(), StorageError> {
+        self.facts.delete(name.clone(), keys.clone())?;
         self.current_updates.push((name, keys, None));
+        Ok(())
     }
 }
 
@@ -1014,7 +998,7 @@ impl<R: Read> Revertable for LinearPerspective<R> {
         }
     }
 
-    fn revert(&mut self, checkpoint: Checkpoint) -> Result<(), Bug> {
+    fn revert(&mut self, checkpoint: Checkpoint) -> Result<(), StorageError> {
         if checkpoint.index == self.commands.len() {
             return Ok(());
         }
@@ -1029,7 +1013,7 @@ impl<R: Read> Revertable for LinearPerspective<R> {
         self.facts.clear();
         self.current_updates.clear();
         for data in &self.commands {
-            self.facts.apply_updates(&data.updates);
+            self.facts.apply_updates(&data.updates)?;
         }
 
         Ok(())
@@ -1049,7 +1033,7 @@ impl<R: Read> Perspective for LinearPerspective<R> {
         self.commands.push(CommandData {
             id: command.id(),
             priority: command.priority(),
-            policy: command.policy().map(Box::from),
+            policy: command.policy().map(Bytes::from),
             data: command.bytes().into(),
             updates: core::mem::take(&mut self.current_updates),
         });
@@ -1118,9 +1102,9 @@ impl Command for LinearCommand<'_> {
 
 fn find_prefixes<'m, 'p: 'm>(
     map: &'m FactMap,
-    prefix: &'p [Box<[u8]>],
+    prefix: &'p [Bytes],
 ) -> impl Iterator<Item = (&'m Keys, Option<&'m [u8]>)> + 'm {
-    map.range::<[Box<[u8]>], _>((Bound::Included(prefix), Bound::Unbounded))
+    map.range::<[Bytes], _>((Bound::Included(prefix), Bound::Unbounded))
         .take_while(|(k, _)| k.starts_with(prefix))
         .map(|(k, v)| (k, v.as_deref()))
 }
@@ -1147,7 +1131,7 @@ mod test {
         ];
         let keys: Vec<Keys> = keys
             .iter()
-            .map(|ks| ks.iter().map(|k| k.as_bytes()).collect())
+            .map(|ks| ks.iter().map(|k| Bytes::from(k.as_bytes())).collect())
             .collect();
 
         for ks in &keys {
@@ -1155,7 +1139,8 @@ mod test {
                 name.into(),
                 ks.clone(),
                 format!("{ks:?}").into_bytes().into(),
-            );
+            )
+            .unwrap();
         }
 
         let prefixes: &[&[&str]] = &[
@@ -1166,11 +1151,10 @@ mod test {
             &["bb", ""],
             &["bb", "ccc"],
             &["bc", ""],
-            &["bc", "", ""],
         ];
 
         for prefix in prefixes {
-            let prefix: Keys = prefix.iter().map(|k| k.as_bytes()).collect();
+            let prefix: Keys = prefix.iter().map(|k| Bytes::from(k.as_bytes())).collect();
             let found: Vec<_> = fp.query_prefix(name, &prefix).unwrap().collect();
             let mut expected: Vec<_> = keys.iter().filter(|k| k.starts_with(&prefix)).collect();
             expected.sort();
@@ -1180,6 +1164,12 @@ mod test {
                 assert_eq!(&a.key, b);
                 assert_eq!(a.value.as_ref(), format!("{b:?}").as_bytes());
             }
+        }
+
+        {
+            let prefix = &["bc", "", ""];
+            let prefix: Keys = prefix.iter().map(|k| Bytes::from(k.as_bytes())).collect();
+            assert!(fp.query_prefix(name, &prefix).is_err());
         }
     }
 

--- a/crates/aranya-runtime/src/storage/mod.rs
+++ b/crates/aranya-runtime/src/storage/mod.rs
@@ -9,7 +9,7 @@ use alloc::{boxed::Box, string::String, vec::Vec};
 use core::{borrow::Borrow, fmt, ops::Deref};
 
 use buggy::{Bug, BugExt as _};
-use rkyv::rend::u64_le;
+use rend::u64_le;
 
 use crate::{Address, CmdId, Command, PolicyId, Prior};
 

--- a/crates/aranya-runtime/src/storage/mod.rs
+++ b/crates/aranya-runtime/src/storage/mod.rs
@@ -6,11 +6,10 @@
 //! [`Perspective`]s, which represent a slice of state.
 
 use alloc::{boxed::Box, string::String, vec::Vec};
-use core::{fmt, ops::Deref};
+use core::{borrow::Borrow, fmt, ops::Deref};
 
 use buggy::{Bug, BugExt as _};
-use serde::{Deserialize, Serialize};
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use rkyv::rend::u64_le;
 
 use crate::{Address, CmdId, Command, PolicyId, Prior};
 
@@ -385,16 +384,23 @@ aranya_crypto::custom_id! {
     Eq,
     PartialOrd,
     Ord,
-    Serialize,
-    Deserialize,
-    IntoBytes,
-    FromBytes,
-    Immutable,
-    KnownLayout,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    rkyv::Portable,
+    rkyv::bytecheck::CheckBytes,
+    zerocopy::IntoBytes,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::KnownLayout,
 )]
+#[rkyv(as = Self)]
+#[bytecheck(crate = rkyv::bytecheck)]
 #[serde(transparent)]
 #[repr(transparent)]
-pub struct SegmentIndex(u64);
+pub struct SegmentIndex(#[serde(with = "crate::util::u64_le_serde")] u64_le);
 
 impl fmt::Display for SegmentIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -404,11 +410,11 @@ impl fmt::Display for SegmentIndex {
 
 impl SegmentIndex {
     pub const fn new(val: u64) -> Self {
-        Self(val)
+        Self(u64_le::from_native(val))
     }
 
     pub const fn get(self) -> u64 {
-        self.0
+        self.0.to_native()
     }
 }
 
@@ -421,16 +427,23 @@ impl SegmentIndex {
     Eq,
     PartialOrd,
     Ord,
-    Serialize,
-    Deserialize,
-    IntoBytes,
-    FromBytes,
-    Immutable,
-    KnownLayout,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    rkyv::Portable,
+    rkyv::bytecheck::CheckBytes,
+    zerocopy::IntoBytes,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::KnownLayout,
 )]
+#[rkyv(as = Self)]
+#[bytecheck(crate = rkyv::bytecheck)]
 #[serde(transparent)]
 #[repr(transparent)]
-pub struct MaxCut(u64);
+pub struct MaxCut(#[serde(with = "crate::util::u64_le_serde")] u64_le);
 
 impl fmt::Display for MaxCut {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -440,11 +453,11 @@ impl fmt::Display for MaxCut {
 
 impl MaxCut {
     pub const fn new(val: u64) -> Self {
-        Self(val)
+        Self(u64_le::from_native(val))
     }
 
     pub const fn get(self) -> u64 {
-        self.0
+        self.0.to_native()
     }
 
     /// Adds an amount to the max cut, returning `None` on overflow.
@@ -475,13 +488,20 @@ impl MaxCut {
     Eq,
     PartialOrd,
     Ord,
-    Serialize,
-    Deserialize,
-    IntoBytes,
-    FromBytes,
-    Immutable,
-    KnownLayout,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    rkyv::Portable,
+    rkyv::bytecheck::CheckBytes,
+    zerocopy::IntoBytes,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::KnownLayout,
 )]
+#[rkyv(as = Self)]
+#[bytecheck(crate = rkyv::bytecheck)]
 #[repr(C)]
 pub struct Location {
     pub max_cut: MaxCut,
@@ -933,7 +953,7 @@ pub trait Revertable {
     fn checkpoint(&self) -> Checkpoint;
 
     /// Revert the perspective to the state it was at when the checkpoint was created.
-    fn revert(&mut self, checkpoint: Checkpoint) -> Result<(), Bug>;
+    fn revert(&mut self, checkpoint: Checkpoint) -> Result<(), StorageError>;
 }
 
 /// A checkpoint used to revert perspectives.
@@ -950,7 +970,7 @@ pub struct Checkpoint {
 /// `(k_1, k_2, ..., k_n)`, where each `k` is a sequence of bytes. The fact value is also a sequence of bytes.
 pub trait Query {
     /// Look up a named fact by an exact match of the compound key.
-    fn query(&self, name: &str, keys: &[Box<[u8]>]) -> Result<Option<Box<[u8]>>, StorageError>;
+    fn query(&self, name: &str, keys: &[Bytes]) -> Result<Option<Bytes>, StorageError>;
 
     /// Iterator for [`Query::query_prefix`].
     type QueryIterator: Iterator<Item = Result<Fact, StorageError>>;
@@ -962,7 +982,7 @@ pub trait Query {
     fn query_prefix(
         &self,
         name: &str,
-        prefix: &[Box<[u8]>],
+        prefix: &[Bytes],
     ) -> Result<Self::QueryIterator, StorageError>;
 }
 
@@ -972,7 +992,7 @@ pub struct Fact {
     /// The sequence of keys.
     pub key: Keys,
     /// The bytes of the value.
-    pub value: Box<[u8]>,
+    pub value: Bytes,
 }
 
 /// Can mutate facts by inserting and deleting them.
@@ -982,10 +1002,10 @@ pub trait QueryMut: Query {
     /// Insert a fact labeled by a name, with a given compound key and a value.
     ///
     /// This fact can later be looked up by [`Query`] methods, using the name and keys.
-    fn insert(&mut self, name: String, keys: Keys, value: Box<[u8]>);
+    fn insert(&mut self, name: String, keys: Keys, value: Bytes) -> Result<(), StorageError>;
 
     /// Delete any fact associated to the compound key, under the given name.
-    fn delete(&mut self, name: String, keys: Keys);
+    fn delete(&mut self, name: String, keys: Keys) -> Result<(), StorageError>;
 }
 
 // TODO(jdygert): Expose this?
@@ -998,25 +1018,44 @@ pub(crate) trait FactIndexExtra {
 }
 
 /// A sequence of byte-based keys, used for facts.
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct Keys(Box<[Box<[u8]>]>);
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
+pub struct Keys(Box<[Bytes]>);
 
 impl Deref for Keys {
-    type Target = [Box<[u8]>];
-    fn deref(&self) -> &[Box<[u8]>] {
+    type Target = [Bytes];
+    fn deref(&self) -> &[Bytes] {
         self.0.as_ref()
     }
 }
 
-impl AsRef<[Box<[u8]>]> for Keys {
-    fn as_ref(&self) -> &[Box<[u8]>] {
+impl AsRef<[Bytes]> for Keys {
+    fn as_ref(&self) -> &[Bytes] {
         self.0.as_ref()
     }
 }
 
-impl core::borrow::Borrow<[Box<[u8]>]> for Keys {
-    fn borrow(&self) -> &[Box<[u8]>] {
+impl Borrow<[Bytes]> for Keys {
+    fn borrow(&self) -> &[Bytes] {
         self.0.as_ref()
+    }
+}
+
+impl From<Vec<Bytes>> for Keys {
+    fn from(value: Vec<Bytes>) -> Self {
+        Self(value.into_boxed_slice())
     }
 }
 
@@ -1026,17 +1065,27 @@ impl From<&[&[u8]]> for Keys {
     }
 }
 
-impl Keys {
-    fn starts_with(&self, prefix: &[Box<[u8]>]) -> bool {
-        self.as_ref().starts_with(prefix)
-    }
-}
-
-impl<B: Into<Box<[u8]>>> FromIterator<B> for Keys {
+impl<B: Into<Bytes>> FromIterator<B> for Keys {
     fn from_iter<T: IntoIterator<Item = B>>(iter: T) -> Self {
         Self(iter.into_iter().map(Into::into).collect())
     }
 }
+
+impl<'a> IntoIterator for &'a Keys {
+    type Item = &'a Bytes;
+    type IntoIter = core::slice::Iter<'a, Bytes>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl ArchivedKeys {
+    pub fn iter(&self) -> impl Iterator<Item = &[u8]> {
+        self.0.iter().map(AsRef::as_ref)
+    }
+}
+
+pub type Bytes = Box<[u8]>;
 
 mod impls {
     use alloc::boxed::Box;

--- a/crates/aranya-runtime/src/testing/protocol.rs
+++ b/crates/aranya-runtime/src/testing/protocol.rs
@@ -129,7 +129,10 @@ impl TestPolicy {
         let key = group.to_be_bytes();
         let value = count.to_be_bytes();
 
-        facts.insert("payload".into(), Keys::from_iter([key]), value.into());
+        facts
+            .insert("payload".into(), Keys::from_iter([key]), value.into())
+            .map_err(|_| PolicyError::Write)?;
+
         Ok(())
     }
 

--- a/crates/aranya-runtime/src/util/mod.rs
+++ b/crates/aranya-runtime/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod u64_le_serde;

--- a/crates/aranya-runtime/src/util/u64_le_serde.rs
+++ b/crates/aranya-runtime/src/util/u64_le_serde.rs
@@ -1,0 +1,16 @@
+use rkyv::rend::u64_le;
+use serde::{Deserialize as _, Serialize as _, de::Deserializer, ser::Serializer};
+
+pub fn serialize<S>(val: &u64_le, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    val.to_native().serialize(serializer)
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<u64_le, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    u64::deserialize(deserializer).map(u64_le::from_native)
+}

--- a/crates/aranya-runtime/src/util/u64_le_serde.rs
+++ b/crates/aranya-runtime/src/util/u64_le_serde.rs
@@ -1,4 +1,4 @@
-use rkyv::rend::u64_le;
+use rend::u64_le;
 use serde::{Deserialize as _, Serialize as _, de::Deserializer, ser::Serializer};
 
 pub fn serialize<S>(val: &u64_le, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/aranya-runtime/src/vm_policy/io.rs
+++ b/crates/aranya-runtime/src/vm_policy/io.rs
@@ -81,7 +81,12 @@ where
     ) -> Result<(), MachineIOError> {
         let keys = ser_keys(key);
         let value = ser_values(value)?;
-        self.facts.insert(name.as_str().to_owned(), keys, value);
+        self.facts
+            .insert(name.as_str().to_owned(), keys, value)
+            .map_err(|err| {
+                tracing::error!(?err);
+                MachineIOError::Internal
+            })?;
         Ok(())
     }
 
@@ -91,7 +96,13 @@ where
         key: impl IntoIterator<Item = FactKey>,
     ) -> Result<(), MachineIOError> {
         let keys = ser_keys(key);
-        self.facts.delete(name.as_str().to_owned(), keys);
+        self.facts
+            .delete(name.as_str().to_owned(), keys)
+            .map_err(|err| {
+                tracing::error!(?err);
+                MachineIOError::Internal
+            })?;
+
         Ok(())
     }
 


### PR DESCRIPTION
- Adds error to some storage trait methods
- Switches u64 to u64_le for max cut, segment index, and policy ID.
- Uses `Bytes` alias more
- Adds `rkyv` trait impls to address, policy ID, etc.