### PR TITLE
runtime: improve skip list and find-needed-segments traversal

### DIFF
--- a/crates/aranya-runtime/src/storage/linear/mod.rs
+++ b/crates/aranya-runtime/src/storage/linear/mod.rs
@@ -279,9 +279,11 @@ impl<FM: IoManager> StorageProvider for LinearStorageProvider<FM> {
 const MIN_SKIP_GAP: u64 = 10;
 
 /// Skip-list target boundaries for a segment of length `n`: `n/2`, `3n/4`,
-/// `7n/8`, ..., halving the remaining gap each step until the gap to `n`
-/// drops to [`MIN_SKIP_GAP`]. Returned ascending; callers walk backwards
-/// and pop highest-first. Empty when `n < 2`.
+/// `7n/8`, ..., halving the remaining gap each step. Continues until the
+/// gap from the final boundary to `n` is ≤ [`MIN_SKIP_GAP`], so the walk
+/// from head to the first skip entry never exceeds the cheap-walk
+/// threshold. Returned ascending; callers walk backwards and pop
+/// highest-first. Empty when `n < 2`.
 fn skip_target_boundaries(n: u64) -> Result<Vec<MaxCut>, StorageError> {
     let mut targets = vec![];
     let mut boundary = n / 2;

--- a/crates/aranya-runtime/src/storage/linear/mod.rs
+++ b/crates/aranya-runtime/src/storage/linear/mod.rs
@@ -30,7 +30,6 @@ pub mod testing;
 use alloc::{boxed::Box, collections::BTreeMap, string::String, vec, vec::Vec};
 use core::ops::Bound;
 
-use aranya_crypto::{Rng, dangerous::spideroak_crypto::csprng::rand::Rng as _};
 use buggy::{Bug, BugExt as _, bug};
 use serde::{Deserialize, Serialize};
 use vec1::Vec1;
@@ -274,38 +273,31 @@ impl<FM: IoManager> StorageProvider for LinearStorageProvider<FM> {
     }
 }
 
-impl<W: Write> LinearStorage<W> {
-    fn get_skip(
-        &self,
-        segment: <Self as Storage>::Segment,
-        max_cut: MaxCut,
-    ) -> Result<Option<Location>, StorageError> {
-        let mut head = segment;
-        let mut current = None;
-        'outer: loop {
-            if max_cut > head.longest_max_cut()? {
-                return Ok(current);
-            }
-            current = Some(head.first_location());
-            if max_cut >= head.shortest_max_cut() {
-                return Ok(current);
-            }
-            // Assumes skip list is sorted in ascending order.
-            // We always want to skip as close to the root as possible.
-            for skip in head.skip_list() {
-                if skip.max_cut <= max_cut {
-                    head = self.get_segment(*skip)?;
-                    continue 'outer;
-                }
-            }
-            head = match head.prior() {
-                Prior::None | Prior::Merge(_, _) => {
-                    return Ok(current);
-                }
-                Prior::Single(l) => self.get_segment(l)?,
-            }
+/// Maximum segment-walk distance for skip-list construction. Below this
+/// threshold the segments are cheap enough to walk one-by-one, so neither
+/// the rich-anchor probe nor a freshly built skip list pay for themselves.
+const MIN_SKIP_GAP: u64 = 10;
+
+/// Skip-list target boundaries for a segment of length `n`: `n/2`, `3n/4`,
+/// `7n/8`, ..., halving the remaining gap each step until the gap to `n`
+/// drops to [`MIN_SKIP_GAP`]. Returned ascending; callers walk backwards
+/// and pop highest-first. Empty when `n < 2`.
+fn skip_target_boundaries(n: u64) -> Result<Vec<MaxCut>, StorageError> {
+    let mut targets = vec![];
+    let mut boundary = n / 2;
+    while boundary > 0 {
+        targets.push(MaxCut::new(boundary));
+        let gap = n
+            .checked_sub(boundary)
+            .assume("boundary < n by loop invariant")?;
+        if gap <= MIN_SKIP_GAP {
+            break;
         }
+        boundary = boundary
+            .checked_add(gap / 2)
+            .assume("boundary + gap/2 <= n <= u64::MAX")?;
     }
+    Ok(targets)
 }
 
 impl<W: Write> LinearStorage<W> {
@@ -392,6 +384,129 @@ impl<W: Write> LinearStorage<W> {
                 prior: FactPerspectivePrior::None,
             })?
             .repr)
+    }
+
+    /// Whether an ancestor within [`MIN_SKIP_GAP`] segments of `start` already
+    /// carries a rich skip list (`len > 1`). The walk crosses merges via the
+    /// LCA recorded as the sole entry in a merge segment's LCA-only skip list,
+    /// so a rich anchor past a merge is still reachable.
+    fn has_nearby_rich_anchor(&self, start: Location) -> Result<bool, StorageError> {
+        let mut check = start;
+        for _ in 0..MIN_SKIP_GAP {
+            let seg = self.get_segment(check)?;
+            if seg.skip_list().len() > 1 {
+                return Ok(true);
+            }
+            match seg.prior() {
+                Prior::Single(p) => check = p,
+                Prior::Merge(_, _) => {
+                    check = seg
+                        .skip_list()
+                        .last()
+                        .copied()
+                        .assume("merge skip list must end with LCA")?;
+                }
+                Prior::None => return Ok(false),
+            }
+        }
+        Ok(false)
+    }
+
+    /// Build the skip list for a new segment with the given `prior`,
+    /// `last_common_ancestor` (required for merges), and length `n`.
+    ///
+    /// Returns:
+    /// - empty for `Prior::None`,
+    /// - `[lca]` (or empty for non-merges) when a nearby ancestor already
+    ///   has a rich skip list or `n < MIN_SKIP_GAP`,
+    /// - otherwise, a list of skip targets at `n/2, 3n/4, 7n/8, ...` plus
+    ///   the LCA for merges. See [`skip_target_boundaries`].
+    fn build_skip_list(
+        &self,
+        prior: Prior<Location>,
+        last_common_ancestor: Option<Location>,
+        n: u64,
+    ) -> Result<Vec<Location>, StorageError> {
+        let (walk_start, lca) = match prior {
+            Prior::None => return Ok(vec![]),
+            Prior::Merge(_, _) => {
+                let lca = last_common_ancestor.assume("lca must exist")?;
+                (lca, Some(lca))
+            }
+            Prior::Single(l) => (l, None),
+        };
+
+        if self.has_nearby_rich_anchor(walk_start)? || n < MIN_SKIP_GAP {
+            return Ok(lca.into_iter().collect());
+        }
+
+        let targets = skip_target_boundaries(n)?;
+        let mut skips = self.walk_collecting_skips(walk_start, targets)?;
+
+        // Always include the LCA for merge segments.
+        if let Some(lca) = lca
+            && !skips.contains(&lca)
+        {
+            skips.push(lca);
+        }
+
+        skips.sort_by_key(|loc| loc.max_cut);
+        skips.dedup();
+        Ok(skips)
+    }
+
+    /// Walk backwards from `start`, recording the `first_location` of each
+    /// segment as it crosses a target in `targets` (ascending; consumed
+    /// highest-first via `pop`). At each segment, jump along the smallest
+    /// available skip entry that still stays at or above the next target;
+    /// otherwise step to the parent. Stops when targets are exhausted or
+    /// no further progress toward them is possible.
+    fn walk_collecting_skips(
+        &self,
+        start: Location,
+        mut targets: Vec<MaxCut>,
+    ) -> Result<Vec<Location>, StorageError> {
+        let mut skips = vec![];
+        let mut current = start;
+
+        loop {
+            let seg = self.get_segment(current)?;
+            let seg_min = seg.shortest_max_cut();
+
+            // Record any targets we've reached or passed.
+            while let Some(&t) = targets.last() {
+                if t >= seg_min {
+                    skips.push(seg.first_location());
+                    targets.pop();
+                } else {
+                    break;
+                }
+            }
+
+            let Some(&next_target) = targets.last() else {
+                break;
+            };
+
+            // Smallest skip entry at or above next_target (and below
+            // current), i.e. the tightest jump that still makes progress.
+            let best = seg
+                .skip_list()
+                .iter()
+                .copied()
+                .filter(|s| s.max_cut >= next_target && s.max_cut < current.max_cut)
+                .min_by_key(|s| s.max_cut);
+            if let Some(skip) = best {
+                current = skip;
+                continue;
+            }
+
+            match seg.prior() {
+                Prior::Single(p) if p.max_cut >= next_target => current = p,
+                _ => break,
+            }
+        }
+
+        Ok(skips)
     }
 }
 
@@ -570,44 +685,12 @@ impl<F: Write> Storage for LinearStorage<F> {
             .try_into()
             .map_err(|_| StorageError::EmptyPerspective)?;
 
-        let get_skips = |l: Location, count: usize| -> Result<Vec<Location>, StorageError> {
-            let mut rng = Rng;
-            let mut skips = vec![];
-            for _ in 0..count {
-                let segment = self.get_segment(l)?;
-                if l.max_cut > MaxCut::new(0) {
-                    let max_cut = MaxCut::new(rng.gen_range(0..l.max_cut.get()));
-                    if let Some(skip) = self.get_skip(segment, max_cut)? {
-                        if !skips.contains(&skip) {
-                            skips.push(skip);
-                        }
-                    } else {
-                        break;
-                    }
-                }
-            }
-            Ok(skips)
-        };
+        let skip_list = self.build_skip_list(
+            perspective.prior,
+            perspective.last_common_ancestor,
+            perspective.max_cut.get(),
+        )?;
 
-        let skip_list = match perspective.prior {
-            Prior::None => vec![],
-            Prior::Merge(_, _) => {
-                let lca = perspective.last_common_ancestor.assume("lca must exist")?;
-                let mut skips = get_skips(lca, 2)?;
-                if !skips.contains(&lca) {
-                    skips.push(lca);
-                }
-                // Sort by max_cut ascending so we can jump as far back as possible
-                skips.sort_by_key(|loc| loc.max_cut);
-                skips
-            }
-            Prior::Single(l) => {
-                let mut skips = get_skips(l, 3)?;
-                // Sort by max_cut ascending so we can jump as far back as possible
-                skips.sort_by_key(|loc| loc.max_cut);
-                skips
-            }
-        };
         let repr = self.writer.append(|offset| SegmentRepr {
             offset: SegmentIndex::new(offset),
             prior: perspective.prior,

--- a/crates/aranya-runtime/src/sync/responder.rs
+++ b/crates/aranya-runtime/src/sync/responder.rs
@@ -9,7 +9,7 @@ use super::{
     wire::{CommandMeta, SyncType},
 };
 use crate::{
-    LocatedAddress, StorageError,
+    LocatedAddress, Prior, StorageError,
     command::{Address, CmdId, Command as _},
     storage::{
         GraphId, Location, MaxCut, Segment as _, Storage, StorageProvider, TraversalBuffer,
@@ -169,6 +169,51 @@ fn push_bounded(v: &mut Vec<Location, SEGMENT_BUFFER_MAX>, loc: Location) {
             .expect("non-empty");
         if loc.max_cut < v[max_idx].max_cut {
             v[max_idx] = loc;
+        }
+    }
+}
+
+/// Walk backwards from `head` along the skip list, taking any skip entry
+/// that stays at or above `target`, until the next step would drop below
+/// `target`. Returns the segment we stopped at — the entry point for the
+/// per-round traversal in `find_needed_segments`.
+fn skip_jump<S: Storage>(
+    storage: &S,
+    head: Location,
+    target: MaxCut,
+) -> Result<Location, StorageError> {
+    if head.max_cut <= target {
+        return Ok(head);
+    }
+    let mut current = head;
+    loop {
+        let seg = storage.get_segment(current)?;
+
+        // Smallest skip entry at or above target (and below current).
+        let best = seg
+            .skip_list()
+            .iter()
+            .copied()
+            .filter(|s| s.max_cut >= target && s.max_cut < current.max_cut)
+            .min_by_key(|s| s.max_cut);
+        if let Some(skip) = best {
+            current = skip;
+            continue;
+        }
+
+        // No useful skip. If any prior would drop below target, stop here.
+        let prior_below = match seg.prior() {
+            Prior::Single(p) => p.max_cut < target,
+            Prior::Merge(a, b) => a.max_cut < target || b.max_cut < target,
+            Prior::None => true,
+        };
+        if prior_below {
+            return Ok(current);
+        }
+
+        match seg.prior() {
+            Prior::Single(p) => current = p,
+            _ => return Ok(current),
         }
     }
 }
@@ -369,7 +414,20 @@ impl SyncResponder {
 
         // heads queue: segments to process, popped by highest max_cut.
         let heads = buffers.primary.get();
-        heads.push(storage.get_head()?)?;
+
+        // Jump from head toward highest_have + SEGMENT_BUFFER_MAX before
+        // starting the main traversal, so per-round cost is O(log n) instead
+        // of O(n).
+        let head = storage.get_head()?;
+        let highest_have = have_locations
+            .first()
+            .map(|l| l.max_cut)
+            .unwrap_or(MaxCut::new(0));
+        let skip_target = highest_have
+            .checked_add(SEGMENT_BUFFER_MAX as u64)
+            .assume("skip target overflow")?;
+        let start = skip_jump(storage, head, skip_target)?;
+        heads.push(start)?;
 
         // pending queue: segments tentatively needed by the peer.
         let pending = buffers.secondary.get();


### PR DESCRIPTION
Implements the design changes from aranya-docs PR #199 (https://github.com/aranya-project/aranya-docs/pull/199).

Skip-list construction (storage/linear/mod.rs):
- Replace per-segment random skip targets with deterministic exponentially-spaced targets (N/2, 3N/4, 7N/8, ...), producing ~log2(N/10) entries per segment for O(log n) worst-case search.
- Build skip-list targets via a single backwards walk that reuses intermediate segments' skip lists to jump when possible.
- Sparse construction: skip building when an ancestor within MIN_SKIP_GAP (10) already carries a rich (len > 1) skip list. The check walks through merges via their LCA — the sole entry in an LCA-only list — so a rich anchor past a merge is still reachable.
- Merge segments walk from the LCA instead of the parent and always include the LCA as a skip entry, preserving the braiding invariant that the last skip entry is the LCA.

find_needed_segments skip optimization (sync/responder.rs):
- Before the main traversal, jump from head to approximately highest_have + SEGMENT_BUFFER_MAX using skip-list entries that stay at or above the target. Reduces per-round cost from O(n) to O(log n + SEGMENT_BUFFER_MAX), cutting total cost across sync rounds from O(n^2) to O(n log n).
- Measured 25x reduction in sync_reads on the 10K-command linear sync benchmark.