### PR TITLE
runtime: fix prior fact index skipping bug

### DIFF
--- a/crates/aranya-runtime/src/client/transaction.rs
+++ b/crates/aranya-runtime/src/client/transaction.rs
@@ -610,24 +610,27 @@ mod test {
                 "merges shouldn't be evaluated"
             );
 
-            // For init and basic commands, append the id to the seq fact.
             let data = command.bytes();
-            if let Some(seq) = facts
-                .query("seq", &Keys::default())
-                .assume("can query")?
-                .as_deref()
-            {
-                facts
-                    .insert(
-                        "seq".into(),
-                        Keys::default(),
-                        [seq, b":", data].concat().into(),
-                    )
-                    .unwrap();
-            } else {
-                facts
-                    .insert("seq".into(), Keys::default(), data.into())
-                    .unwrap();
+            // (q)uiet commmands add no facts so we can test that.
+            if !data.starts_with(b"q") {
+                // For init and basic commands, append the id to the seq fact.
+                if let Some(seq) = facts
+                    .query("seq", &Keys::default())
+                    .assume("can query")?
+                    .as_deref()
+                {
+                    facts
+                        .insert(
+                            "seq".into(),
+                            Keys::default(),
+                            [seq, b":", data].concat().into(),
+                        )
+                        .unwrap();
+                } else {
+                    facts
+                        .insert("seq".into(), Keys::default(), data.into())
+                        .unwrap();
+                }
             }
             Ok(())
         }
@@ -779,10 +782,11 @@ mod test {
         }
 
         fn get_addr(&self, id: CmdId) -> Address {
-            Address {
-                id,
-                max_cut: self.max_cuts[&id],
-            }
+            let max_cut = *self
+                .max_cuts
+                .get(&id)
+                .unwrap_or_else(|| panic!("bad ID {id}"));
+            Address { id, max_cut }
         }
 
         pub fn line(&mut self, prev: CmdId, ids: &[CmdId]) -> Result<(), ClientError> {
@@ -1104,6 +1108,62 @@ mod test {
         };
         let err = gb.commit().expect_err("merge should fail");
         assert!(matches!(err, ClientError::ParallelFinalize), "{err:?}");
+    }
+
+    #[test]
+    fn test_merge_bug() -> Result<(), StorageError> {
+        let mut gb = graph! {
+            ClientState::new(SeqPolicyStore, MemStorageProvider::default());
+            "i";
+            "i" < "j";
+            "j" < "qo1";
+            "j" < "qa1";
+            "qo1" "qa1" < "m1";
+            "m1" < "qo2";
+            "m1" < "qa2";
+            "qo2" "qa2" < "m2";
+            "m2" < "h";
+            commit;
+        };
+        let g = gb.client.provider.get_storage(mkid("i")).unwrap();
+
+        #[cfg(feature = "graphviz")]
+        graphviz::dot(g, "merge-bug");
+
+        assert_eq!(g.get_head().unwrap().max_cut, MaxCut::new(6));
+
+        let seq = lookup(g, "seq").unwrap();
+        let seq = std::str::from_utf8(&seq).unwrap();
+        assert_eq!(seq, "i:j:h");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_linear_bug() -> Result<(), StorageError> {
+        let mut gb = graph! {
+            ClientState::new(SeqPolicyStore, MemStorageProvider::default());
+            "i";
+            "i" < "j";
+            commit;
+            "j" < "qa" "qb";
+            commit;
+            "qa" < "c";
+            "qb" "c" < "m";
+            commit;
+        };
+        let g = gb.client.provider.get_storage(mkid("i")).unwrap();
+
+        #[cfg(feature = "graphviz")]
+        graphviz::dot(g, "linear-bug");
+
+        assert_eq!(g.get_head().unwrap().max_cut, MaxCut::new(4));
+
+        let seq = lookup(g, "seq").unwrap();
+        let seq = std::str::from_utf8(&seq).unwrap();
+        assert_eq!(seq, "i:j:c");
+
+        Ok(())
     }
 
     #[cfg(feature = "graphviz")]

--- a/crates/aranya-runtime/src/storage/linear/mod.rs
+++ b/crates/aranya-runtime/src/storage/linear/mod.rs
@@ -80,6 +80,8 @@ struct SegmentRepr {
     policy: PolicyId,
     /// Offset in file to associated fact index.
     facts: u64,
+    /// Prior fact offset used to reconstruct facts within segment.
+    prior_facts: Option<u64>,
     commands: Vec1<CommandData>,
     max_cut: MaxCut,
     skip_list: Vec<Location>,
@@ -330,6 +332,7 @@ impl<W: Write> LinearStorage<W> {
             parents: Prior::None,
             policy: init.policy,
             facts,
+            prior_facts: None,
             commands,
             max_cut: MaxCut::new(0),
             skip_list: vec![],
@@ -510,6 +513,63 @@ impl<W: Write> LinearStorage<W> {
 
         Ok(skips)
     }
+
+    /// Write a fact perspective out if non-empty, returning it with the prior fact offset to be stored in the segment.
+    fn write_facts_with_prior(
+        &mut self,
+        facts: <Self as Storage>::FactPerspective,
+    ) -> Result<(<Self as Storage>::FactIndex, Option<u64>), StorageError> {
+        let mut prior = match facts.prior {
+            FactPerspectivePrior::None => None,
+            FactPerspectivePrior::FactPerspective(prior) => {
+                let prior = self.write_facts(*prior)?;
+                if facts.map.is_empty() {
+                    let offset = prior.repr.offset;
+                    return Ok((prior, Some(offset)));
+                }
+                Some(prior.repr)
+            }
+            FactPerspectivePrior::FactIndex { offset, reader } => {
+                let repr: FactIndexRepr = reader.fetch(offset)?;
+                if facts.map.is_empty() {
+                    let offset = repr.offset;
+                    return Ok((LinearFactIndex { repr, reader }, Some(offset)));
+                }
+                Some(repr)
+            }
+        };
+
+        let depth = if let Some(mut p) = prior.take() {
+            if p.depth > MAX_FACT_INDEX_DEPTH - 1 {
+                p = self.compact(p)?;
+            }
+            prior.insert(p).depth
+        } else {
+            0
+        };
+
+        let depth = depth.checked_add(1).assume("depth won't overflow")?;
+
+        if depth > MAX_FACT_INDEX_DEPTH {
+            bug!("fact index too deep");
+        }
+
+        let prior_offset = prior.map(|p| p.offset);
+        let repr = self.writer.append(|offset| FactIndexRepr {
+            offset,
+            prior: prior_offset,
+            depth,
+            facts: facts.map,
+        })?;
+
+        Ok((
+            LinearFactIndex {
+                repr,
+                reader: self.writer.readonly(),
+            },
+            prior_offset,
+        ))
+    }
 }
 
 impl<F: Write> Storage for LinearStorage<F> {
@@ -530,7 +590,7 @@ impl<F: Write> Storage for LinearStorage<F> {
                 reader: self.writer.readonly(),
             }
         } else {
-            let prior = match segment.facts()?.repr.prior {
+            let prior = match segment.repr.prior_facts {
                 Some(offset) => FactPerspectivePrior::FactIndex {
                     offset,
                     reader: self.writer.readonly(),
@@ -590,7 +650,7 @@ impl<F: Write> Storage for LinearStorage<F> {
             ));
         }
 
-        let prior = match segment.facts()?.repr.prior {
+        let prior = match segment.repr.prior_facts {
             Some(offset) => FactPerspectivePrior::FactIndex {
                 offset,
                 reader: self.writer.readonly(),
@@ -680,7 +740,8 @@ impl<F: Write> Storage for LinearStorage<F> {
     fn write(&mut self, perspective: Self::Perspective) -> Result<Self::Segment, StorageError> {
         // TODO(jdygert): Validate prior?
 
-        let facts = self.write_facts(perspective.facts)?.repr.offset;
+        let (facts, prior_facts) = self.write_facts_with_prior(perspective.facts)?;
+        let facts = facts.repr.offset;
 
         let commands: Vec1<CommandData> = perspective
             .commands
@@ -699,6 +760,7 @@ impl<F: Write> Storage for LinearStorage<F> {
             parents: perspective.parents,
             policy: perspective.policy,
             facts,
+            prior_facts,
             commands,
             max_cut: perspective.max_cut,
             skip_list,
@@ -714,50 +776,8 @@ impl<F: Write> Storage for LinearStorage<F> {
         &mut self,
         facts: Self::FactPerspective,
     ) -> Result<Self::FactIndex, StorageError> {
-        let mut prior = match facts.prior {
-            FactPerspectivePrior::None => None,
-            FactPerspectivePrior::FactPerspective(prior) => {
-                let prior = self.write_facts(*prior)?;
-                if facts.map.is_empty() {
-                    return Ok(prior);
-                }
-                Some(prior.repr)
-            }
-            FactPerspectivePrior::FactIndex { offset, reader } => {
-                let repr = reader.fetch(offset)?;
-                if facts.map.is_empty() {
-                    return Ok(LinearFactIndex { repr, reader });
-                }
-                Some(repr)
-            }
-        };
-
-        let depth = if let Some(mut p) = prior.take() {
-            if p.depth > MAX_FACT_INDEX_DEPTH - 1 {
-                p = self.compact(p)?;
-            }
-            prior.insert(p).depth
-        } else {
-            0
-        };
-
-        let depth = depth.checked_add(1).assume("depth won't overflow")?;
-
-        if depth > MAX_FACT_INDEX_DEPTH {
-            bug!("fact index too deep");
-        }
-
-        let repr = self.writer.append(|offset| FactIndexRepr {
-            offset,
-            prior: prior.map(|p| p.offset),
-            depth,
-            facts: facts.map,
-        })?;
-
-        Ok(LinearFactIndex {
-            repr,
-            reader: self.writer.readonly(),
-        })
+        self.write_facts_with_prior(facts)
+            .map(|(fact_index, _)| fact_index)
     }
 }
 


### PR DESCRIPTION
Fixes #709 by storing the prior fact index offset directly in the segment. Thus when we reuse an existing fact index, the segment will use that existing fact index as the base for reconstructing the facts.