### PR TITLE
Avoid exposing AST VType to client

### DIFF
--- a/crates/aranya-policy-compiler/src/compile.rs
+++ b/crates/aranya-policy-compiler/src/compile.rs
@@ -1151,12 +1151,12 @@ impl<'a> CompileState<'a> {
         self.m
             .interface
             .action_defs
-            .insert(ActionDef {
-                name: action_node.identifier.clone(),
-                persistence: action_node.persistence.clone(),
+            .insert(ActionDef::new(
+                action_node.identifier.clone(),
+                action_node.persistence.clone(),
                 params,
-                result_type: action_node.return_type.clone(),
-            })
+                action_node.return_type.clone(),
+            ))
             .map_err(|e| {
                 self.err(AlreadyDefined::new(
                     action_node.identifier.clone(),

--- a/crates/aranya-policy-module/src/module.rs
+++ b/crates/aranya-policy-module/src/module.rs
@@ -139,12 +139,29 @@ pub struct ActionDef {
     pub persistence: ast::Persistence,
     /// The parameters of the action.
     pub params: NamedMap<Param>,
-    /// action return type: result or unit
-    pub result_type: ast::VType,
+    /// Action return type: `result[unit, E]` for fallible actions or `unit`
+    /// for infallible ones. Kept private so clients depend on
+    /// Use [`ActionDef::is_fallible`] to determine whether action can fail.
+    result_type: ast::VType,
 }
 named!(ActionDef);
 
 impl ActionDef {
+    /// Creates a new [`ActionDef`].
+    pub fn new(
+        name: Ident,
+        persistence: ast::Persistence,
+        params: NamedMap<Param>,
+        result_type: ast::VType,
+    ) -> Self {
+        Self {
+            name,
+            persistence,
+            params,
+            result_type,
+        }
+    }
+
     /// Whether the action is fallible, i.e. it returns a `result[unit, E]`
     /// value. An infallible action (return type `unit`) returns nothing.
     pub fn is_fallible(&self) -> bool {

--- a/crates/aranya-policy-vm/tests/vm.rs
+++ b/crates/aranya-policy-vm/tests/vm.rs
@@ -2387,10 +2387,8 @@ fn test_boolean_short_circuit() {
         let ctx = dummy_ctx_action(ident!("f"));
         let mut rs = machine.create_run_state(&mut io, ctx);
 
-        let reason = rs
-            .call_action(ident!("f"), iter::empty::<Value>())
-            .expect("action runs");
-        reason
+        rs.call_action(ident!("f"), iter::empty::<Value>())
+            .expect("action runs")
     }
 
     // `todo()` panics if it runs. A failing `check` runs its `else return Err(..)`,

--- a/crates/aranya-runtime/src/client.rs
+++ b/crates/aranya-runtime/src/client.rs
@@ -247,7 +247,7 @@ where
         graph_id: GraphId,
         sink: &mut impl Sink<PS::Effect>,
         action: <PS::Policy as Policy>::Action<'_>,
-    ) -> Result<(), ClientError> {
+    ) -> Result<<PS::Policy as Policy>::ActionReturn, ClientError> {
         let storage = self.provider.get_storage(graph_id)?;
 
         let head = storage.get_head()?;
@@ -262,11 +262,11 @@ where
 
         sink.begin();
         match policy.call_action(action, &mut perspective, sink, ActionPlacement::OnGraph) {
-            Ok(()) => {
+            Ok(ret) => {
                 let segment = storage.write(perspective)?;
                 storage.commit(segment)?;
                 sink.commit();
-                Ok(())
+                Ok(ret)
             }
             Err(e) => {
                 sink.rollback();

--- a/crates/aranya-runtime/src/client/session.rs
+++ b/crates/aranya-runtime/src/client/session.rs
@@ -75,7 +75,7 @@ impl<SP: StorageProvider, PS: PolicyStore> Session<SP, PS> {
         effect_sink: &mut ES,
         message_sink: &mut MS,
         action: <PS::Policy as Policy>::Action<'_>,
-    ) -> Result<(), ClientError>
+    ) -> Result<<PS::Policy as Policy>::ActionReturn, ClientError>
     where
         ES: Sink<PS::Effect>,
         MS: for<'b> Sink<&'b [u8]>,
@@ -97,10 +97,10 @@ impl<SP: StorageProvider, PS: PolicyStore> Session<SP, PS> {
             effect_sink,
             ActionPlacement::OffGraph,
         ) {
-            Ok(()) => {
+            Ok(ret) => {
                 // Success, commit effects
                 effect_sink.commit();
-                Ok(())
+                Ok(ret)
             }
             Err(e) => {
                 // Other error, revert all? See #513.

--- a/crates/aranya-runtime/src/client/transaction.rs
+++ b/crates/aranya-runtime/src/client/transaction.rs
@@ -591,6 +591,7 @@ mod test {
 
     impl Policy for SeqPolicy {
         type Action<'a> = &'a str;
+        type ActionReturn = ();
         type Effect = ();
         type Command<'a> = SeqCommand;
 
@@ -641,7 +642,7 @@ mod test {
             _facts: &mut impl Perspective,
             _sink: &mut impl Sink<Self::Effect>,
             _placement: ActionPlacement,
-        ) -> Result<(), PolicyError> {
+        ) -> Result<Self::ActionReturn, PolicyError> {
             unimplemented!()
         }
 

--- a/crates/aranya-runtime/src/policy.rs
+++ b/crates/aranya-runtime/src/policy.rs
@@ -145,6 +145,7 @@ impl From<MergeIds> for (Address, Address) {
 /// as a result.
 pub trait Policy {
     type Action<'a>;
+    type ActionReturn;
     type Effect;
     type Command<'a>: Command;
 
@@ -172,7 +173,7 @@ pub trait Policy {
         facts: &mut impl Perspective,
         sink: &mut impl Sink<Self::Effect>,
         placement: ActionPlacement,
-    ) -> Result<(), PolicyError>;
+    ) -> Result<Self::ActionReturn, PolicyError>;
 
     /// Produces a merge message serialized to target. The `struct` representing the
     /// Command is returned.

--- a/crates/aranya-runtime/src/testing/protocol.rs
+++ b/crates/aranya-runtime/src/testing/protocol.rs
@@ -268,6 +268,7 @@ pub enum TestActions {
 impl Policy for TestPolicy {
     type Effect = TestEffect;
     type Action<'a> = TestActions;
+    type ActionReturn = ();
     type Command<'a> = TestProtocol<'a>;
 
     fn serial(&self) -> u32 {

--- a/crates/aranya-runtime/src/testing/vm.rs
+++ b/crates/aranya-runtime/src/testing/vm.rs
@@ -448,7 +448,7 @@ pub fn test_action_result(policy_store: TestPolicyStore) -> Result<(), VmPolicyE
         )
         .expect("Ok action should succeed");
 
-    // `return Err(reason)` => `Check(Some(value))` surfaces the reason to the caller.
+    // `return Err(reason)` => surfaced as `PolicyError::Check(Some(value))`.
     let err = session
         .action(
             &cs,
@@ -481,7 +481,7 @@ pub fn test_query_fact_value(policy_store: TestPolicyStore) -> Result<(), VmPoli
         .expect("could not create graph");
 
     cs.action(graph, &mut NullSink, vm_action!(create_action(1)))
-        .expect("can create");
+        .expect("create failed");
 
     let mut session = cs.session(graph).expect("should be able to create session");
 

--- a/crates/aranya-runtime/src/vm_policy.rs
+++ b/crates/aranya-runtime/src/vm_policy.rs
@@ -490,6 +490,7 @@ impl<CE> VmPolicy<CE> {
 
 impl<CE: aranya_crypto::Engine> Policy for VmPolicy<CE> {
     type Action<'a> = VmAction<'a>;
+    type ActionReturn = ();
     type Effect = VmEffect;
     type Command<'a> = VmProtocol<'a>;
 
@@ -587,7 +588,7 @@ impl<CE: aranya_crypto::Engine> Policy for VmPolicy<CE> {
         facts: &mut impl Perspective,
         sink: &mut impl Sink<Self::Effect>,
         action_placement: ActionPlacement,
-    ) -> Result<(), PolicyError> {
+    ) -> Result<Self::ActionReturn, PolicyError> {
         let VmAction { name, args } = action;
 
         let def = self.machine.action_defs.get(&name).ok_or_else(|| {
@@ -645,8 +646,8 @@ impl<CE: aranya_crypto::Engine> Policy for VmPolicy<CE> {
                                 error!("expected action result value: {e}");
                                 PolicyError::InternalError
                             })?;
-                            // `Err(payload)` => the action failed with that value;
-                            // anything else (`Ok`/placeholder success) succeeds.
+                            // Surface `Err(payload)` through `PolicyError::Check`
+                            // so callers see a single flat `Result`.
                             if let Value::Result(Err(payload)) = value {
                                 info!("action returned Err {}", self.source_location(&rs));
                                 return Err(PolicyError::Check(Some(*payload)));


### PR DESCRIPTION
Use associated ActionReturn associated type instead.