### PR TITLE
build: bump rkyv to 0.8.17 for RustSec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck",
  "hashbrown 0.17.1",
@@ -2096,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

Bumps `rkyv` (and `rkyv_derive`) from 0.8.16 to 0.8.17 in `Cargo.lock` to clear three RustSec advisories currently failing the `security-checks` job on all PRs:

- [RUSTSEC-2026-0233](https://rustsec.org/advisories/RUSTSEC-2026-0233) — crafted archives can cause a use-after-free during deserialization
- [RUSTSEC-2026-0234](https://rustsec.org/advisories/RUSTSEC-2026-0234) — insufficient archive validation can cause out-of-bounds reads in archives containing hash tables
- [RUSTSEC-2026-0235](https://rustsec.org/advisories/RUSTSEC-2026-0235) — insufficient archive validation can cause out-of-bounds reads in archives containing Rc/Arc

Lockfile-only change; 0.8.17 is within the workspace's existing `^0.8.13` requirement.

## Test plan

- [x] `cargo test -p aranya-runtime --lib` passes locally (96 passed)
- [ ] CI `security-checks` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)