### PR TITLE
chore: update rkyv for rustsec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck",
  "hashbrown 0.17.1",
@@ -2096,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2447,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,12 +109,12 @@ proptest = { version = "1.6", default-features = false, features = ["no_std", "a
 proptest-derive = { version = "0.5" }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-rkyv = { version = "0.8.13", default-features = false, features = ["bytecheck"] }
+rkyv = { version = "0.8.17", default-features = false, features = ["bytecheck"] }
 rustix = { version = "0.38", default-features = false }
 serde = { version = "1.0.210", default-features = false }
 serde_derive = { version = "1" }
 spideroak-base58 = { version = "0.2.0", default-features = false }
-spin = { version = "0.10", default-features = false }
+spin = { version = "0.10.1", default-features = false }
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 thiserror = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -113,6 +113,11 @@ who = "Jonathan Dygert <jdygert@spideroak.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.13 -> 0.8.16"
 
+[[audits.rkyv]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.16 -> 0.8.17"
+
 [[audits.rkyv_derive]]
 who = "Jonathan Dygert <jdygert@spideroak.com>"
 criteria = "safe-to-deploy"
@@ -122,6 +127,11 @@ delta = "0.8.11 -> 0.8.13"
 who = "Jonathan Dygert <jdygert@spideroak.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.13 -> 0.8.16"
+
+[[audits.rkyv_derive]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.16 -> 0.8.17"
 
 [[audits.rstest]]
 who = "Jonathan Dygert <jdygert@spideroak.com>"
@@ -167,6 +177,11 @@ delta = "0.3.0 -> 0.5.0"
 who = "Eric Lagergren <elagergren@spideroak.com>"
 criteria = "safe-to-deploy"
 delta = "0.9.8 -> 0.10.0"
+
+[[audits.spin]]
+who = "Jonathan Dygert <jdygert@spideroak.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.0 -> 0.10.1"
 
 [[audits.syn]]
 who = "Jonathan Dygert <jdygert@spideroak.com>"


### PR DESCRIPTION
Multiple rustsec advisories fixed in this version.

- RUSTSEC-2026-0233
- RUSTSEC-2026-0234
- RUSTSEC-2026-0235

Also update spin off a yanked version. No advisory for that one.