### PR TITLE
fix(runtime): clear pending fact writes in LinearPerspective::revert

### DIFF
--- a/crates/aranya-runtime/src/storage/linear/mod.rs
+++ b/crates/aranya-runtime/src/storage/linear/mod.rs
@@ -1128,11 +1128,16 @@ impl<R: Read> Revertable for LinearPerspective<R> {
     }
 
     fn revert(&mut self, checkpoint: Checkpoint) -> Result<(), StorageError> {
-        // No early return when `checkpoint.index == self.commands.len()`:
-        // fact writes accumulate in `facts`/`current_updates` between
-        // `add_command` calls, so the perspective can be dirty even when no
-        // command was added since the checkpoint (e.g. a rule that wrote
-        // facts and then failed). Those writes must be cleared too.
+        // Equal command count alone does not mean clean: a rule that wrote
+        // facts and then failed leaves its writes pending in
+        // `facts`/`current_updates` without having added a command. But
+        // every fact write pushes onto `current_updates`, so an empty
+        // buffer at equal command count means the fact overlay is untouched
+        // since the checkpoint and there is nothing to rebuild.
+        if checkpoint.index == self.commands.len() && self.current_updates.is_empty() {
+            return Ok(());
+        }
+
         if checkpoint.index > self.commands.len() {
             bug!(
                 "A checkpoint's index should always be less than or equal to the length of a perspective's command history!"

--- a/crates/aranya-runtime/src/storage/linear/mod.rs
+++ b/crates/aranya-runtime/src/storage/linear/mod.rs
@@ -1128,10 +1128,11 @@ impl<R: Read> Revertable for LinearPerspective<R> {
     }
 
     fn revert(&mut self, checkpoint: Checkpoint) -> Result<(), StorageError> {
-        if checkpoint.index == self.commands.len() {
-            return Ok(());
-        }
-
+        // No early return when `checkpoint.index == self.commands.len()`:
+        // fact writes accumulate in `facts`/`current_updates` between
+        // `add_command` calls, so the perspective can be dirty even when no
+        // command was added since the checkpoint (e.g. a rule that wrote
+        // facts and then failed). Those writes must be cleared too.
         if checkpoint.index > self.commands.len() {
             bug!(
                 "A checkpoint's index should always be less than or equal to the length of a perspective's command history!"

--- a/crates/aranya-runtime/src/storage/linear/mod.rs
+++ b/crates/aranya-runtime/src/storage/linear/mod.rs
@@ -1292,6 +1292,33 @@ mod test {
         }
     }
 
+    /// `revert` must restore the exact state captured by `checkpoint`.
+    ///
+    /// This mirrors how `Transaction::add_single` uses the API: the
+    /// checkpoint is taken *before* the policy rule runs, the rule may write
+    /// facts, and on rule failure `revert` is called before any
+    /// `add_command`. So at revert time `checkpoint.index == commands.len()`
+    /// always holds, and the pending fact writes must still be cleared.
+    #[test]
+    fn test_revert_clears_writes_made_after_checkpoint() {
+        let mut provider = LinearStorageProvider::new(Manager::new());
+        let mut p = provider.new_perspective(PolicyId::new(0));
+
+        let checkpoint = p.checkpoint();
+        p.insert("x".into(), Keys::default(), Bytes::from(&b"1"[..]))
+            .unwrap();
+        p.revert(checkpoint).unwrap();
+
+        assert!(
+            p.query("x", &[]).unwrap().is_none(),
+            "revert must clear fact writes made after the checkpoint"
+        );
+        assert!(
+            p.current_updates.is_empty(),
+            "revert must clear pending updates made after the checkpoint"
+        );
+    }
+
     struct LinearBackend;
     impl StorageBackend for LinearBackend {
         type StorageProvider = LinearStorageProvider<Manager>;

--- a/crates/aranya-runtime/src/testing/dsl.rs
+++ b/crates/aranya-runtime/src/testing/dsl.rs
@@ -67,13 +67,14 @@ use tracing::{debug, error};
 
 use crate::{
     Address, Bytes, COMMAND_RESPONSE_MAX, ClientError, ClientState, CmdId, Command as _,
-    CommandExt as _, GraphId, Keys, Location, MAX_SYNC_MESSAGE_SIZE, MaxCut, MemSpill, PeerCache,
+    CommandExt as _, GraphId, Keys, Location, MAX_COMMAND_LENGTH, MAX_SYNC_MESSAGE_SIZE, MaxCut,
+    MemSpill, PeerCache,
     PolicyError, Prior, Query as _, RuntimeBuffers, Segment as _, Storage, StorageError,
     StorageProvider, SyncError, SyncHello, SyncIncoming, SyncRequester, SyncResponder, Transaction,
     TraversalBuffer, TraversalBuffers,
     sync::wire::{SyncHelloType, SyncType},
     testing::{
-        protocol::{TestActions, TestEffect, TestPolicyStore, TestSink},
+        protocol::{TestActions, TestEffect, TestPolicy, TestPolicyStore, TestSink},
         short_b58,
     },
 };
@@ -447,6 +448,23 @@ pub enum TestRule {
         #[serde(default)]
         priority: u32,
     },
+    /// Ingests a command whose rule writes `payload[poison_key] =
+    /// poison_value` and then fails, asserts the runtime rejects it, then
+    /// adds a valid basic command setting `payload[key] = value` in the
+    /// same transaction and commits.
+    ///
+    /// Models a caller that keeps using a transaction after a per-command
+    /// policy failure, which the `Transaction` API permits: the failed
+    /// rule's writes are reverted, so nothing from the rejected command may
+    /// reach committed fact state.
+    IngestPoisonThenSet {
+        client: u64,
+        graph: u64,
+        poison_key: u64,
+        poison_value: u64,
+        key: u64,
+        value: u64,
+    },
     CompareGraphs {
         clienta: u64,
         clientb: u64,
@@ -605,6 +623,18 @@ impl Display for TestRule {
                 f,
                 r#"{{"ActionNoOp": {{ "graph": {}, "client": {}, "nonce": {}, "priority": {} }} }},"#,
                 graph, client, nonce, priority,
+            ),
+            Self::IngestPoisonThenSet {
+                client,
+                graph,
+                poison_key,
+                poison_value,
+                key,
+                value,
+            } => write!(
+                f,
+                r#"{{"IngestPoisonThenSet": {{ "client": {}, "graph": {}, "poison_key": {}, "poison_value": {}, "key": {}, "value": {} }} }},"#,
+                client, graph, poison_key, poison_value, key, value,
             ),
             Self::AddClient { id } => write!(f, r#"{{"AddClient": {{ "id": {} }} }},"#, id),
             Self::AddExpectation(value) => write!(f, r#"{{"AddExpectation": {} }},"#, value),
@@ -1505,6 +1535,71 @@ where
                 }
             }
 
+            TestRule::IngestPoisonThenSet {
+                client,
+                graph,
+                poison_key,
+                poison_value,
+                key,
+                value,
+            } => {
+                let state = clients
+                    .get_mut(&client)
+                    .ok_or(TestError::MissingClient)?
+                    .get_mut();
+                let graph_id = *graphs.get(&graph).ok_or(TestError::MissingGraph(graph))?;
+
+                // Both commands extend the current head, like a batch synced
+                // from a peer would.
+                let parent = {
+                    let storage = state.provider().get_storage(graph_id)?;
+                    let heads = storage.get_heads()?;
+                    assert_eq!(
+                        1,
+                        heads.len(),
+                        "IngestPoisonThenSet requires a single-head graph"
+                    );
+                    heads.as_slice()[0].address()
+                };
+                let policy = TestPolicy::new(0);
+
+                let mut trx = state.transaction(graph_id);
+
+                // The poison command's rule writes a fact and then fails, so
+                // the runtime must reject the command and revert the write.
+                let mut buffer = [0u8; MAX_COMMAND_LENGTH];
+                let poison =
+                    policy.poison(buffer.as_mut_slice(), parent, (poison_key, poison_value), 0)?;
+                let result = state.add_commands(
+                    &mut trx,
+                    &mut sink,
+                    core::slice::from_ref(&poison),
+                    &mut rt_buffers,
+                    MemSpill::new,
+                );
+                assert!(
+                    matches!(
+                        result,
+                        Err(ClientError::PolicyError(PolicyError::Rejected))
+                    ),
+                    "poison command must be rejected, got {result:?}"
+                );
+
+                // The transaction remains usable after a rejected command;
+                // the next command must not observe (or absorb into its own
+                // persisted updates) the rejected command's fact write.
+                let mut buffer = [0u8; MAX_COMMAND_LENGTH];
+                let cmd = policy.basic(buffer.as_mut_slice(), parent, (key, value), 0)?;
+                let added = state.add_commands(
+                    &mut trx,
+                    &mut sink,
+                    core::slice::from_ref(&cmd),
+                    &mut rt_buffers,
+                    MemSpill::new,
+                )?;
+                assert_eq!(1, added);
+                state.commit(trx, &mut sink, &mut rt_buffers, MemSpill::new)?;
+            }
             TestRule::PrintGraph { client, graph } => {
                 let state = clients
                     .get_mut(&client)
@@ -2277,6 +2372,7 @@ test_vectors! {
     hello_sync_extended_head,
     hello_sync_multiple_heads,
     no_such_parent,
+    rejected_command_fact_leak,
     exponential_traversal_regression,
     find_needed_segments_queue_max,
     four_seventy_three_failure,

--- a/crates/aranya-runtime/src/testing/dsl.rs
+++ b/crates/aranya-runtime/src/testing/dsl.rs
@@ -68,10 +68,9 @@ use tracing::{debug, error};
 use crate::{
     Address, Bytes, COMMAND_RESPONSE_MAX, ClientError, ClientState, CmdId, Command as _,
     CommandExt as _, GraphId, Keys, Location, MAX_COMMAND_LENGTH, MAX_SYNC_MESSAGE_SIZE, MaxCut,
-    MemSpill, PeerCache,
-    PolicyError, Prior, Query as _, RuntimeBuffers, Segment as _, Storage, StorageError,
-    StorageProvider, SyncError, SyncHello, SyncIncoming, SyncRequester, SyncResponder, Transaction,
-    TraversalBuffer, TraversalBuffers,
+    MemSpill, PeerCache, PolicyError, Prior, Query as _, RuntimeBuffers, Segment as _, Storage,
+    StorageError, StorageProvider, SyncError, SyncHello, SyncIncoming, SyncRequester,
+    SyncResponder, Transaction, TraversalBuffer, TraversalBuffers,
     sync::wire::{SyncHelloType, SyncType},
     testing::{
         protocol::{TestActions, TestEffect, TestPolicy, TestPolicyStore, TestSink},
@@ -1578,10 +1577,7 @@ where
                     MemSpill::new,
                 );
                 assert!(
-                    matches!(
-                        result,
-                        Err(ClientError::PolicyError(PolicyError::Rejected))
-                    ),
+                    matches!(result, Err(ClientError::PolicyError(PolicyError::Rejected))),
                     "poison command must be rejected, got {result:?}"
                 );
 

--- a/crates/aranya-runtime/src/testing/protocol.rs
+++ b/crates/aranya-runtime/src/testing/protocol.rs
@@ -52,6 +52,12 @@ pub enum WireProtocol {
     Basic(WireBasic),
     Delete(WireDelete),
     NoOp(WireNoOp),
+    /// A command whose rule writes its payload fact and then fails.
+    ///
+    /// Models a write-then-fail rule (e.g. a VM policy `finish` block that
+    /// inserts a fact and then errors partway through): the runtime must
+    /// revert the write when it rejects the command.
+    Poison(WireBasic),
 }
 
 #[derive(Debug, Clone)]
@@ -69,6 +75,7 @@ impl Command for TestProtocol<'_> {
             WireProtocol::Basic(m) => Priority::Basic(m.prority),
             WireProtocol::Delete(m) => Priority::Basic(m.prority),
             WireProtocol::NoOp(m) => Priority::Basic(m.prority),
+            WireProtocol::Poison(m) => Priority::Basic(m.prority),
         }
     }
 
@@ -83,6 +90,7 @@ impl Command for TestProtocol<'_> {
             WireProtocol::Merge(m) => Prior::Merge(m.left, m.right),
             WireProtocol::Delete(m) => Prior::Single(m.parent),
             WireProtocol::NoOp(m) => Prior::Single(m.parent),
+            WireProtocol::Poison(m) => Prior::Single(m.parent),
         }
     }
 
@@ -93,6 +101,7 @@ impl Command for TestProtocol<'_> {
             WireProtocol::Basic(_) => None,
             WireProtocol::Delete(_) => None,
             WireProtocol::NoOp(_) => None,
+            WireProtocol::Poison(_) => None,
         }
     }
 
@@ -179,6 +188,12 @@ impl TestPolicy {
                     .delete("payload".into(), Keys::from_iter([key]))
                     .map_err(|_| PolicyError::Write)?;
             }
+            WireProtocol::Poison(m) => {
+                // Write-then-fail: the fact write lands before the rule
+                // rejects, so the caller's revert must clear it.
+                self.origin_check_message(m, facts)?;
+                return Err(PolicyError::Rejected);
+            }
             WireProtocol::Init(_) | WireProtocol::Merge(_) | WireProtocol::NoOp(_) => {}
         }
 
@@ -198,7 +213,7 @@ impl TestPolicy {
         Ok(TestProtocol { id, command, data })
     }
 
-    fn basic<'a>(
+    pub(crate) fn basic<'a>(
         &self,
         target: &'a mut [u8],
         parent: Address,
@@ -212,6 +227,32 @@ impl TestPolicy {
         };
 
         let command = WireProtocol::Basic(message);
+        let data = write(target, &command)?;
+        let id = hash_for_testing_only(data);
+
+        Ok(TestProtocol { id, command, data })
+    }
+
+    /// Builds a [`WireProtocol::Poison`] command: its rule writes
+    /// `payload` under the `"payload"` fact name and then rejects.
+    ///
+    /// There is deliberately no [`TestActions`] variant for this: an action
+    /// whose rule fails never produces a command, so a poison command can
+    /// only arrive on the ingest path (as if from a peer).
+    pub(crate) fn poison<'a>(
+        &self,
+        target: &'a mut [u8],
+        parent: Address,
+        payload: (u64, u64),
+        priority: u32,
+    ) -> Result<TestProtocol<'a>, PolicyError> {
+        let message = WireBasic {
+            parent,
+            prority: priority,
+            payload,
+        };
+
+        let command = WireProtocol::Poison(message);
         let data = write(target, &command)?;
         let id = hash_for_testing_only(data);
 

--- a/crates/aranya-runtime/src/testing/testdata/rejected_command_fact_leak.test
+++ b/crates/aranya-runtime/src/testing/testdata/rejected_command_fact_leak.test
@@ -1,0 +1,50 @@
+[
+  {
+    "AddClient": {
+      "id": 0
+    }
+  },
+  {
+    "AddClient": {
+      "id": 1
+    }
+  },
+  {
+    "NewGraph": {
+      "client": 0,
+      "id": 0,
+      "policy": 0
+    }
+  },
+  {
+    "IgnoreExpectations": {
+      "ignore": true
+    }
+  },
+  {
+    "IngestPoisonThenSet": {
+      "client": 0,
+      "graph": 0,
+      "poison_key": 9,
+      "poison_value": 99,
+      "key": 2,
+      "value": 20
+    }
+  },
+  {
+    "Sync": {
+      "graph": 0,
+      "client": 1,
+      "from": 0,
+      "max_syncs": 1
+    }
+  },
+  {
+    "CompareGraphs": {
+      "clienta": 0,
+      "clientb": 1,
+      "graph": 0,
+      "equal": true
+    }
+  }
+]


### PR DESCRIPTION
`LinearPerspective::revert` early-returned when `checkpoint.index == self.commands.len()`, treating "no commands added since the checkpoint" as "nothing to revert". But fact writes accumulate in the perspective's overlay map and `current_updates` buffer *while a rule executes*, and are only attributed to a command by `add_command` afterwards — so the perspective can be dirty at equal index. `Transaction::add_single` hits exactly that state on every rule failure (checkpoint before the rule, revert on error, `add_command` never runs), meaning the early return made `revert` a no-op on the one path that depends on it.

The consequence of a rule that writes facts and then fails — the shape a VM policy produces whenever a `finish` block errors partway, since `VmPolicyIO` writes into the perspective unbuffered per instruction — is twofold:

1. **Phantom facts:** the rejected command's writes stay visible to every subsequent policy evaluation in the same transaction, so commands that should be rejected can be accepted.
2. **Silent fact divergence:** the next successful `add_command` does `mem::take(&mut current_updates)`, absorbing the leaked writes into *its own* persisted `CommandData.updates`. A peer reconstructing facts mid-segment from stored updates then computes different fact state than a peer that evaluated the same commands in a clean transaction — at an identical graph head, so graph-equality convergence checks stay green while fact state forks permanently.

The fix drops the early return: the equal-index case now falls through to the same rebuild the truncating path already used (clear the overlay and `current_updates`, replay the remaining commands' updates). `revert` is only called on failure paths, so the replay adds no hot-path cost. `SessionPerspective::revert` keeps its analogous-looking early return deliberately — its checkpoint indexes the fact log itself (write granularity), so equal index there genuinely means nothing was written.

Reproduced at two levels, committed failing-first so each is verified against the broken behavior:

- `test_revert_clears_writes_made_after_checkpoint` — minimal `Revertable` contract test mirroring the `add_single` call pattern (checkpoint → insert → revert, no `add_command`).
- `rejected_command_fact_leak` DSL vector — end-to-end divergence: adds a `Poison` test command whose rule writes its fact and then rejects, plus an `IngestPoisonThenSet` DSL rule that ingests it, asserts the rejection, then commits a valid command in the same transaction (modeling a caller that tolerates per-command errors, which the API permits). Before the fix, the ingesting peer committed the rejected command's write while a cleanly-synced peer at the identical head did not, failing `CompareGraphs`' fact-cache check with `payload[9]=99` vs. absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
