### PR TITLE
chore: release 2026-08-25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aranya-afc-util"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "aranya-afc-util",
  "aranya-crypto",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-capi-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "aranya-capi-macro",
  "aranya-libc",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-core"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "aranya-crypto",
  "aranya-id",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-crypto"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "aranya-crypto",
  "aranya-id",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-crypto-ffi"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "aranya-crypto",
  "aranya-crypto-ffi",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-device-ffi"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-envelope-ffi"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-fast-channels"
-version = "0.19.3"
+version = "0.20.0"
 dependencies = [
  "aranya-crypto",
  "aranya-fast-channels",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-id"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "ctutils",
  "derive-where",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-idam-ffi"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "aranya-crypto",
  "aranya-idam-ffi",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-libc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cfg-if",
  "errno",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-perspective-ffi"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "aranya-crypto",
  "aranya-policy-vm",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ast"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aranya-policy-text",
  "rkyv",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-compiler"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-derive"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "aranya-policy-lang",
  "prettyplease",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "aranya-core",
  "aranya-policy-compiler",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen-build"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "aranya-policy-ast",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen-macro"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-lang"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-module"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "aranya-policy-ast",
  "fnv",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-text"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aranya-policy-text-macro",
  "proptest",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-vm"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "aranya-crypto",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-runtime"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "aranya-crypto",
  "aranya-libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "aranya-policy-ifgen-macro"
-version = "0.9.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/aranya-afc-util/CHANGELOG.md
+++ b/crates/aranya-afc-util/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0](https://github.com/aranya-project/aranya-core/compare/aranya-afc-util-v0.25.0...aranya-afc-util-v0.26.0) - 2026-08-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.25.0](https://github.com/aranya-project/aranya-core/compare/aranya-afc-util-v0.24.0...aranya-afc-util-v0.25.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-afc-util/Cargo.toml
+++ b/crates/aranya-afc-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-afc-util"
 description = "Utilities for using Aranya Fast Channels"
-version = "0.25.0"
+version = "0.26.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -40,9 +40,9 @@ testing = [
 ]
 
 [dependencies]
-aranya-crypto = { version = "0.14.1", path = "../aranya-crypto", default-features = false, features = ["alloc", "afc"] }
-aranya-fast-channels = { version = "0.19.3", path = "../aranya-fast-channels", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.23.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.15.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "afc"] }
+aranya-fast-channels = { version = "0.20.0", path = "../aranya-fast-channels", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.24.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 buggy = { version = "0.1.0", default-features = false }
 postcard = { workspace = true, default-features = false, features = ["alloc"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }

--- a/crates/aranya-capi-core/CHANGELOG.md
+++ b/crates/aranya-capi-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/aranya-project/aranya-core/compare/aranya-capi-core-v0.8.1...aranya-capi-core-v0.8.2) - 2026-08-25
+
+### Other
+
+- updated the following local packages: aranya-libc
+
 ## [0.8.1](https://github.com/aranya-project/aranya-core/compare/aranya-capi-core-v0.8.0...aranya-capi-core-v0.8.1) - 2026-03-17
 
 ### Other

--- a/crates/aranya-capi-core/Cargo.toml
+++ b/crates/aranya-capi-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-capi-core"
 description = "Aranya's C API tooling"
-version = "0.8.1"
+version = "0.8.2"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -32,7 +32,7 @@ std = [
 
 [dependencies]
 aranya-capi-macro = { version = "0.7.1", path = "../aranya-capi-macro", default-features = false }
-aranya-libc = { version = "0.4.0", path = "../aranya-libc", default-features = false }
+aranya-libc = { version = "0.4.1", path = "../aranya-libc", default-features = false }
 buggy = { version = "0.1.0", default-features = false }
 
 cfg-if = { workspace = true, default-features = false }

--- a/crates/aranya-core/CHANGELOG.md
+++ b/crates/aranya-core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/aranya-project/aranya-core/compare/aranya-core-v1.1.0...aranya-core-v2.0.0) - 2026-08-25
+
+### Other
+
+- update crypto dependencies ([#762](https://github.com/aranya-project/aranya-core/pull/762))
+- derive max cut from parents always ([#742](https://github.com/aranya-project/aranya-core/pull/742))
+
 ## [1.1.0](https://github.com/aranya-project/aranya-core/compare/aranya-core-v1.0.0...aranya-core-v1.1.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-core/Cargo.toml
+++ b/crates/aranya-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-core"
 description = "Stable public API for the Aranya runtime"
-version = "1.1.0"
+version = "2.0.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -12,10 +12,10 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aranya-crypto = { version = "0.14.1", path = "../aranya-crypto", default-features = false }
-aranya-id = { version = "0.2.2", path = "../aranya-id", default-features = false }
-aranya-policy-ifgen = { version = "0.24.0", path = "../aranya-policy-ifgen", features = ["serde"] }
-aranya-runtime = { version = "0.24.0", path = "../aranya-runtime", default-features = false }
+aranya-crypto = { version = "0.15.0", path = "../aranya-crypto", default-features = false }
+aranya-id = { version = "0.3.0", path = "../aranya-id", default-features = false }
+aranya-policy-ifgen = { version = "0.25.0", path = "../aranya-policy-ifgen", features = ["serde"] }
+aranya-runtime = { version = "0.25.0", path = "../aranya-runtime", default-features = false }
 
 [features]
 default = []

--- a/crates/aranya-crypto-ffi/CHANGELOG.md
+++ b/crates/aranya-crypto-ffi/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-ffi-v0.23.0...aranya-crypto-ffi-v0.24.0) - 2026-08-25
+
+### Other
+
+- update crypto dependencies ([#762](https://github.com/aranya-project/aranya-core/pull/762))
+- accept option key input ([#750](https://github.com/aranya-project/aranya-core/pull/750))
+- bypass open in braid ([#738](https://github.com/aranya-project/aranya-core/pull/738))
+
 ## [0.23.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-ffi-v0.22.0...aranya-crypto-ffi-v0.23.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-crypto-ffi/Cargo.toml
+++ b/crates/aranya-crypto-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-crypto-ffi"
 description = "The crypto FFI for Aranya Policy"
-version = "0.23.0"
+version = "0.24.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -43,8 +43,8 @@ testing = [
 ]
 
 [dependencies]
-aranya-crypto = { version = "0.14.1", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.23.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.15.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.24.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 postcard = { workspace = true, default-features = false, features = ["alloc"] }
 serde = { workspace = true, default-features = false, features = ["derive"], optional = true }

--- a/crates/aranya-crypto/CHANGELOG.md
+++ b/crates/aranya-crypto/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-v0.14.1...aranya-crypto-v0.15.0) - 2026-08-25
+
+### Other
+
+- update crypto dependencies ([#762](https://github.com/aranya-project/aranya-core/pull/762))
+- add tests to aranya-crypto for additional branch coverage ([#715](https://github.com/aranya-project/aranya-core/pull/715))
+
 ## [0.14.1](https://github.com/aranya-project/aranya-core/compare/aranya-crypto-v0.14.0...aranya-crypto-v0.14.1) - 2026-05-22
 
 ### Other

--- a/crates/aranya-crypto/Cargo.toml
+++ b/crates/aranya-crypto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-crypto"
 description = "The Aranya Cryptography Engine"
-version = "0.14.1"
+version = "0.15.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -136,7 +136,7 @@ tls = []
 trng = ["spideroak-crypto/trng"]
 
 [dependencies]
-aranya-id = { version = "0.2.2", path = "../aranya-id", default-features = false }
+aranya-id = { version = "0.3.0", path = "../aranya-id", default-features = false }
 
 buggy = { version = "0.1.0", default-features = false }
 spideroak-base58 = { workspace = true, default-features = false }

--- a/crates/aranya-device-ffi/CHANGELOG.md
+++ b/crates/aranya-device-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/aranya-project/aranya-core/compare/aranya-device-ffi-v0.23.0...aranya-device-ffi-v0.24.0) - 2026-08-25
+
+### Other
+
+- updated the following local packages: aranya-crypto, aranya-policy-vm
+
 ## [0.23.0](https://github.com/aranya-project/aranya-core/compare/aranya-device-ffi-v0.22.0...aranya-device-ffi-v0.23.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-device-ffi/Cargo.toml
+++ b/crates/aranya-device-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-device-ffi"
 description = "The device FFI for Aranya Policy"
-version = "0.23.0"
+version = "0.24.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -24,8 +24,8 @@ std = ["alloc"]
 testing = []
 
 [dependencies]
-aranya-crypto = { version = "0.14.1", path = "../aranya-crypto", default-features = false }
-aranya-policy-vm = { version = "0.23.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.15.0", path = "../aranya-crypto", default-features = false }
+aranya-policy-vm = { version = "0.24.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 aranya-crypto = { path = "../aranya-crypto", features = ["getrandom"] }

--- a/crates/aranya-envelope-ffi/CHANGELOG.md
+++ b/crates/aranya-envelope-ffi/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/aranya-project/aranya-core/compare/aranya-envelope-ffi-v0.23.0...aranya-envelope-ffi-v0.24.0) - 2026-08-25
+
+### Other
+
+- accept option key input ([#750](https://github.com/aranya-project/aranya-core/pull/750))
+- bypass open in braid ([#738](https://github.com/aranya-project/aranya-core/pull/738))
+
 ## [0.23.0](https://github.com/aranya-project/aranya-core/compare/aranya-envelope-ffi-v0.22.0...aranya-envelope-ffi-v0.23.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-envelope-ffi/Cargo.toml
+++ b/crates/aranya-envelope-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-envelope-ffi"
 description = "The envelope FFI for Aranya Policy"
-version = "0.23.0"
+version = "0.24.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -28,8 +28,8 @@ std = [
 ]
 
 [dependencies]
-aranya-crypto = { version = "0.14.1", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.23.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.15.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.24.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/aranya-fast-channels/CHANGELOG.md
+++ b/crates/aranya-fast-channels/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0](https://github.com/aranya-project/aranya-core/compare/aranya-fast-channels-v0.19.3...aranya-fast-channels-v0.20.0) - 2026-08-25
+
+### Other
+
+- update crypto dependencies ([#762](https://github.com/aranya-project/aranya-core/pull/762))
+
 ## [0.19.3](https://github.com/aranya-project/aranya-core/compare/aranya-fast-channels-v0.19.2...aranya-fast-channels-v0.19.3) - 2026-07-09
 
 ### Other

--- a/crates/aranya-fast-channels/Cargo.toml
+++ b/crates/aranya-fast-channels/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-fast-channels"
 description = "High throughput, low latency encryption protected by Aranya Policy"
-version = "0.19.3"
+version = "0.20.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -90,7 +90,7 @@ try_find = []
 
 
 [dependencies]
-aranya-crypto = { version = "0.14.1", path = "../aranya-crypto", default-features = false, features = ["afc", "getrandom"] }
+aranya-crypto = { version = "0.15.0", path = "../aranya-crypto", default-features = false, features = ["afc", "getrandom"] }
 buggy = { version = "0.1.0", default-features = false }
 
 cfg-if = { workspace = true }

--- a/crates/aranya-id/CHANGELOG.md
+++ b/crates/aranya-id/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/aranya-project/aranya-core/compare/aranya-id-v0.2.2...aranya-id-v0.3.0) - 2026-08-25
+
+### Other
+
+- update crypto dependencies ([#762](https://github.com/aranya-project/aranya-core/pull/762))
+
 ## [0.2.2](https://github.com/aranya-project/aranya-core/compare/aranya-id-v0.2.1...aranya-id-v0.2.2) - 2026-03-17
 
 ### Other

--- a/crates/aranya-id/Cargo.toml
+++ b/crates/aranya-id/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aranya-id"
 description = "Aranya ID types"
 publish = true
-version = "0.2.2"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-idam-ffi/CHANGELOG.md
+++ b/crates/aranya-idam-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/aranya-project/aranya-core/compare/aranya-idam-ffi-v0.23.0...aranya-idam-ffi-v0.24.0) - 2026-08-25
+
+### Other
+
+- update crypto dependencies ([#762](https://github.com/aranya-project/aranya-core/pull/762))
+
 ## [0.23.0](https://github.com/aranya-project/aranya-core/compare/aranya-idam-ffi-v0.22.0...aranya-idam-ffi-v0.23.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-idam-ffi/Cargo.toml
+++ b/crates/aranya-idam-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-idam-ffi"
 description = "The IDAM FFI for Aranya Policy"
-version = "0.23.0"
+version = "0.24.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -35,8 +35,8 @@ testing = [
 ]
 
 [dependencies]
-aranya-crypto = { version = "0.14.1", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
-aranya-policy-vm = { version = "0.23.0", path = "../aranya-policy-vm", features = ["derive"] }
+aranya-crypto = { version = "0.15.0", path = "../aranya-crypto", default-features = false, features = ["alloc"] }
+aranya-policy-vm = { version = "0.24.0", path = "../aranya-policy-vm", features = ["derive"] }
 postcard = { workspace = true, default-features = false, features = ["alloc"] }
 # For `custom_id!`
 serde = { workspace = true, default-features = false }

--- a/crates/aranya-libc/CHANGELOG.md
+++ b/crates/aranya-libc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/aranya-project/aranya-core/compare/aranya-libc-v0.4.0...aranya-libc-v0.4.1) - 2026-08-25
+
+### Other
+
+- Optimize fsync ([#717](https://github.com/aranya-project/aranya-core/pull/717))
+- fix gates for android builds ([#749](https://github.com/aranya-project/aranya-core/pull/749))
+
 ## [0.4.0](https://github.com/aranya-project/aranya-core/compare/aranya-libc-v0.3.2...aranya-libc-v0.4.0) - 2025-10-16
 
 ### Other

--- a/crates/aranya-libc/Cargo.toml
+++ b/crates/aranya-libc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-libc"
 description = "A wrapper around parts of libc for Aranya Core"
-version = "0.4.0"
+version = "0.4.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-perspective-ffi/CHANGELOG.md
+++ b/crates/aranya-perspective-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/aranya-project/aranya-core/compare/aranya-perspective-ffi-v0.23.0...aranya-perspective-ffi-v0.24.0) - 2026-08-25
+
+### Other
+
+- updated the following local packages: aranya-crypto, aranya-policy-vm
+
 ## [0.23.0](https://github.com/aranya-project/aranya-core/compare/aranya-perspective-ffi-v0.22.0...aranya-perspective-ffi-v0.23.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-perspective-ffi/Cargo.toml
+++ b/crates/aranya-perspective-ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-perspective-ffi"
 description = "The perspective FFI for Aranya Policy"
-version = "0.23.0"
+version = "0.24.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -26,8 +26,8 @@ std = []
 testing = []
 
 [dependencies]
-aranya-crypto = { version = "0.14.1", path = "../aranya-crypto", default-features = false }
-aranya-policy-vm = { version = "0.23.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
+aranya-crypto = { version = "0.15.0", path = "../aranya-crypto", default-features = false }
+aranya-policy-vm = { version = "0.24.0", path = "../aranya-policy-vm", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 aranya-crypto = { path = "../aranya-crypto", features = ["getrandom"] }

--- a/crates/aranya-policy-ast/CHANGELOG.md
+++ b/crates/aranya-policy-ast/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ast-v0.15.0...aranya-policy-ast-v0.16.0) - 2026-08-25
+
+### Other
+
+- 707 remove unwrap ([#736](https://github.com/aranya-project/aranya-core/pull/736))
+- bypass open in braid ([#738](https://github.com/aranya-project/aranya-core/pull/738))
+- Close #705: Actions can return results ([#706](https://github.com/aranya-project/aranya-core/pull/706))
+
 ## [0.15.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ast-v0.14.0...aranya-policy-ast-v0.15.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-policy-ast/Cargo.toml
+++ b/crates/aranya-policy-ast/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ast"
 description = "The Aranya Policy Language AST"
-version = "0.15.0"
+version = "0.16.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -29,7 +29,7 @@ proptest = [
 
 
 [dependencies]
-aranya-policy-text = { version = "0.1.4", path = "../aranya-policy-text", default-features = false }
+aranya-policy-text = { version = "0.1.5", path = "../aranya-policy-text", default-features = false }
 
 rkyv = { workspace = true, features = ["alloc"] }
 serde = { workspace = true, default-features = false, features = ["alloc"] }

--- a/crates/aranya-policy-compiler/CHANGELOG.md
+++ b/crates/aranya-policy-compiler/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-compiler-v0.24.0...aranya-policy-compiler-v0.25.0) - 2026-08-25
+
+### Other
+
+- 707 remove unwrap ([#736](https://github.com/aranya-project/aranya-core/pull/736))
+- Remove vm span dependency ([#726](https://github.com/aranya-project/aranya-core/pull/726))
+- bypass open in braid ([#738](https://github.com/aranya-project/aranya-core/pull/738))
+- Close #661: Implement `Some(ident)` pattern matching. ([#712](https://github.com/aranya-project/aranya-core/pull/712))
+- Close #705: Actions can return results ([#706](https://github.com/aranya-project/aranya-core/pull/706))
+
 ## [0.24.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-compiler-v0.23.0...aranya-policy-compiler-v0.24.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-policy-compiler/Cargo.toml
+++ b/crates/aranya-policy-compiler/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-compiler"
 description = "The Aranya Policy Compiler"
-version = "0.24.0"
+version = "0.25.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -15,9 +15,9 @@ workspace = true
 default = []
 
 [dependencies]
-aranya-policy-ast = { version = "0.15.0", path = "../aranya-policy-ast" }
-aranya-policy-lang = { version = "0.16.0", path = "../aranya-policy-lang" }
-aranya-policy-module = { version = "0.22.0", path = "../aranya-policy-module", features = ["std"] }
+aranya-policy-ast = { version = "0.16.0", path = "../aranya-policy-ast" }
+aranya-policy-lang = { version = "0.17.0", path = "../aranya-policy-lang" }
+aranya-policy-module = { version = "0.23.0", path = "../aranya-policy-module", features = ["std"] }
 buggy = { version = "0.1.0", features = ["std"] }
 
 annotate-snippets = { workspace = true }

--- a/crates/aranya-policy-derive/CHANGELOG.md
+++ b/crates/aranya-policy-derive/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-derive-v0.17.0...aranya-policy-derive-v0.18.0) - 2026-08-25
+
+### Other
+
+- updated the following local packages: aranya-policy-lang
+
 ## [0.17.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-derive-v0.16.0...aranya-policy-derive-v0.17.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-policy-derive/Cargo.toml
+++ b/crates/aranya-policy-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-derive"
 description = "Proc macros for generating Aranya Policy Language FFIs"
-version = "0.17.0"
+version = "0.18.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ proc-macro = true
 default = []
 
 [dependencies]
-aranya-policy-lang = { version = "0.16.0", path = "../aranya-policy-lang" }
+aranya-policy-lang = { version = "0.17.0", path = "../aranya-policy-lang" }
 
 prettyplease = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/crates/aranya-policy-ifgen-build/CHANGELOG.md
+++ b/crates/aranya-policy-ifgen-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-build-v0.17.0...aranya-policy-ifgen-build-v0.18.0) - 2026-08-25
+
+### Other
+
+- Remove vm span dependency ([#726](https://github.com/aranya-project/aranya-core/pull/726))
+
 ## [0.17.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-build-v0.16.0...aranya-policy-ifgen-build-v0.17.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-policy-ifgen-build/Cargo.toml
+++ b/crates/aranya-policy-ifgen-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ifgen-build"
 description = "Code generator for aranya-policy-ifgen"
-version = "0.17.0"
+version = "0.18.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -12,10 +12,10 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-aranya-policy-ast = { version = "0.15.0", path = "../aranya-policy-ast" }
-aranya-policy-compiler = { version = "0.24.0", path = "../aranya-policy-compiler" }
-aranya-policy-lang = { version = "0.16.0", path = "../aranya-policy-lang" }
-aranya-policy-module = { version = "0.22.0", path = "../aranya-policy-module" }
+aranya-policy-ast = { version = "0.16.0", path = "../aranya-policy-ast" }
+aranya-policy-compiler = { version = "0.25.0", path = "../aranya-policy-compiler" }
+aranya-policy-lang = { version = "0.17.0", path = "../aranya-policy-lang" }
+aranya-policy-module = { version = "0.23.0", path = "../aranya-policy-module" }
 
 anyhow = { workspace = true }
 prettyplease = { workspace = true }

--- a/crates/aranya-policy-ifgen-macro/CHANGELOG.md
+++ b/crates/aranya-policy-ifgen-macro/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-macro-v0.7.0...aranya-policy-ifgen-macro-v0.8.0) - 2026-05-22
+## [0.9.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-macro-v0.7.0...aranya-policy-ifgen-macro-v0.9.0) - 2026-05-22
 
 ### Other
 

--- a/crates/aranya-policy-ifgen-macro/CHANGELOG.md
+++ b/crates/aranya-policy-ifgen-macro/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.9.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-macro-v0.7.0...aranya-policy-ifgen-macro-v0.9.0) - 2026-05-22
+## [0.8.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-macro-v0.7.0...aranya-policy-ifgen-macro-v0.8.0) - 2026-05-22
 
 ### Other
 

--- a/crates/aranya-policy-ifgen-macro/Cargo.toml
+++ b/crates/aranya-policy-ifgen-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ifgen-macro"
 description = "Proc macros for aranya-policy-ifgen"
-version = "0.8.0"
+version = "0.9.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-policy-ifgen-macro/Cargo.toml
+++ b/crates/aranya-policy-ifgen-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ifgen-macro"
 description = "Proc macros for aranya-policy-ifgen"
-version = "0.9.0"
+version = "0.8.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-policy-ifgen/CHANGELOG.md
+++ b/crates/aranya-policy-ifgen/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.24.0...aranya-policy-ifgen-v0.25.0) - 2026-08-25
+
+### Other
+
+- updated the following local packages: aranya-policy-vm, aranya-runtime
+
 ## [0.24.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-ifgen-v0.23.0...aranya-policy-ifgen-v0.24.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-policy-ifgen/Cargo.toml
+++ b/crates/aranya-policy-ifgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-ifgen"
 description = "Tools for generating Rust interfaces to Aranya Policies"
-version = "0.24.0"
+version = "0.25.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -18,9 +18,9 @@ serde = [
 ]
 
 [dependencies]
-aranya-policy-ifgen-macro = { version = "0.8.0", path = "../aranya-policy-ifgen-macro" }
-aranya-policy-vm = { version = "0.23.0", path = "../aranya-policy-vm" }
-aranya-runtime = { version = "0.24.0", path = "../aranya-runtime" }
+aranya-policy-ifgen-macro = { version = "0.9.0", path = "../aranya-policy-ifgen-macro" }
+aranya-policy-vm = { version = "0.24.0", path = "../aranya-policy-vm" }
+aranya-runtime = { version = "0.25.0", path = "../aranya-runtime" }
 
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/crates/aranya-policy-ifgen/Cargo.toml
+++ b/crates/aranya-policy-ifgen/Cargo.toml
@@ -18,7 +18,7 @@ serde = [
 ]
 
 [dependencies]
-aranya-policy-ifgen-macro = { version = "0.9.0", path = "../aranya-policy-ifgen-macro" }
+aranya-policy-ifgen-macro = { version = "0.8.0", path = "../aranya-policy-ifgen-macro" }
 aranya-policy-vm = { version = "0.24.0", path = "../aranya-policy-vm" }
 aranya-runtime = { version = "0.25.0", path = "../aranya-runtime" }
 

--- a/crates/aranya-policy-lang/CHANGELOG.md
+++ b/crates/aranya-policy-lang/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-lang-v0.16.0...aranya-policy-lang-v0.17.0) - 2026-08-25
+
+### Other
+
+- 707 remove unwrap ([#736](https://github.com/aranya-project/aranya-core/pull/736))
+- bypass open in braid ([#738](https://github.com/aranya-project/aranya-core/pull/738))
+- Close #705: Actions can return results ([#706](https://github.com/aranya-project/aranya-core/pull/706))
+
 ## [0.16.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-lang-v0.15.0...aranya-policy-lang-v0.16.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-policy-lang/Cargo.toml
+++ b/crates/aranya-policy-lang/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-lang"
 description = "The Aranya Policy Language parser"
-version = "0.16.0"
+version = "0.17.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -18,7 +18,7 @@ default = []
 buggy = { version = "0.1.0", features = ["std"] }
 # `std` is required because bin/parser-explorer uses `clap` which
 # requires it for arg parsing.
-aranya-policy-ast = { version = "0.15.0", path = "../aranya-policy-ast", features = ["std"] }
+aranya-policy-ast = { version = "0.16.0", path = "../aranya-policy-ast", features = ["std"] }
 
 annotate-snippets = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/aranya-policy-module/CHANGELOG.md
+++ b/crates/aranya-policy-module/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-module-v0.22.0...aranya-policy-module-v0.23.0) - 2026-08-25
+
+### Other
+
+- Remove vm span dependency ([#726](https://github.com/aranya-project/aranya-core/pull/726))
+- bypass open in braid ([#738](https://github.com/aranya-project/aranya-core/pull/738))
+- Close #705: Actions can return results ([#706](https://github.com/aranya-project/aranya-core/pull/706))
+
 ## [0.22.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-module-v0.21.0...aranya-policy-module-v0.22.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-policy-module/Cargo.toml
+++ b/crates/aranya-policy-module/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-module"
 description = "The Aranya Policy module format"
-version = "0.22.0"
+version = "0.23.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -9,7 +9,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-aranya-policy-ast = { version = "0.15.0", path = "../aranya-policy-ast" }
+aranya-policy-ast = { version = "0.16.0", path = "../aranya-policy-ast" }
 
 fnv = { workspace = true, default-features = false }
 indexmap = { workspace = true, default-features = false, features = ["serde"] }

--- a/crates/aranya-policy-runner/Cargo.toml
+++ b/crates/aranya-policy-runner/Cargo.toml
@@ -12,17 +12,17 @@ publish = false
 [lib]
 
 [dependencies]
-aranya-afc-util = { version = "0.25.0", path = "../aranya-afc-util" }
-aranya-crypto = { version = "0.14.1", path = "../aranya-crypto", features = ["fs-keystore", "memstore"] }
-aranya-crypto-ffi = { version = "0.23.0", path = "../aranya-crypto-ffi" }
-aranya-device-ffi = { version = "0.23.0", path = "../aranya-device-ffi" }
-aranya-envelope-ffi = { version = "0.23.0", path = "../aranya-envelope-ffi" }
-aranya-idam-ffi = { version = "0.23.0", path = "../aranya-idam-ffi" }
-aranya-perspective-ffi = { version = "0.23.0", path = "../aranya-perspective-ffi" }
-aranya-policy-compiler = { version = "0.24.0", path = "../aranya-policy-compiler" }
-aranya-policy-lang = { version = "0.16.0", path = "../aranya-policy-lang" }
-aranya-policy-vm = { version = "0.23.0", path = "../aranya-policy-vm" }
-aranya-runtime = { version = "0.24.0", path = "../aranya-runtime", features = ["std", "libc"] }
+aranya-afc-util = { version = "0.26.0", path = "../aranya-afc-util" }
+aranya-crypto = { version = "0.15.0", path = "../aranya-crypto", features = ["fs-keystore", "memstore"] }
+aranya-crypto-ffi = { version = "0.24.0", path = "../aranya-crypto-ffi" }
+aranya-device-ffi = { version = "0.24.0", path = "../aranya-device-ffi" }
+aranya-envelope-ffi = { version = "0.24.0", path = "../aranya-envelope-ffi" }
+aranya-idam-ffi = { version = "0.24.0", path = "../aranya-idam-ffi" }
+aranya-perspective-ffi = { version = "0.24.0", path = "../aranya-perspective-ffi" }
+aranya-policy-compiler = { version = "0.25.0", path = "../aranya-policy-compiler" }
+aranya-policy-lang = { version = "0.17.0", path = "../aranya-policy-lang" }
+aranya-policy-vm = { version = "0.24.0", path = "../aranya-policy-vm" }
+aranya-runtime = { version = "0.25.0", path = "../aranya-runtime", features = ["std", "libc"] }
 
 anyhow = { workspace = true }
 clap = { version = "4.5", features = ["derive"] }
@@ -33,7 +33,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 
 [build-dependencies]
-aranya-policy-ifgen-build = { version = "0.17.0", path = "../aranya-policy-ifgen-build" }
+aranya-policy-ifgen-build = { version = "0.18.0", path = "../aranya-policy-ifgen-build" }
 
 [lints]
 workspace = true

--- a/crates/aranya-policy-text/CHANGELOG.md
+++ b/crates/aranya-policy-text/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/aranya-project/aranya-core/compare/aranya-policy-text-v0.1.4...aranya-policy-text-v0.1.5) - 2026-08-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.4](https://github.com/aranya-project/aranya-core/compare/aranya-policy-text-v0.1.3...aranya-policy-text-v0.1.4) - 2026-01-06
 
 ### Other

--- a/crates/aranya-policy-text/Cargo.toml
+++ b/crates/aranya-policy-text/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-text"
 description = "The Aranya Policy Language textual types"
-version = "0.1.4"
+version = "0.1.5"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/aranya-policy-vm/CHANGELOG.md
+++ b/crates/aranya-policy-vm/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.23.0...aranya-policy-vm-v0.24.0) - 2026-08-25
+
+### Other
+
+- 707 remove unwrap ([#736](https://github.com/aranya-project/aranya-core/pull/736))
+- Remove vm span dependency ([#726](https://github.com/aranya-project/aranya-core/pull/726))
+- validate enum value on deserialization ([#748](https://github.com/aranya-project/aranya-core/pull/748))
+- bypass open in braid ([#738](https://github.com/aranya-project/aranya-core/pull/738))
+- Close #661: Implement `Some(ident)` pattern matching. ([#712](https://github.com/aranya-project/aranya-core/pull/712))
+- Close #705: Actions can return results ([#706](https://github.com/aranya-project/aranya-core/pull/706))
+
 ## [0.23.0](https://github.com/aranya-project/aranya-core/compare/aranya-policy-vm-v0.22.0...aranya-policy-vm-v0.23.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-policy-vm/Cargo.toml
+++ b/crates/aranya-policy-vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-policy-vm"
 description = "The Aranya Policy Virtual Machine"
-version = "0.23.0"
+version = "0.24.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -38,11 +38,11 @@ proptest = [
 bench = ["dep:table_formatter", "std"]
 
 [dependencies]
-aranya-crypto = { version = "0.14.1", path = "../aranya-crypto", default-features = false }
-aranya-id = { version = "0.2.2", path = "../aranya-id", default-features = false }
-aranya-policy-ast = { version = "0.15.0", path = "../aranya-policy-ast" }
-aranya-policy-derive = { version = "0.17.0", path = "../aranya-policy-derive" }
-aranya-policy-module = { version = "0.22.0", path = "../aranya-policy-module" }
+aranya-crypto = { version = "0.15.0", path = "../aranya-crypto", default-features = false }
+aranya-id = { version = "0.3.0", path = "../aranya-id", default-features = false }
+aranya-policy-ast = { version = "0.16.0", path = "../aranya-policy-ast" }
+aranya-policy-derive = { version = "0.18.0", path = "../aranya-policy-derive" }
+aranya-policy-module = { version = "0.23.0", path = "../aranya-policy-module" }
 buggy = { version = "0.1.0", features = ["alloc"] }
 
 heapless = { workspace = true }

--- a/crates/aranya-runtime/CHANGELOG.md
+++ b/crates/aranya-runtime/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/aranya-project/aranya-core/compare/aranya-runtime-v0.24.0...aranya-runtime-v0.25.0) - 2026-08-25
+
+### Fixed
+
+- *(runtime)* clear pending fact writes in LinearPerspective::revert ([#760](https://github.com/aranya-project/aranya-core/pull/760))
+- *(runtime)* resume mid-segment when a sync response fills ([#752](https://github.com/aranya-project/aranya-core/pull/752))
+
+### Other
+
+- Address GenerateGraph review nits from #743 ([#763](https://github.com/aranya-project/aranya-core/pull/763))
+- update crypto dependencies ([#762](https://github.com/aranya-project/aranya-core/pull/762))
+- Fact db convergence ([#743](https://github.com/aranya-project/aranya-core/pull/743))
+- 707 remove unwrap ([#736](https://github.com/aranya-project/aranya-core/pull/736))
+- Optimize fsync ([#717](https://github.com/aranya-project/aranya-core/pull/717))
+- general bug! cleanup ([#747](https://github.com/aranya-project/aranya-core/pull/747))
+- Remove vm span dependency ([#726](https://github.com/aranya-project/aranya-core/pull/726))
+- derive max cut from parents always ([#742](https://github.com/aranya-project/aranya-core/pull/742))
+- Lazy merges ([#716](https://github.com/aranya-project/aranya-core/pull/716))
+- validate enum value on deserialization ([#748](https://github.com/aranya-project/aranya-core/pull/748))
+- bypass open in braid ([#738](https://github.com/aranya-project/aranya-core/pull/738))
+- resolve two dos bugs ([#739](https://github.com/aranya-project/aranya-core/pull/739))
+- Close #705: Actions can return results ([#706](https://github.com/aranya-project/aranya-core/pull/706))
+- use alloc collections to remove limit ([#720](https://github.com/aranya-project/aranya-core/pull/720))
+
 ## [0.24.0](https://github.com/aranya-project/aranya-core/compare/aranya-runtime-v0.23.0...aranya-runtime-v0.24.0) - 2026-07-09
 
 ### Other

--- a/crates/aranya-runtime/Cargo.toml
+++ b/crates/aranya-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aranya-runtime"
 description = "The Aranya core runtime"
-version = "0.24.0"
+version = "0.25.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -14,9 +14,9 @@ workspace = true
 [dependencies]
 buggy = { version = "0.1.0", features = ["alloc"] }
 # `aranya-crypto` enables `getrandom` by default.
-aranya-crypto = { version = "0.14.1", path = "../aranya-crypto", default-features = false, features = ["alloc", "rand_compat"] }
-aranya-libc = { version = "0.4.0", path = "../aranya-libc", default-features = false, optional = true }
-aranya-policy-vm = { version = "0.23.0", path = "../aranya-policy-vm" }
+aranya-crypto = { version = "0.15.0", path = "../aranya-crypto", default-features = false, features = ["alloc", "rand_compat"] }
+aranya-libc = { version = "0.4.1", path = "../aranya-libc", default-features = false, optional = true }
+aranya-policy-vm = { version = "0.24.0", path = "../aranya-policy-vm" }
 
 heapless = { workspace = true, features = ["serde"] }
 postcard = { workspace = true, features = ["alloc"] }
@@ -31,7 +31,7 @@ yoke = { version = "0.8", features = ["derive"] }
 zerocopy = { workspace = true, features = ["derive"] }
 
 # Used by `testing`.
-aranya-policy-module = { version = "0.22.0", path = "../aranya-policy-module", optional = true }
+aranya-policy-module = { version = "0.23.0", path = "../aranya-policy-module", optional = true }
 serde_json = { version = "1.0.117", default-features = false, features = ["alloc"], optional = true }
 spin = { workspace = true, features = ["spin_mutex"], optional = true }
 


### PR DESCRIPTION
```
aranya-afc-util@0.26.0
aranya-capi-core@0.8.2
aranya-core@2.0.0
aranya-crypto-ffi@0.24.0
aranya-crypto@0.15.0
aranya-device-ffi@0.24.0
aranya-envelope-ffi@0.24.0
aranya-fast-channels@0.20.0
aranya-id@0.3.0
aranya-idam-ffi@0.24.0
aranya-libc@0.4.1
aranya-perspective-ffi@0.24.0
aranya-policy-ast@0.16.0
aranya-policy-compiler@0.25.0
aranya-policy-derive@0.18.0
aranya-policy-ifgen-build@0.18.0
aranya-policy-ifgen@0.25.0
aranya-policy-lang@0.17.0
aranya-policy-module@0.23.0
aranya-policy-text@0.1.5
aranya-policy-vm@0.24.0
aranya-runtime@0.25.0
```