### PR TITLE
fix(afc): various fixes and cleanup for AFC

### DIFF
--- a/crates/aranya-fast-channels/src/client.rs
+++ b/crates/aranya-fast-channels/src/client.rs
@@ -259,25 +259,26 @@ impl<S: AfcState> Client<S> {
         // like so:
         //    ciphertext || tag || header
 
-        // Split `data` into its components.
-        let (seq, out, tag) = {
-            let (rest, header) = data
+        let (seq, ciphertext) = {
+            let (ciphertext, header) = data
                 .split_last_chunk_mut()
                 .ok_or(HeaderError::InvalidSize)?;
             let DataHeader { seq, .. } = DataHeader::try_parse(header)?;
 
-            #[allow(clippy::incompatible_msrv)] // clippy#12280
-            let (ciphertext, tag) = rest
-                .split_at_mut_checked(rest.len() - Self::TAG_SIZE)
-                // Missing an authentication tag, so by
-                // definition we cannot authenticate the
-                // ciphertext.
-                .ok_or(Error::Authentication)?;
-            (seq, ciphertext, tag)
+            (seq, ciphertext)
         };
+
+        let plaintext_len = ciphertext
+            .len()
+            .checked_sub(Self::TAG_SIZE)
+            // We're missing an authentication tag, so by
+            // definition we cannot authenticate the ciphertext.
+            .ok_or(Error::Authentication)?;
+        let (out, tag) = ciphertext
+            .split_at_mut_checked(plaintext_len)
+            .ok_or(Error::Authentication)?;
         debug!("data=[{:?}; {}]", out.as_ptr(), out.len());
 
-        let plaintext_len = out.len();
         let label_id = self
             .do_open(ctx, seq, |aead, ad, seq| {
                 aead.open_in_place(out, tag, ad, seq)?;

--- a/crates/aranya-fast-channels/src/client.rs
+++ b/crates/aranya-fast-channels/src/client.rs
@@ -132,7 +132,6 @@ impl<S: AfcState> Client<S> {
         let (rest, header) = data
             .split_last_chunk_mut()
             .assume("we've already checked that `data` can fit a header")?;
-        #[allow(clippy::incompatible_msrv)] // clippy#12280
         let (out, tag) = rest
             .split_at_mut_checked(rest.len() - Self::TAG_SIZE)
             .assume("we've already checked that `data` can fit a tag")?;

--- a/crates/aranya-fast-channels/src/shm/error.rs
+++ b/crates/aranya-fast-channels/src/shm/error.rs
@@ -93,20 +93,20 @@ impl From<Infallible> for Corrupted {
 }
 
 pub(super) const fn bad_state_magic(magic: U32) -> Corrupted {
-    Corrupted::SharedMemMagic(magic.into())
+    Corrupted::SharedMemMagic(magic.get())
 }
 
 pub(super) const fn bad_state_version(got: U32, want: U32) -> Corrupted {
     Corrupted::SharedMemVersion {
-        got: got.into(),
-        want: want.into(),
+        got: got.get(),
+        want: want.get(),
     }
 }
 
 pub(super) const fn bad_state_size(got: U64, want: U64) -> Corrupted {
     Corrupted::SharedMemSize {
-        got: got.into(),
-        want: want.into(),
+        got: got.get(),
+        want: want.get(),
     }
 }
 
@@ -115,19 +115,19 @@ pub(super) const fn bad_page_alignment(aligned: bool) -> Corrupted {
 }
 
 pub(super) const fn bad_state_key_size(size: U64) -> Corrupted {
-    Corrupted::SharedMemKeySize(size.into())
+    Corrupted::SharedMemKeySize(size.get())
 }
 
 pub(super) const fn bad_chanlist_magic(magic: U32) -> Corrupted {
-    Corrupted::ChanListMagic(magic.into())
+    Corrupted::ChanListMagic(magic.get())
 }
 
 pub(super) const fn bad_chan_magic(magic: U32) -> Corrupted {
-    Corrupted::ChanMagic(magic.into())
+    Corrupted::ChanMagic(magic.get())
 }
 
 pub(super) const fn bad_chan_direction(v: U32) -> Corrupted {
-    Corrupted::ChanDirection(v.into())
+    Corrupted::ChanDirection(v.get())
 }
 
 pub(super) const fn corrupted(msg: &'static str) -> Corrupted {

--- a/crates/aranya-fast-channels/src/shm/le.rs
+++ b/crates/aranya-fast-channels/src/shm/le.rs
@@ -2,61 +2,59 @@ macro_rules! little_endian {
 	($($name:ident => $type:ty),* $(,)?) => {
         $(
             /// A little-endian integer.
-            #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+            #[derive(Copy, Clone, Debug, Eq, PartialEq)]
             #[repr(transparent)]
-            pub(super) struct $name($type);
+            pub(super) struct $name {
+                __raw: $type
+            }
 
             impl $name {
-                /// The maximum value.
-                #[allow(dead_code, reason = "U32::MAX is not used")]
-                pub const MAX: Self = Self::new(<$type>::MAX);
-
-                /// Interprets `v` as a little-endian integer.
+                /// Creates a little-endian integer from native-endian `v`.
                 pub const fn new(v: $type) -> Self {
-                    Self(v.to_le())
+                    Self { __raw: v.to_le() }
                 }
 
-                /// Returns the little-endian integer in its
-                /// original endianness.
-                pub const fn into(self) -> $type {
-                    <$type>::from_le(self.0)
+                /// Converts the little-endian integer to native-endian.
+                pub const fn get(self) -> $type {
+                    <$type>::from_le(self.__raw)
                 }
             }
 
             impl ::core::cmp::PartialEq<$type> for $name {
                 fn eq(&self, other: &$type) -> bool {
-                    <$type>::from_le(self.0) == *other
+                    self.get() == *other
                 }
             }
 
             impl ::core::cmp::PartialOrd<$type> for $name {
                 fn partial_cmp(&self, other: &$type) -> ::core::option::Option<::core::cmp::Ordering> {
-                    let lhs = <$type>::from_le(self.0);
-                    ::core::cmp::PartialOrd::partial_cmp(&lhs, other)
+                    self.get().partial_cmp(other)
+                }
+            }
+
+            impl ::core::cmp::PartialOrd for $name {
+                fn partial_cmp(&self, other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
+                    Some(self.cmp(other))
+                }
+            }
+
+            impl ::core::cmp::Ord for $name {
+                fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
+                    self.get().cmp(&other.get())
                 }
             }
 
             impl ::core::ops::AddAssign<$type> for $name {
                 fn add_assign(&mut self, rhs: $type) {
                     #![allow(clippy::arithmetic_side_effects, reason = "keeping behavior")]
-                    *self = Self::new(Self::into(*self) + rhs);
+                    *self = Self::new(self.get() + rhs);
                 }
             }
 
             impl ::core::ops::SubAssign<$type> for $name {
                 fn sub_assign(&mut self, rhs: $type) {
                     #![allow(clippy::arithmetic_side_effects, reason = "keeping behavior")]
-                    *self = Self::new(Self::into(*self) - rhs);
-                }
-            }
-
-            impl ::core::convert::TryFrom<&[u8]> for $name {
-                type Error = ::buggy::Bug;
-
-                fn try_from(b: &[u8]) -> ::core::result::Result<Self, Self::Error> {
-                    use ::buggy::BugExt as _;
-                    let v = <$type>::from_le_bytes(b.try_into().assume("incorrect size")?);
-                    Ok(Self(v))
+                    *self = Self::new(self.get() - rhs);
                 }
             }
 
@@ -68,7 +66,7 @@ macro_rules! little_endian {
 
             impl ::core::convert::From<$name> for $type {
                 fn from(v: $name) -> Self {
-                    <$type>::from_le(v.0)
+                    v.get()
                 }
             }
 
@@ -76,18 +74,19 @@ macro_rules! little_endian {
                 type Error = <usize as ::core::convert::TryFrom<$type>>::Error;
 
                 fn try_from(v: $name) -> Result<Self, Self::Error> {
-                    usize::try_from(v.0)
+                    v.get().try_into()
                 }
             }
 
             impl ::core::fmt::Display for $name {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    write!(f, "{}", self.0)
+                    ::core::fmt::Display::fmt(&self.get(), f)
                 }
             }
         )*
 	};
 }
+
 little_endian! {
     U32 => u32,
     U64 => u64,

--- a/crates/aranya-fast-channels/src/shm/shared.rs
+++ b/crates/aranya-fast-channels/src/shm/shared.rs
@@ -10,7 +10,7 @@ use core::{
 use aranya_crypto::{
     CipherSuite, Csprng, DeviceId, Random,
     afc::{RawOpenKey, RawSealKey},
-    dangerous::spideroak_crypto::{aead::Aead, hash::tuple_hash},
+    dangerous::spideroak_crypto::aead::Aead,
     policy::LabelId,
 };
 use buggy::{Bug, BugExt as _};
@@ -366,8 +366,6 @@ pub(super) struct ShmChan<CS: CipherSuite> {
     /// The key/nonce used to decrypt data from the channel peer.
     #[derive_where(skip(Debug))]
     pub open_key: RawOpenKey<CS>,
-    /// Uniquely identifies `seal_key` and `open_key`.
-    pub key_id: KeyId,
 }
 assert_ffi_safe!(ShmChan<aranya_crypto::default::DefaultCipherSuite>);
 
@@ -408,7 +406,6 @@ impl<CS: CipherSuite> ShmChan<CS> {
         // a ciphertext.
         let seal_key = keys.seal().cloned().unwrap_or_else(|| Random::random(&rng));
         let open_key = keys.open().cloned().unwrap_or_else(|| Random::random(&rng));
-        let key_id = KeyId::new(&seal_key, &open_key);
         let chan = Self {
             magic: Self::MAGIC,
             direction: ChanDirection::from_directed(keys).to_u32().into(),
@@ -417,7 +414,6 @@ impl<CS: CipherSuite> ShmChan<CS> {
             peer_id,
             seal_key,
             open_key,
-            key_id,
         };
         ptr.write(chan);
     }
@@ -1061,29 +1057,6 @@ impl<CS: CipherSuite> ChanListData<CS> {
         self.check();
 
         Ok(self.chans_mut()?.iter_mut())
-    }
-}
-
-/// Uniquely identifies a [`RawSealKey`], [`RawOpenKey`] tuple.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(super) struct KeyId([u8; 16]);
-
-impl KeyId {
-    fn new<CS: CipherSuite>(seal: &RawSealKey<CS>, open: &RawOpenKey<CS>) -> Self {
-        let id = tuple_hash::<CS::Hash, _>([
-            seal.key.as_bytes(),
-            &seal.base_nonce,
-            open.key.as_bytes(),
-            &open.base_nonce,
-        ])
-        .into_array();
-        #[allow(
-            clippy::unwrap_used,
-            clippy::indexing_slicing,
-            reason = "The compiler proves that this does not panic."
-        )]
-        Self(id[..16].try_into().unwrap())
     }
 }
 

--- a/crates/aranya-fast-channels/src/shm/shared.rs
+++ b/crates/aranya-fast-channels/src/shm/shared.rs
@@ -712,7 +712,7 @@ struct ChanList<CS> {
     /// The locked list data.
     data: Mutex<ChanListData<CS>>,
 }
-assert_ffi_safe!(ChanList<aranya_crypto::default::DefaultEngine<aranya_crypto::Rng>>);
+assert_ffi_safe!(ChanList<aranya_crypto::default::DefaultCipherSuite>);
 
 impl<CS: CipherSuite> ChanList<CS> {
     const MAGIC: U32 = U32::new(0x1b771244);
@@ -801,7 +801,7 @@ pub(super) struct ChanListData<CS> {
     /// It is a ZST and does not affect the memory layout.
     chans: PhantomData<CS>,
 }
-assert_ffi_safe!(ChanListData<aranya_crypto::default::DefaultEngine<aranya_crypto::Rng>>);
+assert_ffi_safe!(ChanListData<aranya_crypto::default::DefaultCipherSuite>);
 
 const_assert!(
     // `Mutex` is 8 bytes, so ensure that `Mutex<ChanListData>`


### PR DESCRIPTION
- Use checked arithmetic for tag in `Client::open_in_place`
- Use ciphersuite instead of engine in ffi safety assertions
- Fix and clean up little endian int wrappers to ensure all operations have correct semantics
- Remove outdated `allow` for clippy mistake
- Remove unused key ID in shared memory channel data.