### PR TITLE
docs: improve docs-rs configuration and CI

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -33,15 +33,14 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Generate docs
-        env:
-          RUSTDOCFLAGS: "-Dwarnings"
         run: |
           cargo make gen-docs
-          cargo make zip-docs
+          cd target/x86_64-unknown-linux-gnu/
+          zip -qr ../../docs.zip doc
 
       - name: Publish docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: docs
           path: docs.zip
+          archive: false
           if-no-files-found: error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,9 +1,9 @@
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = 1
 CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = "canaries/*"
-RUSTDOCFLAGS = { value = "", condition = { env_not_set = ["RUSTDOCFLAGS"] } }
 
 RUSTFLAGS = { value = "-Dwarnings", condition = { env_true = ["CARGO_MAKE_CI"] } }
+RUSTDOCFLAGS = { value = "-Dwarnings", condition = { env_true = ["CARGO_MAKE_CI"] } }
 
 [config]
 default_to_workspace = false
@@ -263,14 +263,8 @@ install_crate = { crate_name = "cargo-machete", version = "0.9.1", binary = "car
 category = "docs"
 description = "Generate docs"
 env.RUSTC_BOOTSTRAP = "1"
-env.RUSTDOCFLAGS = "--cfg docsrs ${RUSTDOCFLAGS}"
-command = "cargo"
-args = ["doc", "--all-features"]
-
-[tasks.zip-docs]
-category = "docs"
-description = "Zip docs"
-script = "zip -qr docs.zip target/doc"
+command = "scripts/docs-rs.py"
+install_crate = { crate_name = "cargo-docs-rs", version = "1.0.4", binary = "cargo-docs-rs", test_arg = "-V" }
 
 
 # Misc

--- a/crates/aranya-capi-codegen-test/Cargo.toml
+++ b/crates/aranya-capi-codegen-test/Cargo.toml
@@ -30,3 +30,7 @@ syn = { workspace = true, features = ["extra-traits", "full"] }
 tracing = { workspace = true, features = ["std"] }
 tracing-appender = { version = "0.2.3" }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "registry", "std"] }
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-capi-codegen/Cargo.toml
+++ b/crates/aranya-capi-codegen/Cargo.toml
@@ -27,3 +27,7 @@ quote = { workspace = true }
 strum = { version = "0.26.3", features = ["derive"] }
 syn = { workspace = true, features = ["extra-traits", "full", "visit-mut"] }
 tracing = { workspace = true, features = ["std"] }
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-capi-core/Cargo.toml
+++ b/crates/aranya-capi-core/Cargo.toml
@@ -48,3 +48,7 @@ ciborium-io = { version = "0.2.2", default-features = false, optional = true }
 libc = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "registry", "std"] }
 tracing-test = { version = "0.2.5" }
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-capi-macro/Cargo.toml
+++ b/crates/aranya-capi-macro/Cargo.toml
@@ -26,3 +26,7 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["extra-traits", "full"] }
 tracing = { workspace = true, features = ["std"] }
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-core-example/Cargo.toml
+++ b/crates/aranya-core-example/Cargo.toml
@@ -31,3 +31,7 @@ postcard = { workspace = true, features = ["alloc"] }
 aranya-policy-ifgen-build = { path = "../aranya-policy-ifgen-build" }
 
 anyhow = { workspace = true, features = ["std"] }
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-core/Cargo.toml
+++ b/crates/aranya-core/Cargo.toml
@@ -35,3 +35,7 @@ low-mem-usage = ["aranya-runtime/low-mem-usage"]
 custom-engine = []
 
 memstore = ["aranya-crypto/memstore"]
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-crypto/Cargo.toml
+++ b/crates/aranya-crypto/Cargo.toml
@@ -174,17 +174,7 @@ name = "hsm"
 crate-type = ["lib"]
 
 [package.metadata.docs.rs]
-features = [
-	"clone-aead",
-	"committing-aead",
-	"ed25519_batch",
-	"fs-keystore",
-	"memstore",
-	"rand_compat",
-	"std",
-	"test_util",
-	"trng",
-]
+all-features = true
 
 [package.metadata.cargo-all-features]
 always_include_features = [

--- a/crates/aranya-id/Cargo.toml
+++ b/crates/aranya-id/Cargo.toml
@@ -47,3 +47,7 @@ serde_json = { version = "1", features = ["alloc"] }
 ignored = [
 	"zerocopy", # for zerocopy-derive
 ]
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-libc/Cargo.toml
+++ b/crates/aranya-libc/Cargo.toml
@@ -35,3 +35,7 @@ thiserror = { workspace = true }
 always_include_features = [
 	"std",
 ]
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-model/Cargo.toml
+++ b/crates/aranya-model/Cargo.toml
@@ -33,3 +33,7 @@ test-log = { workspace = true }
 
 [lints]
 workspace = true
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-policy-compiler/Cargo.toml
+++ b/crates/aranya-policy-compiler/Cargo.toml
@@ -31,3 +31,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 insta = { workspace = true }
 rstest = { workspace = true }
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-policy-ifgen-build/Cargo.toml
+++ b/crates/aranya-policy-ifgen-build/Cargo.toml
@@ -22,3 +22,7 @@ prettyplease = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-policy-ifgen-macro/Cargo.toml
+++ b/crates/aranya-policy-ifgen-macro/Cargo.toml
@@ -21,3 +21,7 @@ serde = []
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["full"] }
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-policy-ifgen/Cargo.toml
+++ b/crates/aranya-policy-ifgen/Cargo.toml
@@ -33,3 +33,7 @@ aranya-policy-lang = { path = "../aranya-policy-lang" }
 
 goldenfile = "1.6.0"
 syn = { workspace = true }
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-policy-lang/Cargo.toml
+++ b/crates/aranya-policy-lang/Cargo.toml
@@ -33,3 +33,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 rstest = { workspace = true }
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-policy-module/Cargo.toml
+++ b/crates/aranya-policy-module/Cargo.toml
@@ -31,3 +31,7 @@ testing = []
 
 [lints]
 workspace = true
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-policy-runner/Cargo.toml
+++ b/crates/aranya-policy-runner/Cargo.toml
@@ -37,3 +37,7 @@ aranya-policy-ifgen-build = { version = "0.18.0", path = "../aranya-policy-ifgen
 
 [lints]
 workspace = true
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-policy-text-macro/Cargo.toml
+++ b/crates/aranya-policy-text-macro/Cargo.toml
@@ -22,3 +22,7 @@ macro-string = { version = "0.1.4" }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-policy-vm-explorer/Cargo.toml
+++ b/crates/aranya-policy-vm-explorer/Cargo.toml
@@ -25,3 +25,6 @@ clap = { version = "4.4", features = ["derive"] }
 [[bin]]
 name = "aranya-policy-vm-explorer"
 path = "src/main.rs"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-runtime/Cargo.toml
+++ b/crates/aranya-runtime/Cargo.toml
@@ -105,3 +105,6 @@ always_include_features = [
 # low-mem-usage breaks brittle dsl tests and is only
 # needed for the embedded build so we exclude it here.
 denylist = ["low-mem-usage"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/aranya-tcp-syncer/Cargo.toml
+++ b/crates/aranya-tcp-syncer/Cargo.toml
@@ -32,3 +32,6 @@ clap = { version = "4", features = ["derive"] }
 [[bench]]
 name = "bench"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true

--- a/scripts/docs-rs.py
+++ b/scripts/docs-rs.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from subprocess import run, PIPE
+from typing import Any
+import json
+
+
+def get_workspace_libs(metadata: Any):
+    workspace = set(metadata["workspace_default_members"])
+    for package in metadata["packages"]:
+        if package["id"] not in workspace:
+            continue
+        if any("lib" in target["kind"] for target in package["targets"]):
+            yield package
+
+
+def main():
+    metadata = json.loads(run(["cargo", "metadata", "--format-version=1"], stdout=PIPE).stdout)
+
+    libs = [lib["name"] for lib in get_workspace_libs(metadata)]
+    for lib in libs:
+        run(["cargo", "docs-rs", "-p", lib], check=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -492,6 +492,12 @@ user-id = 6743 # Ed Page (epage)
 start = "2024-05-02"
 end = "2026-11-19"
 
+[[trusted.proc-macro2]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-04-23"
+end = "2027-09-01"
+
 [[trusted.spideroak-base58]]
 criteria = "safe-to-deploy"
 user-id = 293722 # aranya-project-bot

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -606,10 +606,6 @@ version = "3.0.0"
 criteria = "safe-to-deploy"
 notes = "RustCrypto"
 
-[[exemptions.simdutf8]]
-version = "0.1.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.similar]]
 version = "2.6.0"
 criteria = "safe-to-run"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -91,6 +91,13 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.proc-macro2]]
+version = "1.0.107"
+when = "2026-07-19"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.spideroak-base58]]
 version = "0.2.0"
 when = "2025-06-06"
@@ -683,105 +690,6 @@ who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
 delta = "0.11.2 -> 0.12.1"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-version = "1.0.78"
-notes = """
-Grepped for "crypt", "cipher", "fs", "net" - there were no hits
-(except for a benign "fs" hit in a doc comment)
-
-Notes from the `unsafe` review can be found in https://crrev.com/c/5385745.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.78 -> 1.0.79"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Adrian Taylor <adetaylor@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.79 -> 1.0.80"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.80 -> 1.0.81"
-notes = "Comment changes only"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.81 -> 1.0.82"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Dustin J. Mitchell <djmitche@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.82 -> 1.0.83"
-notes = "Substantive change is replacing String with Box<str>, saving memory."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.83 -> 1.0.84"
-notes = "Only doc comment changes in `src/lib.rs`."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "danakj@chromium.org"
-criteria = "safe-to-deploy"
-delta = "1.0.84 -> 1.0.85"
-notes = "Test-only changes."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.85 -> 1.0.86"
-notes = """
-Comment-only changes in `build.rs`.
-Reordering of `Cargo.toml` entries.
-Just bumping up the version number in `lib.rs`.
-Config-related changes in `test_size.rs`.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "danakj <danakj@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.86 -> 1.0.87"
-notes = "No new unsafe interactions."
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Liza Burakova <liza@chromium.org"
-criteria = "safe-to-deploy"
-delta = "1.0.87 -> 1.0.89"
-notes = """
-Biggest change is adding error handling in build.rs.
-Some config related changes in wrapper.rs.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.proc-macro2]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.89 -> 1.0.92"
-notes = """
-I looked at the delta and the previous discussion at
-https://chromium-review.googlesource.com/c/chromium/src/+/5385745/3#message-a8e2813129fa3779dab15acede408ee26d67b7f3
-and the changes look okay to me (including the `unsafe fn from_str_unchecked`
-changes in `wrapper.rs`).
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.quote]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
@@ -1954,6 +1862,13 @@ who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.227 -> 1.0.228"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.simdutf8]]
+who = "Henri Sivonen <hsivonen@hsivonen.fi>"
+criteria = "safe-to-deploy"
+version = "0.1.5"
+notes = "Confidence in correctness of the algorithm is based on fuzzing the SSE 4.2 and AVX2 implementations rather than working through the logic of the code. Audit of aarch64 and Wasm is by comparing the code with the SSE 4.2 case."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.strsim]]
 who = "Ben Dean-Kawamura <bdk@mozilla.com>"


### PR DESCRIPTION
Many of our crates did not set the docs-rs `all-features` metadata, meaning that any non-default feature items would just be omitted from docs.rs. I set it for every crate, even though some don't have features.

Previously, we were using `RUSTDOCFLAGS='--cfg docsrs' cargo doc --all-features` to test our doc generation. We are now using `cargo-docs-rs` which mimics docs.rs.

This only generates docs for one crate, so a python script is used to run for each workspace crate with a library. (Using cargo-make's workspace feature failed because it ran on all crates, while cargo-docs-rs fails on non-library crates, and excluding crates from cargo-make is rather awkward.)

Now that we are essentially just running `rustdoc` across our own workspace crates, we avoid the issue which was blocking a toolchain update. Many of our pinned dependencies still use `#![cfg_attr(docsrs, feature(doc_auto_cfg))]`, but that feature was removed from nightly around 1.92, meaning that trying to use a newer compiler would previously break our `gen-docs` task. I imagine they may have updated by now, but updating every dependency in our lockfile is rather painful with cargo-vet. This change avoids the issue by just not building dependencies' docs.

I also switched to upload action v7 with `archive: false` to avoid double zipping the docs which was happening before.