### PR TITLE
chore: bump Rust version to 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["SpiderOak, Inc."]
 edition = "2024"
 license = "AGPL-3.0-only"
 repository = "https://github.com/aranya-project/aranya-core"
-rust-version = "1.90.0"
+rust-version = "1.95.0"
 
 [workspace.lints.rust]
 # missing_docs = "warn"

--- a/crates/aranya-crypto/src/apq.rs
+++ b/crates/aranya-crypto/src/apq.rs
@@ -661,7 +661,7 @@ impl<CS: CipherSuite> ReceiverPublicKey<CS> {
 mod tests {
     #![allow(clippy::arithmetic_side_effects)]
 
-    use spideroak_crypto::{ed25519::Ed25519, import::Import as _, kem::Kem, rust, signer::Signer};
+    use spideroak_crypto::{ed25519::Ed25519, kem::Kem, rust, signer::Signer};
 
     use super::*;
     use crate::{Rng, default::DhKemP256HkdfSha256, test_util::TestCs};

--- a/crates/aranya-crypto/src/aranya.rs
+++ b/crates/aranya-crypto/src/aranya.rs
@@ -482,7 +482,7 @@ where
 mod tests {
     use core::cell::OnceCell;
 
-    use spideroak_crypto::{ed25519::Ed25519, import::Import as _, kem::Kem, rust, signer::Signer};
+    use spideroak_crypto::{ed25519::Ed25519, kem::Kem, rust, signer::Signer};
 
     use super::*;
     use crate::{default::DhKemP256HkdfSha256, test_util::TestCs};

--- a/crates/aranya-fast-channels/src/buf.rs
+++ b/crates/aranya-fast-channels/src/buf.rs
@@ -79,7 +79,7 @@ pub trait Buf: AsRef<[u8]> + Deref<Target = [u8]> + AsMut<[u8]> + DerefMut<Targe
 #[cfg(all(any(test, feature = "alloc"), feature = "allocator_api"))]
 impl<A: Allocator> Buf for Vec<u8, A> {
     fn len(&self) -> usize {
-        Vec::len(self)
+        Self::len(self)
     }
 
     fn split_at_mut(&mut self, mid: usize) -> (&mut [u8], &mut [u8]) {
@@ -87,15 +87,15 @@ impl<A: Allocator> Buf for Vec<u8, A> {
     }
 
     fn truncate(&mut self, len: usize) {
-        Vec::truncate(self, len);
+        Self::truncate(self, len);
     }
 
     fn try_reserve_exact(&mut self, additional: usize) -> Result<(), AllocError> {
-        Ok(Vec::try_reserve_exact(self, additional)?)
+        Ok(Self::try_reserve_exact(self, additional)?)
     }
 
     fn try_resize(&mut self, new_len: usize, value: u8) -> Result<(), AllocError> {
-        Vec::resize(self, new_len, value);
+        Self::resize(self, new_len, value);
         Ok(())
     }
 }

--- a/crates/aranya-fast-channels/src/shm/path.rs
+++ b/crates/aranya-fast-channels/src/shm/path.rs
@@ -113,7 +113,7 @@ impl fmt::Display for Path {
         let data = self.as_cstr().to_bytes();
         match str::from_utf8(data) {
             Ok(s) => write!(f, "{s}"),
-            Err(_) => write!(f, "invalid UTF-8: {:?}", &data),
+            Err(_) => write!(f, "invalid UTF-8: {:?}", data),
         }
     }
 }

--- a/crates/aranya-fast-channels/src/shm/sdlib.rs
+++ b/crates/aranya-fast-channels/src/shm/sdlib.rs
@@ -6,7 +6,7 @@ use core::{
     ptr,
 };
 
-use buggy::BugExt;
+use buggy::BugExt as _;
 use derive_where::derive_where;
 use libc::off_t;
 
@@ -158,7 +158,7 @@ impl<T> Mapping<T> {
             Err(Error::Errno(errno()))
         } else {
             let ptr = Aligned::new(addr.cast::<T>(), layout).assume("unable to align pointer")?;
-            Ok(Mapping { ptr, id })
+            Ok(Self { ptr, id })
         }
     }
 }

--- a/crates/aranya-policy-compiler/src/tracer.rs
+++ b/crates/aranya-policy-compiler/src/tracer.rs
@@ -127,7 +127,7 @@ impl TraceAnalyzer<'_> {
 
         // Multiple paths may give us the same failures. Sort them by responsible
         // instruction and consider them identical if they have the same message.
-        failures.sort_by(|a, b| a.responsible_instruction.cmp(&b.responsible_instruction));
+        failures.sort_by_key(|a| a.responsible_instruction);
         failures.dedup_by(|a, b| {
             a.message == b.message && a.responsible_instruction == b.responsible_instruction
         });

--- a/crates/aranya-policy-compiler/src/tracer/analyzers/action_analyzer.rs
+++ b/crates/aranya-policy-compiler/src/tracer/analyzers/action_analyzer.rs
@@ -24,10 +24,8 @@ impl Analyzer for ActionAnalyzer {
     ) -> Result<AnalyzerStatus, TraceError> {
         match i {
             Instruction::Publish => self.have_publish = true,
-            Instruction::Return => {
-                if !self.have_publish {
-                    return Ok(AnalyzerStatus::Failed("no publish".to_string()));
-                }
+            Instruction::Return if !self.have_publish => {
+                return Ok(AnalyzerStatus::Failed("no publish".to_string()));
             }
             _ => (),
         }

--- a/crates/aranya-policy-compiler/src/tracer/analyzers/finish_analyzer.rs
+++ b/crates/aranya-policy-compiler/src/tracer/analyzers/finish_analyzer.rs
@@ -26,10 +26,8 @@ impl Analyzer for FinishAnalyzer {
             Instruction::Meta(Meta::Finish(s)) => {
                 self.finish = *s;
             }
-            Instruction::Exit(ExitReason::Normal) => {
-                if !self.finish {
-                    return Ok(AnalyzerStatus::fail("Exit without Finish"));
-                }
+            Instruction::Exit(ExitReason::Normal) if !self.finish => {
+                return Ok(AnalyzerStatus::fail("Exit without Finish"));
             }
             _ => (),
         }

--- a/crates/aranya-policy-compiler/src/tracer/analyzers/function_analyzer.rs
+++ b/crates/aranya-policy-compiler/src/tracer/analyzers/function_analyzer.rs
@@ -24,11 +24,9 @@ impl Analyzer for FunctionAnalyzer {
     ) -> Result<AnalyzerStatus, TraceError> {
         match i {
             Instruction::Return => self.have_return = true,
-            Instruction::Exit(_) => {
-                if !self.have_return {
-                    // Branches without returns are potential errors; it depends on whether there is a return following the branch.
-                    return Ok(AnalyzerStatus::Failed("no return".to_string()));
-                }
+            Instruction::Exit(_) if !self.have_return => {
+                // Branches without returns are potential errors; it depends on whether there is a return following the branch.
+                return Ok(AnalyzerStatus::Failed("no return".to_string()));
             }
             _ => (),
         }

--- a/crates/aranya-policy-compiler/src/tracer/analyzers/value_analyzer.rs
+++ b/crates/aranya-policy-compiler/src/tracer/analyzers/value_analyzer.rs
@@ -53,10 +53,8 @@ impl Analyzer for ValueAnalyzer {
                     return Ok(AnalyzerStatus::Failed(format!("Value `{s}` is set twice")));
                 }
             }
-            Instruction::Get(s) => {
-                if !self.contains(s) {
-                    return Ok(AnalyzerStatus::Failed(format!("Value `{s}` is not set")));
-                }
+            Instruction::Get(s) if !self.contains(s) => {
+                return Ok(AnalyzerStatus::Failed(format!("Value `{s}` is not set")));
             }
             _ => (),
         }

--- a/crates/aranya-policy-compiler/src/tracer/analyzers/value_analyzer.rs
+++ b/crates/aranya-policy-compiler/src/tracer/analyzers/value_analyzer.rs
@@ -48,10 +48,8 @@ impl Analyzer for ValueAnalyzer {
             Instruction::Return => {
                 self.value_sets.pop();
             }
-            Instruction::Def(s) => {
-                if !self.insert(s.clone()) {
-                    return Ok(AnalyzerStatus::Failed(format!("Value `{s}` is set twice")));
-                }
+            Instruction::Def(s) if !self.insert(s.clone()) => {
+                return Ok(AnalyzerStatus::Failed(format!("Value `{s}` is set twice")));
             }
             Instruction::Get(s) if !self.contains(s) => {
                 return Ok(AnalyzerStatus::Failed(format!("Value `{s}` is not set")));

--- a/crates/aranya-policy-ifgen-build/src/imp.rs
+++ b/crates/aranya-policy-ifgen-build/src/imp.rs
@@ -288,11 +288,9 @@ fn collect_reachable_types(target: &PolicyInterface) -> HashSet<Identifier> {
         ty: &TypeKind,
     ) {
         match ty {
-            TypeKind::Struct(s) => {
-                if found.insert(s.inner.clone()) {
-                    for field in struct_defs[s.as_str()] {
-                        visit(struct_defs, found, &field.field_type.inner);
-                    }
+            TypeKind::Struct(s) if found.insert(s.inner.clone()) => {
+                for field in struct_defs[s.as_str()] {
+                    visit(struct_defs, found, &field.field_type.inner);
                 }
             }
             TypeKind::Enum(s) => {

--- a/crates/aranya-policy-lang/src/lang/parse.rs
+++ b/crates/aranya-policy-lang/src/lang/parse.rs
@@ -45,7 +45,7 @@ impl<'i> PairContext<'i, '_> {
         match (self.to_ast_span)(self.span) {
             Ok(span) => ParseError::new(
                 ParseErrorKind::Unknown,
-                format!("{:?}", &self.span),
+                format!("{:?}", self.span),
                 Some(span),
             ),
             Err(err) => err,

--- a/crates/aranya-policy-module/src/data.rs
+++ b/crates/aranya-policy-module/src/data.rs
@@ -75,7 +75,7 @@ pub enum TypeKind {
     /// Named enumeration
     Enum(Identifier),
     /// An optional type of some other type
-    Optional(#[rkyv(omit_bounds)] Box<TypeKind>),
+    Optional(#[rkyv(omit_bounds)] Box<Self>),
     /// A type which cannot be instantiated.
     Never,
     /// Result with value, or error

--- a/crates/aranya-policy-module/src/ffi.rs
+++ b/crates/aranya-policy-module/src/ffi.rs
@@ -24,9 +24,9 @@ pub enum Type<'a> {
     /// A named enum.
     Enum(Identifier),
     /// An optional type of some other type.
-    Optional(&'a Type<'a>),
+    Optional(&'a Self),
     /// Result
-    Result(&'a Type<'a>, &'a Type<'a>),
+    Result(&'a Self, &'a Self),
 }
 
 impl Type<'_> {

--- a/crates/aranya-policy-runner/src/lib.rs
+++ b/crates/aranya-policy-runner/src/lib.rs
@@ -191,7 +191,7 @@ impl PolicyRunner {
         CE: Engine,
         KS: KeyStore,
     {
-        let mut policy_doc = self.policy.to_string();
+        let mut policy_doc = self.policy.clone();
         // Append generated policy thunks to the policy doc
         policy_doc.push_str("\n```policy\n");
         let mut thunk_counter = 0usize;

--- a/crates/aranya-policy-vm/src/bench.rs
+++ b/crates/aranya-policy-vm/src/bench.rs
@@ -156,7 +156,7 @@ impl BenchMeasurements {
                 }
             })
             .collect();
-        m.sort_by(|a, b| b.mean.cmp(&a.mean));
+        m.sort_by_key(|a| core::cmp::Reverse(a.mean));
         m
     }
 

--- a/crates/aranya-policy-vm/src/data.rs
+++ b/crates/aranya-policy-vm/src/data.rs
@@ -74,7 +74,7 @@ pub enum Value {
     /// Optional value
     Option(Option<Box<Self>>),
     /// Result value
-    Result(Result<Box<Value>, Box<Value>>),
+    Result(Result<Box<Self>, Box<Self>>),
 }
 
 impl Value {

--- a/crates/aranya-runtime/src/client.rs
+++ b/crates/aranya-runtime/src/client.rs
@@ -1,7 +1,6 @@
 use core::{fmt, iter::DoubleEndedIterator};
 
 use buggy::Bug;
-use tracing::error;
 
 use crate::{
     Address, CmdId, Command, GraphId, LocatedAddress, PeerCache, Perspective as _, Policy,

--- a/crates/aranya-runtime/src/storage/linear/mod.rs
+++ b/crates/aranya-runtime/src/storage/linear/mod.rs
@@ -840,14 +840,11 @@ impl<R: Read> Segment for LinearSegment<R> {
         let cmd_idx = self.repr.cmd_index(location.max_cut).ok()?;
         let data = self.repr.commands.get(cmd_idx)?;
         let parent = if let Some(prev) = usize::checked_sub(cmd_idx, 1) {
-            if let Some(max_cut) = self.repr.max_cut.checked_add(prev as u64) {
-                Prior::Single(Address {
-                    id: self.repr.commands[prev].id,
-                    max_cut,
-                })
-            } else {
-                return None;
-            }
+            let max_cut = self.repr.max_cut.checked_add(prev as u64)?;
+            Prior::Single(Address {
+                id: self.repr.commands[prev].id,
+                max_cut,
+            })
         } else {
             self.repr.parents
         };

--- a/crates/aranya-runtime/src/storage/mod.rs
+++ b/crates/aranya-runtime/src/storage/mod.rs
@@ -301,10 +301,8 @@ impl TraversalQueue {
 
     /// Drain all entries. Uncovered entries are passed to `f`.
     /// Covered entries are discarded. O(n) single pass.
-    pub fn drain_all(&mut self, mut f: impl FnMut(Location)) {
-        for i in 0..self.partition {
-            f(self.entries[i]);
-        }
+    pub fn drain_all(&mut self, f: impl FnMut(Location)) {
+        self.entries[..self.partition].iter().copied().for_each(f);
         self.entries.clear();
         self.partition = 0;
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.90"
+channel = "1.95"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
Sets MSRV and toolchain to 1.95 and fixes some new lints.

Rust 1.95 is `LATEST - 3`, was released on 2026-04-16, and is supported by the latest ferrocene release.