### PR TITLE
runtime: clean up constants

### DIFF
--- a/crates/aranya-core/src/lib.rs
+++ b/crates/aranya-core/src/lib.rs
@@ -144,8 +144,8 @@ pub mod sync {
     #[doc(inline)]
     pub use aranya_runtime::sync::{
         COMMAND_RESPONSE_MAX, HelloNotification, HelloSubscribe, HelloUnsubscribe,
-        MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX, PeerCache, PollIncoming, PushIncoming,
-        SubscribeIncoming, SubscribeResponse, SyncCommand, SyncError, SyncHeads, SyncHello,
-        SyncIncoming, SyncRequester, SyncResponder, UnsubscribeIncoming,
+        MAX_SYNC_MESSAGE_SIZE, PeerCache, PollIncoming, PushIncoming, SubscribeIncoming,
+        SubscribeResponse, SyncCommand, SyncError, SyncHeads, SyncHello, SyncIncoming,
+        SyncRequester, SyncResponder, UnsubscribeIncoming,
     };
 }

--- a/crates/aranya-runtime/src/storage/mod.rs
+++ b/crates/aranya-runtime/src/storage/mod.rs
@@ -21,7 +21,7 @@ pub use self::{
     head_set::HeadSet,
     spill::{MemSpill, mem_spill},
 };
-use crate::{Address, CmdId, Command, CommandExt as _, PolicyId, Prior};
+use crate::{Address, CmdId, Command, CommandExt as _, PolicyId, Prior, util::mem_usage};
 
 /// Byte-addressable overflow storage for braid and convergence data.
 ///
@@ -362,10 +362,7 @@ impl Default for TraversalBuffers {
     }
 }
 
-#[cfg(feature = "low-mem-usage")]
-pub const MAX_COMMAND_LENGTH: usize = 400;
-#[cfg(not(feature = "low-mem-usage"))]
-pub const MAX_COMMAND_LENGTH: usize = 2048;
+pub const MAX_COMMAND_LENGTH: usize = mem_usage(400, 2048);
 
 aranya_crypto::custom_id! {
     /// The ID of the graph, taken from initialization.

--- a/crates/aranya-runtime/src/sync/mod.rs
+++ b/crates/aranya-runtime/src/sync/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     Address, Prior,
     command::{CmdId, Command, Priority},
     storage::{GraphId, LocatedAddress, Location, MAX_COMMAND_LENGTH, StorageError},
+    util::mem_usage,
 };
 
 mod requester;
@@ -70,33 +71,18 @@ impl PeerCache {
 
 // TODO: These should all be compile time parameters
 
-/// The maximum number of heads that will be stored for a peer.
-pub const PEER_HEAD_MAX: usize = 10;
-
 /// The maximum number of samples in a request
-#[cfg(feature = "low-mem-usage")]
-const COMMAND_SAMPLE_MAX: usize = 20;
-#[cfg(not(feature = "low-mem-usage"))]
-const COMMAND_SAMPLE_MAX: usize = 100;
+const COMMAND_SAMPLE_MAX: usize = mem_usage(20, 100);
 
 /// The maximum number of missing segments that can be requested
 /// in a single message
-#[cfg(feature = "low-mem-usage")]
-const REQUEST_MISSING_MAX: usize = 1;
-#[cfg(not(feature = "low-mem-usage"))]
-const REQUEST_MISSING_MAX: usize = 100;
+const REQUEST_MISSING_MAX: usize = mem_usage(1, 100);
 
 /// The maximum number of commands in a response
-#[cfg(feature = "low-mem-usage")]
-pub const COMMAND_RESPONSE_MAX: usize = 5;
-#[cfg(not(feature = "low-mem-usage"))]
-pub const COMMAND_RESPONSE_MAX: usize = 100;
+pub const COMMAND_RESPONSE_MAX: usize = mem_usage(5, 100);
 
 /// The maximum number of segments which can be stored to send
-#[cfg(feature = "low-mem-usage")]
-const SEGMENT_BUFFER_MAX: usize = 10;
-#[cfg(not(feature = "low-mem-usage"))]
-const SEGMENT_BUFFER_MAX: usize = 100;
+const SEGMENT_BUFFER_MAX: usize = mem_usage(10, 100);
 
 /// The maximum size of a sync message
 // TODO: Use postcard to calculate max size (which accounts for overhead)

--- a/crates/aranya-runtime/src/sync/responder.rs
+++ b/crates/aranya-runtime/src/sync/responder.rs
@@ -3,7 +3,7 @@ use heapless::Vec;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    COMMAND_RESPONSE_MAX, COMMAND_SAMPLE_MAX, MAX_SYNC_MESSAGE_SIZE, PEER_HEAD_MAX, PollIncoming,
+    COMMAND_RESPONSE_MAX, COMMAND_SAMPLE_MAX, MAX_SYNC_MESSAGE_SIZE, PollIncoming,
     SEGMENT_BUFFER_MAX, SyncError,
     requester::SyncRequestMessage,
     wire::{CommandMeta, SyncType},
@@ -16,6 +16,9 @@ use crate::{
         TraversalBuffers,
     },
 };
+
+/// The maximum number of heads that will be stored for a peer.
+const PEER_HEAD_MAX: usize = 10;
 
 #[derive(Default, Debug)]
 pub struct PeerCache {

--- a/crates/aranya-runtime/src/util/mod.rs
+++ b/crates/aranya-runtime/src/util/mod.rs
@@ -1,1 +1,13 @@
 pub(crate) mod u64_le_serde;
+
+/// Helper function for defining constants which differ based on the `low-mem-usage` feature.
+pub(crate) const fn mem_usage<T: Copy>(low: T, high: T) -> T {
+    if cfg!(doc) {
+        // show high value in rustdoc since it is more common.
+        high
+    } else if cfg!(feature = "low-mem-usage") {
+        low
+    } else {
+        high
+    }
+}


### PR DESCRIPTION
Defining the constants twice with different `cfg`s showed up poorly in rustdoc, so define them once instead. Now they show up like this:

```rust
pub const MAX_COMMAND_LENGTH: usize = _; // 2048usize;
```

Moves `PEER_HEAD_MAX` and stop exposing it since it is not used in the public API.